### PR TITLE
Use recoverable errors in fs cache

### DIFF
--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -64,11 +64,15 @@ fn api_key_present() {
     stderr_ref.read_to_string(&mut output).unwrap();
 
     // Check that the agent logs that it has sent lines from each file
-    assert!(predicate::str::contains(&format!(
-        "watching \"{}\"",
-        before_file_path.to_str().unwrap()
-    ))
-    .eval(&output));
+    assert!(
+        predicate::str::contains(&format!(
+            "watching \"{}\"",
+            before_file_path.to_str().unwrap()
+        ))
+        .eval(&output),
+        "'watching' not found in output: {}",
+        output
+    );
     assert!(predicate::str::contains(&format!(
         "tailer sendings lines for [\"{}\"]",
         before_file_path.to_str().unwrap()

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -260,12 +260,22 @@ where
             let mut path = self.resolve_direct_path(&entry.borrow(), _entries);
             path.push(name);
 
+            let mut errors = vec![];
             if let Some(new_entry) = self.insert(&path, events, _entries)? {
                 if matches!(_entries.get(new_entry).map(|n_e| n_e.borrow()), Some(_)) {
                     for new_path in recursive_scan(&path) {
-                        self.insert(&new_path, events, _entries)?;
+                        if let Err(e) = self.insert(&new_path, events, _entries) {
+                            errors.push(e);
+                        }
                     }
                 };
+            }
+
+            if errors.len() > 0 {
+                return Err(format!(
+                    "encountered errors when inserting recursively: {}",
+                    errors.join(";")
+                ));
             }
 
             Ok(())

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -158,7 +158,7 @@ where
             }
         };
 
-        let initial_events: Vec<Event> = {
+        let initial_events = {
             let mut fs = fs.try_lock().expect("could not lock filesystem cache");
 
             let mut acc = Vec::new();

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -173,7 +173,7 @@ where
         let events = events_stream.into_stream().map(move |event| {
             let fs = fs.clone();
             {
-                let mut acc: Vec<Event> = Vec::new();
+                let mut acc = Vec::new();
 
                 match event {
                     Ok(event) => {
@@ -182,7 +182,7 @@ where
                             .process(event, &mut acc);
                         futures::stream::iter(acc)
                     }
-                    Err(_) => panic!("Inotify error"),
+                    _ => panic!("Inotify error"),
                 }
             }
         });

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -178,7 +178,7 @@ impl Tailer {
                                             entry = r_entry
                                         }
                                     } else {
-                                        error!("can't wrap up deleted symlink - pointed to file / directory doesn't exist: {:?}", paths[0]);
+                                        info!("can't wrap up deleted symlink - pointed to file / directory doesn't exist: {:?}", paths[0]);
                                     }
                                 }
 

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -173,8 +173,8 @@ impl Tailer {
                             debug!("Delete Event");
                             if !paths.is_empty() {
                                 if let Entry::Symlink { link, .. } = entry.borrow().deref() {
-                                    if let Some(real_entry) = fs.lookup(link, &entries) {
-                                        if let Some(r_entry) = entries.get(real_entry){
+                                    if let Ok(Some(real_entry)) = fs.lookup(link, &entries) {
+                                        if let Some(r_entry) = entries.get(real_entry) {
                                             entry = r_entry
                                         }
                                     } else {

--- a/common/journald/src/stream.rs
+++ b/common/journald/src/stream.rs
@@ -296,7 +296,7 @@ mod tests {
         sleep(Duration::from_millis(50));
         journal::print(1, "Reader got the correct line 2!");
 
-        let first_batch = match timeout(Duration::from_millis(50), stream.next()).await {
+        let first_batch = match timeout(Duration::from_millis(500), stream.next()).await {
             Err(e) => {
                 panic!("unable to grab first batch of lines from stream: {:?}", e);
             }
@@ -313,7 +313,7 @@ mod tests {
             assert_eq!(line_str, "Reader got the correct line 1!");
         }
 
-        let second_batch = match timeout(Duration::from_millis(50), stream.next()).await {
+        let second_batch = match timeout(Duration::from_millis(500), stream.next()).await {
             Err(e) => {
                 panic!("unable to grab second batch of lines from stream: {:?}", e);
             }


### PR DESCRIPTION
This patch replaces `unwrap()` and `expect()` calls that would cause thread panic with recoverable errors.

Ref: LOG-8421.