### PR TITLE
Add unique tag that marks the hash of the build for each MAJOR.MINOR.PATCH version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,11 +175,10 @@ build-image: ## Build a docker image as specified in the Dockerfile
 		--build-arg REPO=$(REPO) \
 		--build-arg VCS_REF=$(VCS_REF) \
 		--build-arg VCS_URL=$(VCS_URL)
-	$(DOCKER) tag $(REPO):$(BUILD_TAG) $(REPO):$(BUILD_VERSION)
 
 .PHONY:publish-image
 publish-image: ## Publish SemVer compliant releases to our registroies
-	$(eval TARGET_VERSIONS := $(BUILD_VERSION) $(shell if [ "$(BETA_VERSION)" = "0" ]; then echo "$(MAJOR_VERSION) $(MAJOR_VERSION).$(MINOR_VERSION) latest"; fi))
+	$(eval TARGET_VERSIONS := $(BUILD_VERSION) $(shell if [ "$(BETA_VERSION)" = "0" ]; then echo "$(BUILD_VERSION)-build.$(shell docker images -q $(REPO):$(BUILD_TAG)) $(MAJOR_VERSION) $(MAJOR_VERSION).$(MINOR_VERSION) latest"; fi))
 	@for image in $(DOCKER_PRIVATE_IMAGE) $(DOCKER_PUBLIC_IMAGE) $(DOCKER_IBM_IMAGE); do \
 		for version in $(TARGET_VERSIONS); do \
 			$(DOCKER) tag $(REPO):$(BUILD_TAG) $${image}:$${version}; \


### PR DESCRIPTION
Example:
```
REPOSITORY                             TAG                  IMAGE ID            CREATED             SIZE
REPOSITORY                                    TAG                        IMAGE ID            CREATED             SIZE
us.gcr.io/logdna-k8s/logdna-agent-v2          2                          fec63c895146        43 minutes ago      185MB
us.gcr.io/logdna-k8s/logdna-agent-v2          2.2                        fec63c895146        43 minutes ago      185MB
us.gcr.io/logdna-k8s/logdna-agent-v2          2.2.0                      fec63c895146        43 minutes ago      185MB
us.gcr.io/logdna-k8s/logdna-agent-v2          2.2.0-build.fec63c895146   fec63c895146        43 minutes ago      185MB
logdna/logdna-agent                           2                          fec63c895146        43 minutes ago      185MB
logdna/logdna-agent                           2.2                        fec63c895146        43 minutes ago      185MB
logdna/logdna-agent                           2.2.0                      fec63c895146        43 minutes ago      185MB
logdna/logdna-agent                           2.2.0-build.fec63c895146   fec63c895146        43 minutes ago      185MB
icr.io/ext/logdna-agent                       2                          fec63c895146        43 minutes ago      185MB
icr.io/ext/logdna-agent                       2.2                        fec63c895146        43 minutes ago      185MB
icr.io/ext/logdna-agent                       2.2.0                      fec63c895146        43 minutes ago      185MB
icr.io/ext/logdna-agent                       2.2.0-build.fec63c895146   fec63c895146        43 minutes ago      185MB
```

Signed-off-by: Jacob Hull <jacob@planethull.com>