### PR TITLE
Add direct resource links to k8s resource files (v2.2-nonroot)

### DIFF
--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -33,9 +33,9 @@ The agent can be installed in your cluster using a set of YAML files we provide.
 1. Navigate to the root directory of the cloned `logdna-agent-v2` repository.
 2. Run the following commands to configure and start the agent:
 ```console
-kubectl apply -f k8s/agent-namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/jondkelley/logdna-agent-v2/2.2-nonroot/k8s/agent-namespace.yaml
 kubectl create secret generic logdna-agent-key -n logdna-agent --from-literal=logdna-agent-key=<YOUR LOGDNA INGESTION KEY>
-kubectl apply -f k8s/agent-resources.yaml
+kubectl apply -f https://raw.githubusercontent.com/jondkelley/logdna-agent-v2/2.2-nonroot/k8s/agent-resources.yaml
 ```
 3. Monitor the pods for startup success:
 ```console
@@ -126,7 +126,7 @@ kubectl patch daemonset -n logdna-agent logdna-agent --type json -p '[{"op":"rep
 The default configuration places all of the Kubernetes objects in a unique namespace. To completely remove all traces of the agent you need to simply delete this namespace:
 
 ```console
-kubectl delete -f k8s/agent-namespace.yaml
+kubectl delete -f https://raw.githubusercontent.com/jondkelley/logdna-agent-v2/2.2-nonroot/k8s/agent-namespace.yaml
 ```
 
 If you're sharing the namespace with other applications, and thus you need to leave the namespace, you can instead remove all traces by deleting the agent with a label filter. You'll also need to remove the logdna-agent-key secret which doesn't have a label:

--- a/docs/OPENSHIFT.md
+++ b/docs/OPENSHIFT.md
@@ -39,7 +39,7 @@ oc adm policy add-scc-to-user privileged system:serviceaccount:logdna-agent:logd
 ```
 3. Create the remaining resources:
 ```console
-oc apply -f k8s/agent-resources-openshift.yaml
+oc apply -f https://raw.githubusercontent.com/jondkelley/logdna-agent-v2/2.2-nonroot/k8s/agent-resources-openshift.yaml
 ```
 4. Monitor the pods for startup success:
 ```console


### PR DESCRIPTION
This should be more convenient then having to work within a checked out local branch when applying these resource sets.

This PR covers the 2.2 agent / branch.