### PR TITLE
docs(community): Point community away from Slack

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -55,13 +55,15 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the team on our [public Slack channel][slack]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported by contacting the team on our [community Discourse][discourse] or via
+[email][oss-email]. All complaints will be reviewed and investigated and will
+result in a response that is deemed necessary and appropriate to the circumstances.
+The project team is obligated to maintain confidentiality with regard to the
+reporter of an incident. Further details of specific enforcement policies may be
+posted separately.
 
-[slack]: http://chat.logdna.com/
+[discourse]: https://community.logdna.com/
+[oss-email]: mailto:opensource@logdna.com?subject=OSS%20COC%20Violation
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other


### PR DESCRIPTION
Switch links from Slack to Discourse and OSS email list.