### PR TITLE
Run logdna-agent as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,12 +70,16 @@ ENV _RJEM_MALLOC_CONF="narenas:1,tcache:false,dirty_decay_ms:0,muzzy_decay_ms:0"
 ENV JEMALLOC_SYS_WITH_MALLOC_CONF="narenas:1,tcache:false,dirty_decay_ms:0,muzzy_decay_ms:0"
 
 RUN microdnf update -y \
-    && microdnf install ca-certificates -y \
+    && microdnf install ca-certificates libcap shadow-utils.x86_64 -y \
     && rm -rf /var/cache/yum
 
 # Copy the agent binary from the build stage
 COPY --from=build /opt/logdna-agent-v2/target/release/logdna-agent /work/
 WORKDIR /work/
 RUN chmod -R 777 .
+
+RUN setcap "cap_dac_read_search+p" /work/logdna-agent
+RUN groupadd -g 500 logdna && \
+useradd -u 5000 -g logdna logdna
 
 CMD ["./logdna-agent"]

--- a/k8s/agent-resources-supertenant.yaml
+++ b/k8s/agent-resources-supertenant.yaml
@@ -99,6 +99,9 @@ spec:
         app.kubernetes.io/instance: logdna-agent
         app.kubernetes.io/version: 2.1.9-beta.2
     spec:
+      securityContext:
+        runAsUser: 5000
+        runAsGroup: 5000
       serviceAccountName: logdna-agent
       containers:
         - name: logdna-agent
@@ -142,6 +145,8 @@ spec:
               mountPath: /etc/os-release
             - name: logdnahostname
               mountPath: /etc/logdna-hostname
+          securityContext:
+            allowPrivilegeEscalation: false
       volumes:
         - name: varlog
           hostPath:

--- a/k8s/agent-resources.yaml
+++ b/k8s/agent-resources.yaml
@@ -99,6 +99,9 @@ spec:
         app.kubernetes.io/instance: logdna-agent
         app.kubernetes.io/version: 2.1.9-beta.2
     spec:
+      securityContext:
+        runAsUser: 5000
+        runAsGroup: 5000
       serviceAccountName: logdna-agent
       containers:
         - name: logdna-agent
@@ -140,6 +143,8 @@ spec:
               mountPath: /etc/os-release
             - name: logdnahostname
               mountPath: /etc/logdna-hostname
+          securityContext:
+            allowPrivilegeEscalation: false
       volumes:
         - name: varlog
           hostPath:


### PR DESCRIPTION
This change gives the logdna-agent special read capabilities over the filesystem so we don't need to run as the root user. This alleviates a common security issue with the agent

Signed-off-by: Jacob Hull <jacob@planethull.com>