### PR TITLE
Fix follow_links() loop and lookup()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -643,7 +643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63f713f8b2aa9e24fec85b0e290c56caee12e3b6ae0aeeda238a75b28251afd6"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -787,7 +787,7 @@ checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -1731,7 +1731,7 @@ checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api 0.4.2",
- "parking_lot_core 0.8.2",
+ "parking_lot_core 0.8.3",
 ]
 
 [[package]]
@@ -1751,14 +1751,14 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.1.57",
+ "redox_syscall 0.2.5",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c220d01f863d13d96ca82359d1e81e64a7c6bf0637bcde7b2349630addf0c6"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
 dependencies = [
  "base64 0.13.0",
  "once_cell",
@@ -1853,7 +1853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -1864,7 +1864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -1974,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2 1.0.24",
 ]
@@ -2002,7 +2002,7 @@ checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
 
@@ -2023,7 +2023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -2037,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
 ]
@@ -2059,7 +2059,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -2095,9 +2095,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]
@@ -2109,7 +2109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.2",
- "redox_syscall 0.2.4",
+ "redox_syscall 0.2.5",
 ]
 
 [[package]]
@@ -2328,7 +2328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -2370,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd2af560da3c1fdc02cb80965289254fc35dff869810061e2d8290ee48848ae"
+checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -2398,7 +2398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -2466,7 +2466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -2531,7 +2531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "serde",
  "serde_derive",
  "syn 1.0.60",
@@ -2545,7 +2545,7 @@ checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2586,7 +2586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "unicode-xid 0.2.1",
 ]
 
@@ -2631,7 +2631,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
- "redox_syscall 0.2.4",
+ "redox_syscall 0.2.5",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2661,7 +2661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -2717,7 +2717,7 @@ checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "standback",
  "syn 1.0.60",
 ]
@@ -2864,7 +2864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -3228,7 +3228,7 @@ dependencies = [
  "lazy_static",
  "log",
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
  "wasm-bindgen-shared",
 ]
@@ -3251,7 +3251,7 @@ version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
 dependencies = [
- "quote 1.0.8",
+ "quote 1.0.9",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3262,7 +3262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -469,7 +469,7 @@ where
         }
 
         let parent_ref = self.create_dir(&path.parent().unwrap().into(), _entries)?;
