### PR TITLE
Use hostname package to instead of libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,6 @@ dependencies = [
  "http 0.1.0",
  "k8s",
  "lazy_static",
- "libc",
  "log",
  "pcre2",
  "scopeguard",

--- a/common/config/Cargo.toml
+++ b/common/config/Cargo.toml
@@ -17,7 +17,6 @@ globber = "0.1"
 pcre2 = "0.2"
 lazy_static = "1.0"
 flate2 = "1.0"
-libc = "0.2"
 log = "0.4"
 sysinfo = "0.15"
 

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -2,7 +2,6 @@
 extern crate log;
 
 use std::convert::{TryFrom, TryInto};
-use std::ffi::CString;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
@@ -268,12 +267,7 @@ pub fn get_hostname() -> Option<String> {
         }
     }
 
-    let name = CString::new(Vec::with_capacity(512)).ok()?.into_raw();
-    if unsafe { libc::gethostname(name, 512) } == 0 {
-        return unsafe { CString::from_raw(name) }.into_string().ok();
-    }
-
-    None
+    System::new_with_specifics(RefreshKind::new()).get_host_name()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This cleans up some more unsafe usage in the config module, in this case it was causing a use-after-free in my local tests.