### PR TITLE
Default the `RUST_LOG` env var to `info`

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::thread::spawn;
 
 use config::Config;
+use env_logger::Env;
 use fs::tail::Tailer as FSSource;
 use futures::StreamExt;
 use http::client::Client;
@@ -40,7 +41,7 @@ pub static PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 // fn register_journald_source(_source_reader: &mut SourceReader) {}
 
 fn main() {
-    env_logger::init();
+    env_logger::from_env(Env::default().default_filter_or("info")).init();
     info!("running version: {}", env!("CARGO_PKG_VERSION"));
 
     let config = match Config::new() {

--- a/k8s/agent-resources-supertenant.yaml
+++ b/k8s/agent-resources-supertenant.yaml
@@ -115,8 +115,6 @@ spec:
                   key: logdna-agent-key
             - name: LOGDNA_ENDPOINT
               value: /supertenant/logs/ingest
-            - name: RUST_LOG
-              value: info
             - name: NODE_NAME
               valueFrom:
                 fieldRef:

--- a/k8s/agent-resources.yaml
+++ b/k8s/agent-resources.yaml
@@ -113,8 +113,6 @@ spec:
                 secretKeyRef:
                   name: logdna-agent-key
                   key: logdna-agent-key
-            - name: RUST_LOG
-              value: info
             - name: NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Previously this would default to `error` or `warn` which confused some users with older yamls that did not specify a default in the environment variable.

Signed-off-by: Jacob Hull <jacob@planethull.com>