### PR TITLE
Port from quickerror to thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,8 +494,8 @@ dependencies = [
  "log",
  "metrics",
  "pcre2",
- "quick-error",
  "tempfile",
+ "thiserror",
  "tokio 0.2.22",
  "tokio-test",
 ]
@@ -595,7 +595,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.44",
+ "syn 1.0.45",
 ]
 
 [[package]]
@@ -722,10 +722,10 @@ dependencies = [
  "logdna-client",
  "metrics",
  "num_cpus",
- "quick-error",
  "rand",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio 0.1.22",
  "uuid",
 ]
@@ -1042,9 +1042,9 @@ dependencies = [
  "metrics",
  "middleware",
  "parking_lot 0.11.0",
- "quick-error",
  "regex",
  "serde_json",
+ "thiserror",
  "tokio 0.2.22",
 ]
 
@@ -1571,7 +1571,7 @@ checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.44",
+ "syn 1.0.45",
 ]
 
 [[package]]
@@ -1924,9 +1924,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 dependencies = [
  "serde_derive",
 ]
@@ -1943,13 +1943,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.44",
+ "syn 1.0.45",
 ]
 
 [[package]]
@@ -2095,7 +2095,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.44",
+ "syn 1.0.45",
 ]
 
 [[package]]
@@ -2111,7 +2111,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.44",
+ "syn 1.0.45",
 ]
 
 [[package]]
@@ -2142,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03e57e4fcbfe7749842d53e24ccb9aa12b7252dbe5e91d2acad31834c8b8fdd"
+checksum = "ea9c5432ff16d6152371f808fb5a871cd67368171b09bb21b43df8e4a47a3556"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2214,7 +2214,7 @@ checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.44",
+ "syn 1.0.45",
 ]
 
 [[package]]
@@ -2272,7 +2272,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "standback",
- "syn 1.0.44",
+ "syn 1.0.45",
 ]
 
 [[package]]
@@ -2741,7 +2741,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.44",
+ "syn 1.0.45",
  "wasm-bindgen-shared",
 ]
 
@@ -2775,7 +2775,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.44",
+ "syn 1.0.45",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/common/fs/Cargo.toml
+++ b/common/fs/Cargo.toml
@@ -12,7 +12,7 @@ metrics = { package = "metrics", path = "../metrics" }
 #io
 inotify = "0.8"
 #error
-quick-error = "1.0"
+thiserror = "1.0"
 #utils
 pcre2 = "0.2"
 globber = "0.1"
@@ -21,9 +21,9 @@ hashbrown = "0.8"
 log = "0.4"
 env_logger = "0.7"
 lazy_static = "1.4"
-tokio = "0.2"
 
 #async
+tokio = "0.2"
 futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"

--- a/common/fs/src/error.rs
+++ b/common/fs/src/error.rs
@@ -1,15 +1,12 @@
 use std::path::PathBuf;
+use thiserror::Error;
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum WatchError {
-        Io(err: std::io::Error) {
-            from()
-            display("I/O error: {}", err)
-        }
-        PathNonUtf8(path: PathBuf) {
-            display("{:?} was not a valid utf8 path", path)
-        }
-        Duplicate
-    }
+#[derive(Debug, Error)]
+pub enum WatchError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("{0:?} was not a valid utf8 path")]
+    PathNonUtf8(PathBuf),
+    #[error("Duplicate Watch")]
+    Duplicate,
 }

--- a/common/fs/src/lib.rs
+++ b/common/fs/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate quick_error;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate lazy_static;

--- a/common/http/Cargo.toml
+++ b/common/http/Cargo.toml
@@ -19,7 +19,7 @@ uuid = { version = "0.8", features = ["v4"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
-quick-error = "1.0"
+thiserror = "1.0"
 
 [dev-dependencies]
 rand = "0.7"

--- a/common/http/src/lib.rs
+++ b/common/http/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate quick_error;
 
 pub mod client;
 pub mod limit;

--- a/common/http/src/retry.rs
+++ b/common/http/src/retry.rs
@@ -10,28 +10,22 @@ use crate::types::body::IngestBody;
 use metrics::Metrics;
 use std::path::PathBuf;
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum Error {
-        Io(e: std::io::Error) {
-            from()
-        }
-        Serde(e: serde_json::Error){
-            from()
-        }
-        Recv(e: crossbeam::RecvError){
-            from()
-        }
-        Send(e: crossbeam::SendError<IngestBody>){
-            from()
-        }
-        NonUTF8(path: std::path::PathBuf){
-            display("{:?} is not valid utf8", path)
-        }
-        InvalidFileName(s: std::string::String){
-            display("{} is not a valid file name", s)
-        }
-    }
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+    #[error(transparent)]
+    Recv(#[from] crossbeam::RecvError),
+    #[error(transparent)]
+    Send(#[from] crossbeam::SendError<IngestBody>),
+    #[error("{0:?} is not valid utf8")]
+    NonUTF8(std::path::PathBuf),
+    #[error("{0} is not a valid file name")]
+    InvalidFileName(std::string::String),
 }
 
 #[derive(Default)]

--- a/common/k8s/Cargo.toml
+++ b/common/k8s/Cargo.toml
@@ -16,7 +16,7 @@ lazy_static = "1.0"
 log = "0.4"
 tokio = { version = "0.2", features = ["rt-threaded"] }
 futures = "0.3"
-quick-error = "1.0"
+thiserror = "1.0"
 parking_lot = "0.11"
 kube = "0.35"
 k8s-openapi = { version = "0.8", default_features = false, features = ["v1_15"] }

--- a/common/k8s/src/errors.rs
+++ b/common/k8s/src/errors.rs
@@ -1,11 +1,9 @@
-quick_error! {
-    #[derive(Debug,Clone)]
-    pub enum K8sError {
-        PodMissingMetaError(descr: &'static str) {
-            display("pod missing {}", descr)
-        }
-        InitializationError(descr: String) {
-            display("failed to initialize kubernetes middleware {}", descr)
-        }
-    }
+use thiserror::Error;
+
+#[derive(Clone, Debug, Error)]
+pub enum K8sError {
+    #[error("pod missing {0}")]
+    PodMissingMetaError(&'static str),
+    #[error("failed to initialize kubernetes middleware {0}")]
+    InitializationError(String),
 }

--- a/common/k8s/src/lib.rs
+++ b/common/k8s/src/lib.rs
@@ -2,8 +2,6 @@
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate quick_error;
 
 pub mod errors;
 pub mod middleware;

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -15,28 +15,17 @@ use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::env;
+use thiserror::Error;
 use tokio::runtime::{Builder, Runtime};
 
-quick_error! {
-    #[derive(Debug)]
-    enum Error {
-        Io(e: std::io::Error) {
-            from()
-            display("{}", e)
-        }
-        Utf(e: std::string::FromUtf8Error) {
-            from()
-            display("{}", e)
-        }
-        Regex {
-            from()
-            display("failed to parse path")
-        }
-        K8s(e: kube::Error) {
-            from()
-            display("{}", e)
-        }
-    }
+#[derive(Error, Debug)]
+enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Utf(#[from] std::string::FromUtf8Error),
+    #[error(transparent)]
+    K8s(#[from] kube::Error),
 }
 
 pub struct K8sMetadata {


### PR DESCRIPTION
Thiserror (and it's partner crate Anyhow) are more or less the de-facto standard for managing custom error types in rust. thiserror operates as a proc macro so the compiler has an easier time looking inside it than with quick-error.

For example while porting over to it the compiler detected that the k8s::middleware::metadata::Error::Regex variant is actually dead code and never constructed.