### PR TITLE
K8s improvements: backoff, small memoization and support disabling k8s log enrichment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,7 +1399,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "url 2.2.0",
+ "url 2.2.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "backoff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+dependencies = [
+ "getrandom 0.2.2",
+ "instant",
+ "rand 0.8.3",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,6 +1377,7 @@ dependencies = [
 name = "k8s"
 version = "0.1.0"
 dependencies = [
+ "backoff",
  "chrono",
  "chrono-humanize",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,6 +1399,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "url 2.2.0",
 ]
 
 [[package]]

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -20,7 +20,7 @@ use journald::source::create_source;
 use k8s::event_source::K8sEventStream;
 
 use k8s::middleware::K8sMetadata;
-use k8s::K8sEventLogConf;
+use k8s::K8sTrackingConf;
 use metrics::Metrics;
 use middleware::Executor;
 
@@ -103,7 +103,9 @@ fn main() {
     client.borrow_mut().set_timeout(config.http.timeout);
 
     let mut executor = Executor::new();
-    if PathBuf::from("/var/log/containers/").exists() {
+    if config.log.use_k8s_api == K8sTrackingConf::Always
+        && PathBuf::from("/var/log/containers/").exists()
+    {
         match K8sMetadata::new() {
             Ok(v) => executor.register(v),
             Err(e) => warn!("{}", e),
@@ -122,8 +124,8 @@ fn main() {
     let journald_source = create_source(&config.journald.paths);
 
     let k8s_event_stream = match config.log.log_k8s_events {
-        K8sEventLogConf::Never => None,
-        K8sEventLogConf::Always => Some(
+        K8sTrackingConf::Never => None,
+        K8sTrackingConf::Always => Some(
             K8sEventStream::try_default(
                 std::env::var("POD_NAME").ok(),
                 std::env::var("NAMESPACE").ok(),

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -103,7 +103,7 @@ fn main() {
     client.borrow_mut().set_timeout(config.http.timeout);
 
     let mut executor = Executor::new();
-    if config.log.use_k8s_api == K8sTrackingConf::Always
+    if config.log.use_k8s_enrichment == K8sTrackingConf::Always
         && PathBuf::from("/var/log/containers/").exists()
     {
         match K8sMetadata::new() {

--- a/common/config/src/env.rs
+++ b/common/config/src/env.rs
@@ -82,9 +82,9 @@ pub struct Config {
     #[example("none")]
     pub lookback: Option<String>,
 
-    #[env(LOGDNA_USE_K8S_API)]
+    #[env(LOGDNA_USE_K8S_LOG_ENRICHMENT)]
     #[example("always")]
-    pub use_k8s_api: Option<String>,
+    pub use_k8s_enrichment: Option<String>,
 
     #[env(LOGDNA_LOG_K8S_EVENTS)]
     #[example("always")]
@@ -224,8 +224,8 @@ impl Config {
             paths.append(&mut v);
         }
 
-        if self.use_k8s_api.is_some() {
-            raw.log.use_k8s_api = self.use_k8s_api;
+        if self.use_k8s_enrichment.is_some() {
+            raw.log.use_k8s_enrichment = self.use_k8s_enrichment;
         }
 
         if self.log_k8s_events.is_some() {

--- a/common/config/src/env.rs
+++ b/common/config/src/env.rs
@@ -82,6 +82,10 @@ pub struct Config {
     #[example("none")]
     pub lookback: Option<String>,
 
+    #[env(LOGDNA_USE_K8S_API)]
+    #[example("always")]
+    pub use_k8s_api: Option<String>,
+
     #[env(LOGDNA_LOG_K8S_EVENTS)]
     #[example("always")]
     pub log_k8s_events: Option<String>,
@@ -218,6 +222,10 @@ impl Config {
         if let Some(mut v) = self.journald_paths {
             let paths = raw.journald.paths.get_or_insert(Vec::new());
             paths.append(&mut v);
+        }
+
+        if self.use_k8s_api.is_some() {
+            raw.log.use_k8s_api = self.use_k8s_api;
         }
 
         if self.log_k8s_events.is_some() {

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -49,7 +49,7 @@ pub struct LogConfig {
     pub db_path: Option<PathBuf>,
     pub rules: Rules,
     pub lookback: Lookback,
-    pub use_k8s_api: K8sTrackingConf,
+    pub use_k8s_enrichment: K8sTrackingConf,
     pub log_k8s_events: K8sTrackingConf,
 }
 
@@ -201,9 +201,9 @@ impl TryFrom<RawConfig> for Config {
                 .lookback
                 .map(|s| s.parse::<Lookback>())
                 .unwrap_or_else(|| Ok(Lookback::default()))?,
-            use_k8s_api: parse_k8s_tracking_or_warn(
-                raw.log.use_k8s_api,
-                "LOGDNA_USE_K8S_API",
+            use_k8s_enrichment: parse_k8s_tracking_or_warn(
+                raw.log.use_k8s_enrichment,
+                "LOGDNA_USE_K8S_LOG_ENRICHMENT",
                 K8sTrackingConf::Always,
             ),
             log_k8s_events: parse_k8s_tracking_or_warn(
@@ -213,7 +213,7 @@ impl TryFrom<RawConfig> for Config {
             ),
         };
 
-        if log.use_k8s_api == K8sTrackingConf::Never
+        if log.use_k8s_enrichment == K8sTrackingConf::Never
             || log.log_k8s_events == K8sTrackingConf::Always
         {
             // It's unlikely that a user will want to disable k8s metadata enrichment
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn test_default_parsed() {
         let config = get_default_config();
-        assert_eq!(config.log.use_k8s_api, K8sTrackingConf::Always);
+        assert_eq!(config.log.use_k8s_enrichment, K8sTrackingConf::Always);
         assert_eq!(config.log.log_k8s_events, K8sTrackingConf::Never);
         assert_eq!(config.log.lookback, Lookback::SmallFiles);
         assert_eq!(

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -53,7 +53,7 @@ pub struct LogConfig {
     pub exclude: Option<Rules>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lookback: Option<String>,
-    pub use_k8s_api: Option<String>,
+    pub use_k8s_enrichment: Option<String>,
     pub log_k8s_events: Option<String>,
 }
 
@@ -125,7 +125,7 @@ impl Default for LogConfig {
                 regex: Vec::new(),
             }),
             lookback: None,
-            use_k8s_api: None,
+            use_k8s_enrichment: None,
             log_k8s_events: None,
         }
     }

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -53,6 +53,7 @@ pub struct LogConfig {
     pub exclude: Option<Rules>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lookback: Option<String>,
+    pub use_k8s_api: Option<String>,
     pub log_k8s_events: Option<String>,
 }
 
@@ -124,6 +125,7 @@ impl Default for LogConfig {
                 regex: Vec::new(),
             }),
             lookback: None,
+            use_k8s_api: None,
             log_k8s_events: None,
         }
     }

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -15,7 +15,7 @@ use futures::{Stream, StreamExt};
 
 use thiserror::Error;
 
-#[derive(Clone, std::fmt::Debug)]
+#[derive(Clone, std::fmt::Debug, PartialEq)]
 pub enum Lookback {
     Start,
     SmallFiles,

--- a/common/k8s/Cargo.toml
+++ b/common/k8s/Cargo.toml
@@ -29,3 +29,6 @@ serde_json = "1.0"
 pin-utils = "0.1"
 pin-project = "1"
 itertools = "0.9"
+
+[dev-dependencies]
+url = "2.2.0"

--- a/common/k8s/Cargo.toml
+++ b/common/k8s/Cargo.toml
@@ -10,6 +10,7 @@ middleware = { package = "middleware", path = "../middleware" }
 http = { package = "http", path = "../http" }
 metrics = { package = "metrics", path = "../metrics" }
 
+backoff = "0.3.0"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-humanize = "0.1"
 crossbeam = "0.7"

--- a/common/k8s/src/lib.rs
+++ b/common/k8s/src/lib.rs
@@ -9,23 +9,23 @@ pub mod middleware;
 pub mod restarting_stream;
 
 #[derive(Clone, std::fmt::Debug, PartialEq)]
-pub enum K8sEventLogConf {
+pub enum K8sTrackingConf {
     Always,
     Never,
 }
 
 #[derive(thiserror::Error, Debug)]
 #[error("{0}")]
-pub struct ParseK8sEventLogConf(String);
+pub struct ParseK8sTrackingConf(String);
 
-impl std::str::FromStr for K8sEventLogConf {
-    type Err = ParseK8sEventLogConf;
+impl std::str::FromStr for K8sTrackingConf {
+    type Err = ParseK8sTrackingConf;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.trim().to_lowercase().as_str() {
-            "always" => Ok(K8sEventLogConf::Always),
-            "never" => Ok(K8sEventLogConf::Never),
-            _ => Err(ParseK8sEventLogConf(format!("failed to parse {}", s))),
+            "always" => Ok(K8sTrackingConf::Always),
+            "never" => Ok(K8sTrackingConf::Never),
+            _ => Err(ParseK8sTrackingConf(format!("failed to parse {}", s))),
         }
     }
 }

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -14,7 +14,6 @@ use backoff::ExponentialBackoff;
 use metrics::Metrics;
 use middleware::{Middleware, Status};
 use parking_lot::Mutex;
-use pin_utils::core_reexport::option::Option::Some;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryFrom;

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -186,7 +186,7 @@ impl Middleware for K8sMetadata {
                         Ok(event) => {
                             backoff.reset();
                             Some(event)
-                        },
+                        }
                         Err(e) => {
                             log::warn!("k8s watch stream error: {}", e);
                             // When polled after a some errors, the watcher will try to recover.
@@ -262,4 +262,79 @@ struct PodMetadata {
     namespace: String,
     labels: KeyValueMap,
     annotations: KeyValueMap,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::types::body::{LineBuilder, LineMeta};
+    use url::Url;
+
+    #[test]
+    fn test_process_with_file_that_can_not_be_parsed() {
+        let k8s_meta = get_instance(HashMap::new());
+        let mut line = LineBuilder::new().line("abc").file("abc.log");
+        let result = k8s_meta.process(&mut line);
+        assert!(matches!(&result, Status::Ok(_)));
+        if let Status::Ok(l) = result {
+            assert!(l.get_annotations().is_none());
+            assert!(l.get_labels().is_none());
+        }
+    }
+
+    #[test]
+    fn test_process_with_different_files() {
+        let matching_file1 = "/var/log/containers/first_file_sample-f39155eb652f5161f4a34b1fbd89a4d361e76ccb6c3cdc0e2c18e0d0abb26516.log";
+        let matching_file2 = "/var/log/containers/second_file_sample-f39155eb652f5161f4a34b1fbd89a4d361e76ccb6c3cdc0e2c18e0d0abb26516.log";
+        let mut map = HashMap::new();
+        map.insert(("first".into(), "file".into()), get_pod_metadata());
+        let k8s_meta = get_instance(map);
+        let mut lines = vec![
+            LineBuilder::new().line("line 0").file(matching_file1),
+            // 1: File not matching
+            LineBuilder::new()
+                .line("line 1")
+                .file("/tmp/not_matching_file.log"),
+            LineBuilder::new().line("line 2").file(matching_file1),
+            // 3: The file matches but there's no metadata for it
+            LineBuilder::new().line("line 3").file(matching_file2),
+            // 4..6 Repeat multiple times w/ file matches with metadata
+            LineBuilder::new().line("line 4").file(matching_file1),
+            LineBuilder::new().line("line 5").file(matching_file1),
+        ];
+
+        for (i, line) in lines.iter_mut().enumerate() {
+            let result = k8s_meta.process(line);
+            if let Status::Ok(_) = result {
+                assert_eq!(line.line, Some(format!("line {}", i)));
+                if i == 1 || i == 3 {
+                    assert!(line.get_annotations().is_none());
+                    assert!(line.get_labels().is_none());
+                } else {
+                    assert!(line.get_annotations().is_some());
+                    assert!(line.get_labels().is_some());
+                }
+            } else {
+                panic!("Unexpected status");
+            }
+        }
+    }
+
+    fn get_instance(map: HashMap<(String, String), PodMetadata>) -> K8sMetadata {
+        let config = Config::new(Url::parse("https://sample.url/").unwrap());
+        K8sMetadata {
+            metadata: Mutex::new(map),
+            api: Api::<Pod>::all(Client::new(config)),
+            runtime: Mutex::new(None),
+        }
+    }
+
+    fn get_pod_metadata() -> PodMetadata {
+        PodMetadata {
+            name: "sample name".to_string(),
+            namespace: "sample ns".to_string(),
+            labels: Default::default(),
+            annotations: Default::default(),
+        }
+    }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,8 +139,8 @@ The agent accepts configuration from two sources, environment variables and a co
 |`LOGDNA_INCLUSION_REGEX_RULES`<br>**Deprecated**: `LOGDNA_INCLUDE_REGEX`|Comma separated list of regex patterns to exclude files from monitoring||
 |`LOGDNA_JOURNALD_PATHS`|Comma separated list of paths (directories or files) of journald paths to monitor||
 |`LOGDNA_LOOKBACK`|The lookback strategy on startup|`smallfiles`|
-|`LOGDNA_USE_K8S_API`|Determines whether the agent should query the K8s API to enrich log lines from other pods.|`always`|
-|`LOGDNA_LOG_K8S_EVENTS`|Whether the agent should log Kubernetes resource events. This setting only affects tracking and logging Kubernetes resource changes via watches. When disabled, the agent may still query k8s metadata to enrich log lines from other pods depending on the value of `LOGDNA_USE_K8S_API` setting value.|`never`|
+|`LOGDNA_USE_K8S_LOG_ENRICHMENT`|Determines whether the agent should query the K8s API to enrich log lines from other pods.|`always`|
+|`LOGDNA_LOG_K8S_EVENTS`|Whether the agent should log Kubernetes resource events. This setting only affects tracking and logging Kubernetes resource changes via watches. When disabled, the agent may still query k8s metadata to enrich log lines from other pods depending on the value of `LOGDNA_USE_K8S_LOG_ENRICHMENT` setting value.|`never`|
 |`LOGDNA_DB_PATH`|The directory the agent will store it's state database. Note that the agent must have write access to the directory and be a persistent volume.||
 
 1. We support [this flavor of globber syntax](https://github.com/CJP10/globber).

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,7 +139,8 @@ The agent accepts configuration from two sources, environment variables and a co
 |`LOGDNA_INCLUSION_REGEX_RULES`<br>**Deprecated**: `LOGDNA_INCLUDE_REGEX`|Comma separated list of regex patterns to exclude files from monitoring||
 |`LOGDNA_JOURNALD_PATHS`|Comma separated list of paths (directories or files) of journald paths to monitor||
 |`LOGDNA_LOOKBACK`|The lookback strategy on startup|`smallfiles`|
-|`LOGDNA_LOG_K8S_EVENTS`|Whether the agent should capture Kubernetes events|`always`|
+|`LOGDNA_USE_K8S_API`|Determines whether the agent should query the K8s API to enrich log lines from other pods.|`always`|
+|`LOGDNA_LOG_K8S_EVENTS`|Whether the agent should log Kubernetes resource events. This setting only affects tracking and logging Kubernetes resource changes via watches. When disabled, the agent may still query k8s metadata to enrich log lines from other pods depending on the value of `LOGDNA_USE_K8S_API` setting value.|`never`|
 |`LOGDNA_DB_PATH`|The directory the agent will store it's state database. Note that the agent must have write access to the directory and be a persistent volume.||
 
 1. We support [this flavor of globber syntax](https://github.com/CJP10/globber).


### PR DESCRIPTION
Adds backoff when handling with upstream k8s errors and supports disabling the use of k8s api altogether.

It also increases test coverage of k8s logic internals and config.

Ref: LOG-8885, LOG-8887 and LOG-8888.

This patch is out of scope of 3.1, so we have can merge it once 3.1 was released or start with 3.2 branch.