### PR TITLE
Add performance regression testing to Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,106 +38,110 @@ pipeline {
                 sh "docker pull ${RUST_IMAGE_REPO}:${RUST_IMAGE_TAG}"
             }
         }
-        parallel {
-            stage ("Lint and Test"){
-                environment {
-                    CREDS_FILE = credentials('pipeline-e2e-creds')
-                    LOGDNA_HOST = "logs.use.stage.logdna.net"
-                }
-                steps {
-                    script {
-                        def creds = readJSON file: CREDS_FILE
-                        // Assumes the pipeline-e2e-creds format remains the same. Chase
-                        // refer to the e2e tests's README's authorization docs for the
-                        // current structure
-                        LOGDNA_INGESTION_KEY = creds["packet-stage"]["account"]["ingestionkey"]
-                    }
-                    withCredentials([[
-                                             $class: 'AmazonWebServicesCredentialsBinding',
-                                             credentialsId: 'aws',
-                                             accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                                             secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                                     ]]){
-                        sh """
+        stage ("Lint and Test"){
+            environment {
+                CREDS_FILE = credentials('pipeline-e2e-creds')
+                LOGDNA_HOST = "logs.use.stage.logdna.net"
+            }
+            parallel {
+                stage('Lint, Unit and Integration Tests'){
+                    steps {
+                        script {
+                            def creds = readJSON file: CREDS_FILE
+                            // Assumes the pipeline-e2e-creds format remains the same. Chase
+                            // refer to the e2e tests's README's authorization docs for the
+                            // current structure
+                            LOGDNA_INGESTION_KEY = creds["packet-stage"]["account"]["ingestionkey"]
+                        }
+                        withCredentials([[
+                                                 $class: 'AmazonWebServicesCredentialsBinding',
+                                                 credentialsId: 'aws',
+                                                 accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                                 secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                         ]]){
+                            sh """
                         make lint
                         make test
                         make integration-test LOGDNA_INGESTION_KEY=${LOGDNA_INGESTION_KEY}
                     """
+                        }
+                    }
+                    post {
+                        success {
+                            sh "make clean"
+                        }
                     }
                 }
-                post {
-                    success {
-                        sh "make clean"
+                stage('Run performance regression testing') {
+                    when {
+                        not {
+                            branch 'master'
+                        }
                     }
-                }
-            }
-            stage('Run performance regression testing') {
-                when {
-                    not {
-                        branch 'master'
-                    }
-                }
-                stages {
-                    stage('Manual approval for regression testing') {
-                        steps {
-                            script {
-                                runBenchmarks = true
-                                try {
-                                    timeout(time: 30, unit: 'SECONDS') {
-                                        input(message: 'Run optional performance regression tests?')
+                    stages {
+                        stage('Manual approval for regression testing') {
+                            steps {
+                                script {
+                                    runBenchmarks = true
+                                    try {
+                                        timeout(time: 30, unit: 'SECONDS') {
+                                            input(message: 'Run optional performance regression tests?')
+                                        }
+                                    } catch (ignored) {
+                                        runBenchmarks = false
                                     }
-                                } catch (err) {
-                                    runBenchmarks = false
                                 }
                             }
                         }
-                    }
-                    stage('Run benchmarks') {
-                        when {
-                            expression { return runBenchmarks == true }
-                        }
-                        steps {
-                            script {
-                                withCredentials([[
-                                                         $class: 'AmazonWebServicesCredentialsBinding',
-                                                         credentialsId: 'aws',
-                                                         accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                                                         secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                                                 ]]){
-                                    timeout(time: 15, unit: 'MINUTES') {
-                                        sh script: '''
-                                        echo "Running performance benchmarks for $GIT_BRANCH with master as baseline"
-                                        rm -Rf agent-benchmarks
-                                        git clone -q https://github.com/logdna/agent-benchmarks.git && cd agent-benchmarks
-                                        echo "" > dummy_github_id_rsa
-                                        terraform init ./terraform/
-                                        terraform apply -auto-approve -var="baseline_agent_type=rust" -var="compare_agent_type=rust" -var="compare_agent_branch=$GIT_BRANCH" -var="test_scenario=2" -var="path_to_ssh_key=dummy_github_id_rsa" -var="aws_access_key=$AWS_ACCESS_KEY_ID" -var="aws_secret_key=$AWS_SECRET_ACCESS_KEY" -var="bucket_folder=$GIT_BRANCH-$BUILD_NUMBER" ./terraform/
-                                    ''', label: 'Run benchmarks using terraform'
-                                    }
+                        stage('Run benchmarks') {
+                            when {
+                                expression { return runBenchmarks == true }
+                            }
+                            steps {
+                                script {
+                                    withCredentials([[
+                                                             $class: 'AmazonWebServicesCredentialsBinding',
+                                                             credentialsId: 'aws',
+                                                             accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                                             secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                                     ]]){
 
-                                    echo "Memory usage: https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/memory-series.png"
-                                    echo "CPU histogram (this branch): https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/benchmarks/compare/cpu.txt"
-                                    echo "CPU histogram (baseline): https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/benchmarks/baseline/cpu.txt"
+                                        timeout(time: 15, unit: 'MINUTES') {
+                                            sh script: '''
+                                                echo "Running performance benchmarks for $GIT_BRANCH with master as baseline"
+                                                rm -Rf agent-benchmarks
+                                                git clone -q https://github.com/logdna/agent-benchmarks.git && cd agent-benchmarks
+                                                echo "" > dummy_github_id_rsa
+                                                terraform init ./terraform/
+                                                terraform apply -auto-approve -var="baseline_agent_type=rust" -var="compare_agent_type=rust" -var="compare_agent_branch=$GIT_BRANCH" -var="test_scenario=2" -var="path_to_ssh_key=dummy_github_id_rsa" -var="aws_access_key=$AWS_ACCESS_KEY_ID" -var="aws_secret_key=$AWS_SECRET_ACCESS_KEY" -var="bucket_folder=$GIT_BRANCH-$BUILD_NUMBER" ./terraform/
+                                            ''', label: 'Run benchmarks using terraform'
+                                        }
+
+                                        echo "Memory usage: https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/memory-series.png"
+                                        echo "CPU histogram (this branch): https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/benchmarks/compare/cpu.txt"
+                                        echo "CPU histogram (baseline): https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/benchmarks/baseline/cpu.txt"
+                                    }
                                 }
                             }
-                        }
-                        post {
-                            always {
-                                withCredentials([[
-                                                         $class: 'AmazonWebServicesCredentialsBinding',
-                                                         credentialsId: 'aws',
-                                                         accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                                                         secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                                                 ]]){
-                                    retry(3) {
-                                        sh script: '''
+                            post {
+                                always {
+                                    withCredentials([[
+                                                             $class: 'AmazonWebServicesCredentialsBinding',
+                                                             credentialsId: 'aws',
+                                                             accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                                             secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                                     ]]){
+                                        retry(3) {
+                                            sh script: '''
                                         cd agent-benchmarks
                                         terraform destroy -auto-approve ./terraform/
                                     ''', label: 'Destroy resources using terraform'
+                                        }
                                     }
                                 }
                             }
                         }
+
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,86 +38,74 @@ pipeline {
                 sh "docker pull ${RUST_IMAGE_REPO}:${RUST_IMAGE_TAG}"
             }
         }
-        stage ("Lint and Test"){
-            environment {
-                CREDS_FILE = credentials('pipeline-e2e-creds')
-                LOGDNA_HOST = "logs.use.stage.logdna.net"
-            }
-            steps {
-                script {
-                    def creds = readJSON file: CREDS_FILE
-                    // Assumes the pipeline-e2e-creds format remains the same. Chase
-                    // refer to the e2e tests's README's authorization docs for the
-                    // current structure
-                    LOGDNA_INGESTION_KEY = creds["packet-stage"]["account"]["ingestionkey"]
+        parallel {
+            stage ("Lint and Test"){
+                environment {
+                    CREDS_FILE = credentials('pipeline-e2e-creds')
+                    LOGDNA_HOST = "logs.use.stage.logdna.net"
                 }
-                withCredentials([[
-                    $class: 'AmazonWebServicesCredentialsBinding',
-                    credentialsId: 'aws',
-                    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                    secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                ]]){
-                    sh """
+                steps {
+                    script {
+                        def creds = readJSON file: CREDS_FILE
+                        // Assumes the pipeline-e2e-creds format remains the same. Chase
+                        // refer to the e2e tests's README's authorization docs for the
+                        // current structure
+                        LOGDNA_INGESTION_KEY = creds["packet-stage"]["account"]["ingestionkey"]
+                    }
+                    withCredentials([[
+                                             $class: 'AmazonWebServicesCredentialsBinding',
+                                             credentialsId: 'aws',
+                                             accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                             secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                     ]]){
+                        sh """
                         make lint
                         make test
                         make integration-test LOGDNA_INGESTION_KEY=${LOGDNA_INGESTION_KEY}
                     """
+                    }
+                }
+                post {
+                    success {
+                        sh "make clean"
+                    }
                 }
             }
-            post {
-                success {
-                    sh "make clean"
+            stage('Run performance regression testing') {
+                when {
+                    not {
+                        branch 'master'
+                    }
                 }
-            }
-        }
-        stage('Run performance regression testing') {
-            when {
-               not {
-                   branch 'master'
-               }
-            }
-            stages {
-                stage('Manual approval for regression testing') {
-                    steps {
-                        script {
-                            runBenchmarks = true
-                            try {
-                                timeout(time: 30, unit: 'SECONDS') {
-                                    input(message: 'Run optional performance regression tests?')
+                stages {
+                    stage('Manual approval for regression testing') {
+                        steps {
+                            script {
+                                runBenchmarks = true
+                                try {
+                                    timeout(time: 30, unit: 'SECONDS') {
+                                        input(message: 'Run optional performance regression tests?')
+                                    }
+                                } catch (err) {
+                                    runBenchmarks = false
                                 }
-                            } catch (err) {
-                                runBenchmarks = false
                             }
                         }
                     }
-                }
-                stage('Run benchmarks') {
-                    when {
-                        expression { return runBenchmarks == true }
-                    }
-                    steps {
-                        script {
-                            withCredentials([[
-                                $class: 'AmazonWebServicesCredentialsBinding',
-                                credentialsId: 'aws',
-                                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                            ]]){
-                                // TODO: Modify Jenkins worker image to include terraform
-                                sh script: '''
-                                    # Install terraform, it should be moved to the image
-                                    if ! command -v terraform &> /dev/null
-                                    then
-                                        echo "Installing terraform"
-                                        curl -o terraform.zip "https://releases.hashicorp.com/terraform/0.14.2/terraform_0.14.2_linux_amd64.zip"
-                                        unzip terraform.zip
-                                        sudo mv terraform /usr/local/bin/
-                                        terraform --version
-                                    fi
-                                ''', label: 'Install terraform'
-
-                                timeout(time: 15, unit: 'MINUTES') {
-                                    sh script: '''
+                    stage('Run benchmarks') {
+                        when {
+                            expression { return runBenchmarks == true }
+                        }
+                        steps {
+                            script {
+                                withCredentials([[
+                                                         $class: 'AmazonWebServicesCredentialsBinding',
+                                                         credentialsId: 'aws',
+                                                         accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                                         secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                                 ]]){
+                                    timeout(time: 15, unit: 'MINUTES') {
+                                        sh script: '''
                                         echo "Running performance benchmarks for $GIT_BRANCH with master as baseline"
                                         rm -Rf agent-benchmarks
                                         git clone -q https://github.com/logdna/agent-benchmarks.git && cd agent-benchmarks
@@ -125,33 +113,33 @@ pipeline {
                                         terraform init ./terraform/
                                         terraform apply -auto-approve -var="baseline_agent_type=rust" -var="compare_agent_type=rust" -var="compare_agent_branch=$GIT_BRANCH" -var="test_scenario=2" -var="path_to_ssh_key=dummy_github_id_rsa" -var="aws_access_key=$AWS_ACCESS_KEY_ID" -var="aws_secret_key=$AWS_SECRET_ACCESS_KEY" -var="bucket_folder=$GIT_BRANCH-$BUILD_NUMBER" ./terraform/
                                     ''', label: 'Run benchmarks using terraform'
-                                }
+                                    }
 
-                                echo "Memory usage: https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/memory-series.png"
-                                echo "CPU histogram (this branch): https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/benchmarks/compare/cpu.txt"
-                                echo "CPU histogram (baseline): https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/benchmarks/baseline/cpu.txt"
+                                    echo "Memory usage: https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/memory-series.png"
+                                    echo "CPU histogram (this branch): https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/benchmarks/compare/cpu.txt"
+                                    echo "CPU histogram (baseline): https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/${env.GIT_BRANCH}-${env.BUILD_NUMBER}/benchmarks/baseline/cpu.txt"
+                                }
                             }
                         }
-                    }
-                    post {
-                        always {
-                            withCredentials([[
-                                $class: 'AmazonWebServicesCredentialsBinding',
-                                credentialsId: 'aws',
-                                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                            ]]){
-                                retry(3) {
-                                    sh script: '''
+                        post {
+                            always {
+                                withCredentials([[
+                                                         $class: 'AmazonWebServicesCredentialsBinding',
+                                                         credentialsId: 'aws',
+                                                         accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                                         secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                                 ]]){
+                                    retry(3) {
+                                        sh script: '''
                                         cd agent-benchmarks
                                         terraform destroy -auto-approve ./terraform/
                                     ''', label: 'Destroy resources using terraform'
+                                    }
                                 }
                             }
                         }
                     }
                 }
-
             }
         }
         stage('Build Release Image') {


### PR DESCRIPTION
It adds an optional stage to the build to run performance regression testing. This approval process has a 30s timeout and if it's not approved, the build can continue without reporting a failure.

The stage generates a memory series ([like this one](https://agent-benchmarks-results.s3.us-east-2.amazonaws.com/perf-regression-testing-27/memory-series.png)) chart and CPU histogram files that are linked in the stage output. Hopefully, CPU histograms [will be charts in the future too](https://github.com/logdna/agent-benchmarks/issues/6).

cc @jmoses @c-nixon 