### PR TITLE
Test removing linked nested directories

### DIFF
--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -274,3 +274,44 @@ fn test_append_after_symlinks_delete() {
     common::assert_agent_running(&mut agent_handle);
     agent_handle.kill().expect("Could not kill process");
 }
+
+#[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
+#[cfg_attr(not(target_os = "linux"), ignore)]
+fn test_directory_symlinks_delete() {
+    let log_dir = tempdir().expect("Could not create temp dir").into_path();
+    let data_dir = tempdir().expect("Could not create temp dir").into_path();
+
+    let dir_1_path = data_dir.join("dir_1");
+    let dir_1_1_path = dir_1_path.join("dir_1_1");
+    let dir_1_2_path = dir_1_path.join("dir_1_2");
+    let dir_1_2_1_path = dir_1_2_path.join("dir_1_2_1");
+    let file1_path = dir_1_1_path.join("file1.log");
+    let file2_path = dir_1_2_1_path.join("file2.log");
+    let file3_path = dir_1_2_1_path.join("file3.log");
+    let symlink_path = log_dir.join("dir_1_link");
+
+    common::create_dirs(&[&dir_1_path, &dir_1_1_path, &dir_1_2_path, &dir_1_2_1_path]);
+
+    common::append_to_file(&file1_path, 100, 50).expect("Could not append");
+    common::append_to_file(&file2_path, 100, 50).expect("Could not append");
+    common::append_to_file(&file3_path, 100, 50).expect("Could not append");
+
+    let mut agent_handle = common::spawn_agent(&log_dir.to_str().unwrap());
+    let mut stderr_reader = BufReader::new(agent_handle.stderr.as_mut().unwrap());
+
+    std::os::unix::fs::symlink(&dir_1_path, &symlink_path).unwrap();
+
+    common::wait_for_file_event("initialized", &file1_path, &mut stderr_reader);
+
+    common::append_to_file(&file1_path, 1_000, 50).expect("Could not append");
+    common::append_to_file(&file2_path, 1_000, 50).expect("Could not append");
+    common::append_to_file(&file3_path, 1_000, 50).expect("Could not append");
+
+    fs::remove_file(&symlink_path).expect("Could not remove symlink");
+
+    common::wait_for_file_event("unwatching", &file3_path, &mut stderr_reader);
+
+    common::assert_agent_running(&mut agent_handle);
+    agent_handle.kill().expect("Could not kill process");
+}

--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -1,5 +1,6 @@
 use assert_cmd::cargo::CommandCargoExt;
 use core::time;
+use std::fs;
 use std::fs::OpenOptions;
 use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
@@ -134,5 +135,11 @@ pub fn assert_agent_running(agent_handle: &mut Child) {
     for _ in 0..10 {
         thread::sleep(std::time::Duration::from_millis(20));
         assert!(agent_handle.try_wait().ok().unwrap().is_none());
+    }
+}
+
+pub fn create_dirs<P: AsRef<Path>>(dirs: &[P]) {
+    for dir in dirs {
+        fs::create_dir(dir).expect("Unable to create dir");
     }
 }

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -908,12 +908,10 @@ where
 
                             match self.create_dir(&real, _entries) {
                                 Some(v) => Some(v),
-                                None => {
-                                    panic!(
-                                        "unable to create symlink directory for entry {:?}",
-                                        &real
-                                    )
-                                }
+                                None => panic!(
+                                    "unable to create symlink directory for entry {:?}",
+                                    &real
+                                ),
                             }
                         }
                     }


### PR DESCRIPTION
Add an integration test that uses nested directories w/ a symlink to the log directory that is removed.

Based on #63. 

This currently fails on master awaiting for the LOG-7968 fix.