### PR TITLE
Use agent binary's CARGO_PKG/VERSION in useragent

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -23,6 +23,15 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 static SLEEP_DURATION: Duration = Duration::from_millis(10);
 
+// Statically include the CARGO_PKG_NAME and CARGO_PKG_VERSIONs in the binary
+// and export under the PKG_NAME and PKG_VERSION symbols.
+// These are used to identify the application and version, for example as part
+// of the user agent string.
+#[no_mangle]
+pub static PKG_NAME: &str = env!("CARGO_PKG_NAME");
+#[no_mangle]
+pub static PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[cfg(use_systemd)]
 fn register_journald_source(source_reader: &mut SourceReader) {
     source_reader.register(JournaldSource::new());


### PR DESCRIPTION
Previously the user agent was built using the CARGO_PKG and CARGO_PKG_VERSION for the common/config module which was statically included during compilation.

This PR changes the behaviour so that the main.rs statically includes it's CARGO_PKG and CARGO_PKG_VERSION which the config module references as an extern &'static str.

Before this change the user-agent string showed as:
`config/0.1.0 (Red Hat Enterprise Linux/8.2 (Ootpa))`

it now appears as:
`logdna-agent/2.1.9-beta.2 (Red Hat Enterprise Linux/8.2 (Ootpa))`

Internal Ref: LOG-7367