### PR TITLE
feat: Add 'auditable' to agent so we can track the dep versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+
+[[package]]
 name = "array_tool"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +81,36 @@ dependencies = [
  "hermit-abi",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "auditable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5688d93433d0c5d82a0214b490358112f359b69efe8093b45e80b48262e891"
+
+[[package]]
+name = "auditable-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75a4eac8b65ab1e9d03394cd522eace98a452554651f3dda58a609873a1bd2"
+dependencies = [
+ "auditable-serde",
+ "cargo_metadata",
+ "miniz_oxide",
+ "serde_json",
+]
+
+[[package]]
+name = "auditable-serde"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6cab96878190de929001e8d9c15bcafbd21d1c259b010e2b1ee8ed1f5786ae"
+dependencies = [
+ "cargo_metadata",
+ "semver 0.10.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -156,6 +192,17 @@ name = "bytes"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+
+[[package]]
+name = "cargo_metadata"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a567c24b86754d629addc2db89e340ac9398d07b5875efcff837e3878e17ec"
+dependencies = [
+ "semver 0.10.0",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cc"
@@ -1362,7 +1409,10 @@ dependencies = [
 name = "logdna-agent"
 version = "3.0.0-beta.1"
 dependencies = [
+ "anyhow",
  "assert_cmd",
+ "auditable",
+ "auditable-build",
  "config",
  "env_logger",
  "fs",
@@ -1374,6 +1424,7 @@ dependencies = [
  "log",
  "metrics",
  "middleware",
+ "miniz_oxide",
  "pin-utils",
  "predicates",
  "serde_yaml",
@@ -2092,7 +2143,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2171,6 +2222,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+dependencies = [
+ "semver-parser",
+ "serde",
 ]
 
 [[package]]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -13,6 +13,7 @@ name = "logdna-agent"
 version = "3.0.0-beta.1"
 authors = ["CJP10 <connor.peticca@logdna.com>"]
 edition = "2018"
+build = "build.rs"
 
 [[bin]]
 name = "logdna-agent"
@@ -30,11 +31,15 @@ journald = { package = "journald", path = "../common/journald" }
 
 log = "0.4"
 env_logger = "0.7"
+anyhow = "1.0"
 serde_yaml = "0.8"
 jemallocator = "0.3"
 futures = "0.3"
 tokio = { version = "0.2", features = ["rt-threaded"] }
 pin-utils = "0.1"
+
+auditable = "0.1"
+miniz_oxide = "0.4"
 
 [features]
 default = []
@@ -45,3 +50,6 @@ journald_tests = ["journald/journald_tests"]
 assert_cmd = "1"
 predicates = "1"
 tempfile = "3"
+
+[build-dependencies]
+auditable-build = "0.1"

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    auditable_build::collect_dependency_list();
+}

--- a/bin/src/dep_audit.rs
+++ b/bin/src/dep_audit.rs
@@ -1,0 +1,11 @@
+use anyhow::{Error, Result};
+// Serialized version of the Cargo.lock file
+static COMPRESSED_DEPENDENCY_LIST: &[u8] = auditable::inject_dependency_list!();
+
+pub(crate) fn get_auditable_dependency_list() -> Result<String> {
+    use miniz_oxide::inflate::decompress_to_vec_zlib;
+    let decompressed_data = decompress_to_vec_zlib(&COMPRESSED_DEPENDENCY_LIST)
+        .map_err(|_| Error::msg("Could not decompress dependency list"))?;
+    //.map_err(|_| ("Failed to decompress audit data"))?;
+    Ok(String::from_utf8(decompressed_data)?)
+}

--- a/bin/src/dep_audit.rs
+++ b/bin/src/dep_audit.rs
@@ -6,6 +6,5 @@ pub(crate) fn get_auditable_dependency_list() -> Result<String> {
     use miniz_oxide::inflate::decompress_to_vec_zlib;
     let decompressed_data = decompress_to_vec_zlib(&COMPRESSED_DEPENDENCY_LIST)
         .map_err(|_| Error::msg("Could not decompress dependency list"))?;
-    //.map_err(|_| ("Failed to decompress audit data"))?;
     Ok(String::from_utf8(decompressed_data)?)
 }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -26,6 +26,8 @@ use std::rc::Rc;
 
 use tokio::runtime::Runtime;
 
+mod dep_audit;
+
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
@@ -41,6 +43,10 @@ pub static PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 fn main() {
     env_logger::from_env(Env::default().default_filter_or("info")).init();
     info!("running version: {}", env!("CARGO_PKG_VERSION"));
+
+    // Actually use the data to work around a bug in rustc:
+    // https://github.com/rust-lang/rust/issues/47384
+    trace!("{:?}", dep_audit::get_auditable_dependency_list());
 
     let config = match Config::new() {
         Ok(v) => v,

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -46,7 +46,8 @@ fn main() {
 
     // Actually use the data to work around a bug in rustc:
     // https://github.com/rust-lang/rust/issues/47384
-    trace!("{:?}", dep_audit::get_auditable_dependency_list());
+    dep_audit::get_auditable_dependency_list()
+        .map_or_else(|e| trace!("{}", e), |d| trace!("{}", d));
 
     let config = match Config::new() {
         Ok(v) => v,


### PR DESCRIPTION
Bonus PR while I'm waiting for builds.

This adds support for https://github.com/Shnatsel/rust-audit, which includes cargo lock metadata in the agent binaries themselves so that we can check the exact versions that were compiled into any given binary.