-        let parent_ref = self.follow_links(parent_ref, _entries)?;
+        let parent_ref = self.follow_links(parent_ref, _entries);
 
         if parent_ref.is_none() {
             return Ok(None);
@@ -630,7 +630,7 @@ where
     ) -> FsResult<()> {
         let path_buf = path.parent().ok_or(Error::PathNotValid)?.into();
         let parent = self
-            .lookup(&path_buf, _entries)?
+            .lookup(&path_buf, _entries)
             .ok_or(Error::ParentLookup)?;
         let component = into_components(path).pop().ok_or(Error::PathNotValid)?;
 
@@ -704,7 +704,7 @@ where
         let parent_path = to.parent().ok_or(Error::ParentNotValid)?;
         let new_parent = self.create_dir(&parent_path.into(), _entries)?;
 
-        match self.lookup(from, _entries)? {
+        match self.lookup(from, _entries) {
             Some(entry_key) => {
                 let entry = _entries.get(entry_key).ok_or(Error::Lookup)?;
                 let new_name = into_components(to).pop().ok_or(Error::PathNotValid)?;
@@ -785,7 +785,7 @@ where
 
             let new_entry = match action {
                 Action::Return(key) => key,
-                Action::Lookup(ref link) => self.lookup(link, _entries)?.ok_or(Error::Lookup)?,
+                Action::Lookup(ref link) => self.lookup(link, _entries).ok_or(Error::Lookup)?,
                 Action::CreateDir => {
                     let wd = self
                         .watcher
@@ -849,8 +849,9 @@ where
         }
     }
 
-    /// Returns the entry that represents the supplied path or `Ok(None)`.
-    pub fn lookup(&self, path: &PathBuf, _entries: &EntryMap<T>) -> FsResult<Option<EntryKey>> {
+    /// Returns the entry that represents the supplied path.
+    /// When the path is not represented and therefore has no entry then `None` is return.
+    pub fn lookup(&self, path: &PathBuf, _entries: &EntryMap<T>) -> Option<EntryKey> {
         let mut parent = self.root;
         let mut components = into_components(path);
         // remove the first component because it will always be the root
@@ -858,56 +859,43 @@ where
 
         // If the path has no components there is nothing to look up.
         if components.is_empty() {
-            return Ok(None);
+            return None;
         }
 
-        let last_component = components.pop().unwrap();
+        let last_component = components.pop()?;
 
         for component in components {
-            if let Some(entry) = self.follow_links(parent, _entries)? {
-                if let Some(parent_ref) = _entries
-                    .get(entry)
-                    .ok_or(Error::ParentLookup)?
-                    .borrow()
-                    .children()
-                    .ok_or(Error::ParentNotValid)?
-                    .get(&component)
-                {
-                    if let Some(parent_ref) = self.follow_links(*parent_ref, _entries)? {
-                        parent = parent_ref;
-                        continue;
-                    }
+            parent = self.follow_links(parent, _entries).and_then(|e| {
+                if let Some(e) = _entries.get(e) {
+                    e.borrow()
+                        .children()?
+                        .get(&component)
+                        .and_then(|entry| self.follow_links(*entry, _entries))
+                } else {
+                    error!("Failed to find entry");
+                    None
                 }
-            }
-
-            // When components are not found `Ok(None)` is returned
-            return Ok(None);
+            })?;
         }
 
-        Ok(_entries
-            .get(parent)
-            .ok_or(Error::ParentLookup)?
+        _entries
+            .get(parent)?
             .borrow()
-            .children()
-            .ok_or(Error::ParentNotValid)?
+            .children()?
             .get(&last_component)
-            .copied())
+            .copied()
     }
 
-    fn follow_links(&self, entry: EntryKey, _entries: &EntryMap<T>) -> FsResult<Option<EntryKey>> {
+    fn follow_links(&self, entry: EntryKey, _entries: &EntryMap<T>) -> Option<EntryKey> {
         let mut result = entry;
-        while let Some(e) = _entries.get(entry) {
+        while let Some(e) = _entries.get(result) {
             if let Some(link) = e.borrow().link() {
-                if let Some(e) = self.lookup(link, _entries)? {
-                    result = e;
-                } else {
-                    return Ok(None);
-                }
+                result = self.lookup(link, _entries)?;
             } else {
                 break;
             }
         }
-        Ok(Some(result))
+        Some(result)
     }
 
     fn is_symlink_target(&self, path: &PathBuf, _entries: &EntryMap<T>) -> bool {
@@ -1096,7 +1084,7 @@ mod tests {
             let fs = $x.lock().expect("failed to lock fs");
             let entries = fs.entries.clone();
             let entries = entries.borrow();
-            fs.lookup(&$y, &entries).unwrap()
+            fs.lookup(&$y, &entries)
         }};
     }
 

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -872,7 +872,7 @@ where
                         .get(&component)
                         .and_then(|entry| self.follow_links(*entry, _entries))
                 } else {
-                    error!("Failed to find entry");
+                    info!("Failed to find entry on lookup");
                     None
                 }
             })?;

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -174,7 +174,7 @@ impl Tailer {
                                 debug!("Delete Event");
                                 if !paths.is_empty() {
                                     if let Entry::Symlink { link, .. } = entry.borrow().deref() {
-                                        if let Ok(Some(real_entry)) = fs.lookup(link, &entries) {
+                                        if let Some(real_entry) = fs.lookup(link, &entries) {
                                             if let Some(r_entry) = entries.get(real_entry) {
                                                 entry = r_entry
                                             }
@@ -204,7 +204,7 @@ impl Tailer {
                             // if Some(..) = entries.get(key) clauses)
                             let mut entries = fs.entries.borrow_mut();
                             if entries.remove(entry_ptr).is_some() {
-                                debug!(
+                                info!(
                                     "Entry was removed from the map, new length: {}",
                                     entries.len());
                             }

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -205,7 +205,7 @@ impl Tailer {
                             let mut entries = fs.entries.borrow_mut();
                             if entries.remove(entry_ptr).is_some() {
                                 info!(
-                                    "Entry was removed from the map, new length: {}",
+                                    "Removed file information, currently tracking {} files",
                                     entries.len());
                             }
                         }


### PR DESCRIPTION
Fixes infinite loop in `follow_links()` method and fixes `lookup()` to only return an `Option<EntryKey>` (instead of wrapped in a result).