### PR TITLE
Point Makefile at public build image by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 library 'magic-butler-catalogue'
 def PROJECT_NAME = 'logdna-agent-v2'
 def RUST_IMAGE_REPO = 'us.gcr.io/logdna-k8s/rust'
+def RUST_IMAGE_TAG = '1.42'
 
 pipeline {
     agent any
@@ -15,13 +16,13 @@ pipeline {
         stage('Test') {
             steps {
                 sh """
-                    make lint RUST_IMAGE_REPO=${RUST_IMAGE_REPO}
-                    make test RUST_IMAGE_REPO=${RUST_IMAGE_REPO}
+                    make lint RUST_IMAGE_REPO=${RUST_IMAGE_REPO} RUST_IMAGE_TAG=${RUST_IMAGE_TAG}
+                    make test RUST_IMAGE_REPO=${RUST_IMAGE_REPO} RUST_IMAGE_TAG=${RUST_IMAGE_TAG}
                 """
             }
             post {
                 success {
-                    sh "make clean RUST_IMAGE_REPO=${RUST_IMAGE_REPO}"
+                    sh "make clean RUST_IMAGE_REPO=${RUST_IMAGE_REPO} RUST_IMAGE_TAG=${RUST_IMAGE_TAG}"
                 }
             }
         }
@@ -29,7 +30,7 @@ pipeline {
             stages {
                 stage('Build Image') {
                     steps {
-                        sh "make build-image RUST_IMAGE_REPO=${RUST_IMAGE_REPO}"
+                        sh "make build-image RUST_IMAGE_REPO=${RUST_IMAGE_REPO} RUST_IMAGE_TAG=${RUST_IMAGE_TAG}"
                     }
                 }
                 stage('Check Publish Images') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,5 @@
 library 'magic-butler-catalogue'
 def PROJECT_NAME = 'logdna-agent-v2'
-def RUST_IMAGE_REPO = 'us.gcr.io/logdna-k8s/rust'
-def RUST_IMAGE_TAG = '1.42'
 
 pipeline {
     agent any
@@ -12,17 +10,21 @@ pipeline {
     triggers {
         cron(env.BRANCH_NAME ==~ /\d\.\d/ ? 'H H 1,15 * *' : '')
     }
+    environment {
+        RUST_IMAGE_REPO = 'us.gcr.io/logdna-k8s/rust'
+        RUST_IMAGE_TAG = '1.42'
+    }
     stages {
         stage('Test') {
             steps {
                 sh """
-                    make lint RUST_IMAGE_REPO=${RUST_IMAGE_REPO} RUST_IMAGE_TAG=${RUST_IMAGE_TAG}
-                    make test RUST_IMAGE_REPO=${RUST_IMAGE_REPO} RUST_IMAGE_TAG=${RUST_IMAGE_TAG}
+                    make lint
+                    make test
                 """
             }
             post {
                 success {
-                    sh "make clean RUST_IMAGE_REPO=${RUST_IMAGE_REPO} RUST_IMAGE_TAG=${RUST_IMAGE_TAG}"
+                    sh "make clean"
                 }
             }
         }
@@ -30,7 +32,7 @@ pipeline {
             stages {
                 stage('Build Image') {
                     steps {
-                        sh "make build-image RUST_IMAGE_REPO=${RUST_IMAGE_REPO} RUST_IMAGE_TAG=${RUST_IMAGE_TAG}"
+                        sh "make build-image"
                     }
                 }
                 stage('Check Publish Images') {

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 REPO := logdna-agent-v2
 
 # The image repo and tag can be modified e.g.
-# `make build RUST_IMAGE=docker.io/rust:1.42.0`
-RUST_IMAGE_REPO ?= docker.io/rust
-RUST_IMAGE_TAG ?= 1.42
+# `make build RUST_IMAGE=docker.io/rust:1.42.0 RUST_IMAGE_TAG=latest`
+RUST_IMAGE_REPO ?= docker.io/logdna/build-images
+RUST_IMAGE_TAG ?= rust-buster-stable
 RUST_IMAGE ?= $(RUST_IMAGE_REPO):$(RUST_IMAGE_TAG)
 RUST_IMAGE := $(RUST_IMAGE)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REPO := logdna-agent-v2
 
 # The image repo and tag can be modified e.g.
-# `make build RUST_IMAGE=docker.io/rust:1.42.0 RUST_IMAGE_TAG=latest`
+# `make build RUST_IMAGE=docker.io/rust:latest
 RUST_IMAGE_REPO ?= docker.io/logdna/build-images
 RUST_IMAGE_TAG ?= rust-buster-stable
 RUST_IMAGE ?= $(RUST_IMAGE_REPO):$(RUST_IMAGE_TAG)


### PR DESCRIPTION
Use a publicly available docker image as the default in the Makefile to ensure it's easy for the public to build the agent.