### PR TITLE
Document upgrading from archived Helm repo

### DIFF
--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -17,7 +17,8 @@ Follow directions from https://app.logdna.com/pages/add-source to obtain your Lo
 A [Helm Chart][helm-concepts], defined in a package containing a set of YAML files, acts a single point of authority
 and provides repeatable build and deploy tasks to define, install, and upgrade Kubernetes resources.
 
-Run the following commands to install the agent with the [release name][helm-concepts] `my-release` in your cluster:
+Run the following commands to install the LogDNA Agent with the [release name][helm-concepts] `my-release` in your
+cluster:
 
 ```bash
 $ helm repo add logdna https://assets.logdna.com/charts
@@ -37,7 +38,7 @@ helm install --set logdna.key=$LOGDNA_INGESTION_KEY -n my-namespace --create-nam
 ### Tags support:
 
 Optionally, you can configure the LogDNA Agent to associate tags to all log records that it collects so that you can
-identify the agent's data quicker in the LogDNA web UI.
+identify the data quicker in the LogDNA web UI.
 
 ```bash
 $ helm install --set logdna.key=$LOGDNA_INGESTION_KEY,logdna.tags=production my-release logdna/agent

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -26,6 +26,14 @@ $ helm install --set logdna.key=$LOGDNA_INGESTION_KEY my-release logdna/agent
 
 You should see logs in https://app.logdna.com in a few seconds.
 
+### Using a namespace
+
+If you want to scope your release to a namespace, you can use Helm's `-n` flag when installing:
+
+```bash
+helm install --set logdna.key=$LOGDNA_INGESTION_KEY -n my-namespace --create-namespace my-release logdna/agent
+```
+
 ### Tags support:
 
 Optionally, you can configure the LogDNA Agent to associate tags to all log records that it collects so that you can
@@ -79,6 +87,36 @@ $ helm uninstall my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Upgrading from the archived charts repository
+
+Charts for the LogDNA Agent were previously available on the [archived "stable" charts repository][helm-stable].
+If you deployed the agent using those helm charts, you can use `helm upgrade` to update your helm installation.
+
+First, locate the release name used to deploy:
+
+```bash
+helm list -A
+```
+
+Next, use the namespace and release name to run the upgrade command:
+
+```bash
+helm upgrade --set logdna.key=$LOGDNA_INGESTION_KEY --set nameOverride=logdna-agent -n my-namespace my-release logdna/agent
+```
+
+In case the upgrade fails due to invalid `spec.selector`, make sure to use the same label:
+
+```bash
+kubectl describe daemonsets -n my-namespace | grep Selector
+```
+
+Use the `app.kubernetes.io/name` value to set `nameOverride` value
+
+```bash
+helm upgrade --set logdna.key=$LOGDNA_INGESTION_KEY --set nameOverride=logdna-agent -n my-namespace my-release logdna/agent
+```
+
 [helm]: https://helm.sh/
 [helm-install]: https://helm.sh/docs/intro/install/
 [helm-concepts]: https://helm.sh/docs/intro/using_helm/#three-big-concepts
+[helm-stable]: https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -90,7 +90,7 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Upgrading from the archived charts repository
 
 Charts for the LogDNA Agent were previously available on the [archived "stable" charts repository][helm-stable].
-If you deployed the agent using those helm charts, you can use `helm upgrade` to update your helm installation.
+If you deployed the LogDNA Agent using those helm charts, you can use `helm upgrade` to update your helm installation.
 
 First, locate the release name used to deploy:
 
@@ -110,7 +110,7 @@ In case the upgrade fails due to invalid `spec.selector`, make sure to use the s
 kubectl describe daemonsets -n my-namespace | grep Selector
 ```
 
-Use the `app.kubernetes.io/name` value to set `nameOverride` value
+Use the `app.kubernetes.io/name` value to set `nameOverride` value:
 
 ```bash
 helm upgrade --set logdna.key=$LOGDNA_INGESTION_KEY --set nameOverride=logdna-agent -n my-namespace my-release logdna/agent

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -38,7 +38,7 @@ helm install --set logdna.key=$LOGDNA_INGESTION_KEY -n my-namespace --create-nam
 ### Tags support:
 
 Optionally, you can configure the LogDNA Agent to associate tags to all log records that it collects so that you can
-identify the data quicker in the LogDNA web UI.
+identify the data more quickly in the LogDNA web UI.
 
 ```bash
 $ helm install --set logdna.key=$LOGDNA_INGESTION_KEY,logdna.tags=production my-release logdna/agent


### PR DESCRIPTION
Document how to upgrade from the common archived charts repo to our own Helm repository charts.

It also includes information about how to use namespaces in Helm.