### PR TITLE
Fix bug where Journald ingests stale records

### DIFF
--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -84,8 +84,6 @@ impl Tailer {
             let fs = self.fs_cache.clone();
             let lookback_config = self.lookback_config.clone();
             move |event| {
-
-                info!("Processing event {:?}", event);
                 let mut final_lines = Vec::new();
 
                 let mut fs = fs.lock().expect("Couldn't lock fs");


### PR DESCRIPTION
Found an issue with Journald that occurs in the following scenario

1. The agent is already started and monitoring a journal such as `/var/log/journal`
2. The node does not currently have Journald logging enabled
3. Modifying the node to enable journald which results in the creation of a new subdirectory `/var/log/journal/<GUID>`
4. The agent will start going through all the stale journald records from the beginning and giving them the false timestamp of `now`

This issue occurs because we only seek the tail of the Journal stream on startup. This fix checks to make sure all records have a timestamp of within 30 seconds. If a timestamp is older than that, then the journal is reseeked to the end.

```
[2020-11-10T10:10:52Z WARN  journald::stream] Received a stale journald record, reseeking pointer
```

Signed-off-by: Jacob Hull <jacob@planethull.com>