### PR TITLE
Refer to UBI not Ubuntu in Dockerfile comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     cargo build --release && strip ./target/release/logdna-agent && \
     sccache --show-stats
 
-# Use ubuntu as the final base image
+# Use Red Hat Universal Base Image Minimal as the final base image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
 
 ARG REPO


### PR DESCRIPTION
Before this change a comment in the Dockerfile incorrectly mentions Ubuntu

After this change a comment correctly names the base image: https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?tag=8.2&push_date=1599576716000