### PR TITLE
feat: Split out TailedFile and flatten log line stream

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -118,7 +118,7 @@ fn main() {
 
         let mut k8s_event_source: Option<std::pin::Pin<&mut _>> = k8s_event_source.as_pin_mut();
 
-        let mut sources: futures::stream::SelectAll<&mut (dyn Stream<Item = Vec<_>> + Unpin)> =
+        let mut sources: futures::stream::SelectAll<&mut (dyn Stream<Item = _> + Unpin)> =
             futures::stream::SelectAll::new();
 
         info!("Enabling filesystem");
@@ -131,11 +131,9 @@ fn main() {
         };
 
         sources
-            .for_each(|lines| async {
-                if let Some(lines) = executor.process(lines) {
-                    for line in lines {
-                        client.borrow_mut().send(line).await
-                    }
+            .for_each(|line| async {
+                if let Some(line) = executor.process(line) {
+                    client.borrow_mut().send(line).await
                 }
             })
             .await

--- a/common/fs/src/cache/entry.rs
+++ b/common/fs/src/cache/entry.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsString;
-use std::fs::File;
 use std::path::PathBuf;
 
 use inotify::WatchDescriptor;
@@ -14,7 +13,6 @@ pub enum Entry<T> {
         parent: EntryKey,
         wd: WatchDescriptor,
         data: T,
-        file_handle: File,
     },
     Dir {
         name: OsString,
@@ -86,13 +84,6 @@ impl<T> Entry<T> {
     pub fn watch_descriptor(&self) -> &WatchDescriptor {
         match self {
             Entry::Dir { wd, .. } | Entry::Symlink { wd, .. } | Entry::File { wd, .. } => wd,
-        }
-    }
-
-    pub fn file_handle(&self) -> Option<&File> {
-        match self {
-            Entry::Dir { .. } | Entry::Symlink { .. } => None,
-            Entry::File { file_handle, .. } => Some(file_handle),
         }
     }
 }

--- a/common/fs/src/cache/entry.rs
+++ b/common/fs/src/cache/entry.rs
@@ -3,16 +3,17 @@ use std::path::PathBuf;
 
 use inotify::WatchDescriptor;
 
+use crate::cache::TailedFile;
 use crate::cache::{Children, EntryKey};
 use crate::rule::Rules;
 
 #[derive(Debug)]
-pub enum Entry<T> {
+pub enum Entry {
     File {
         name: OsString,
         parent: EntryKey,
         wd: WatchDescriptor,
-        data: T,
+        data: TailedFile,
     },
     Dir {
         name: OsString,
@@ -29,7 +30,7 @@ pub enum Entry<T> {
     },
 }
 
-impl<T> Entry<T> {
+impl Entry {
     pub fn name(&self) -> &OsString {
         match self {
             Entry::File { name, .. } | Entry::Dir { name, .. } | Entry::Symlink { name, .. } => {

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -1,11 +1,12 @@
 use crate::cache::entry::Entry;
 use crate::cache::event::Event;
+use crate::cache::tailed_file::TailedFile;
 use crate::cache::watch::{WatchEvent, Watcher};
 use crate::rule::{GlobRule, Rules, Status};
 
 use std::cell::RefCell;
 use std::ffi::{OsStr, OsString};
-use std::fs::{read_dir, OpenOptions};
+use std::fs::read_dir;
 use std::iter::FromIterator;
 use std::ops::Deref;
 use std::path::{Component, PathBuf};
@@ -24,6 +25,7 @@ use thiserror::Error;
 pub mod dir_path;
 pub mod entry;
 pub mod event;
+pub mod tailed_file;
 pub use dir_path::{DirPathBuf, DirPathBufError};
 
 mod watch;
@@ -34,7 +36,7 @@ type WatchDescriptors = HashMap<WatchDescriptor, Vec<EntryKey>>;
 
 pub type EntryKey = DefaultKey;
 
-type EntryMap<T> = SlotMap<EntryKey, RefCell<entry::Entry<T>>>;
+type EntryMap<TailedFile> = SlotMap<EntryKey, RefCell<entry::Entry<TailedFile>>>;
 type FsResult<T> = Result<T, Error>;
 
 #[derive(Debug, Error)]
@@ -59,12 +61,9 @@ pub enum Error {
     InsertRecursively(Vec<Error>),
 }
 
-pub struct FileSystem<T>
-where
-    T: Clone + std::fmt::Debug,
-{
+pub struct FileSystem {
     watcher: Watcher,
-    pub entries: Rc<RefCell<EntryMap<T>>>,
+    pub entries: Rc<RefCell<EntryMap<TailedFile>>>,
     root: EntryKey,
 
     symlinks: Symlinks,
@@ -77,10 +76,7 @@ where
     initial_events: Vec<Event>,
 }
 
-impl<'a, T: 'a + Default> FileSystem<T>
-where
-    T: Clone + std::fmt::Debug,
-{
+impl FileSystem {
     pub fn new(initial_dirs: Vec<DirPathBuf>, rules: Rules) -> Self {
         initial_dirs.iter().for_each(|path| {
             if !path.is_dir() {
@@ -164,9 +160,9 @@ where
     }
 
     pub fn stream_events(
-        fs: Arc<Mutex<FileSystem<T>>>,
-        buf: &'a mut [u8],
-    ) -> Result<impl Stream<Item = Event> + 'a, std::io::Error> {
+        fs: Arc<Mutex<FileSystem>>,
+        buf: &mut [u8],
+    ) -> Result<impl Stream<Item = Event> + '_, std::io::Error> {
         let events_stream = {
             match fs
                 .try_lock()
@@ -280,7 +276,7 @@ where
         watch_descriptor: &WatchDescriptor,
         name: OsString,
         events: &mut Vec<Event>,
-        _entries: &mut EntryMap<T>,
+        _entries: &mut EntryMap<TailedFile>,
     ) -> FsResult<()> {
         // directories can't be a hard link so we're guaranteed the watch descriptor maps to one
         // entry
@@ -332,7 +328,7 @@ where
         watch_descriptor: &WatchDescriptor,
         name: OsString,
         events: &mut Vec<Event>,
-        _entries: &mut EntryMap<T>,
+        _entries: &mut EntryMap<TailedFile>,
     ) -> FsResult<()> {
         // directories can't be a hard link so we're guaranteed the watch descriptor maps to one
         // entry
@@ -354,7 +350,7 @@ where
         to_watch_descriptor: &WatchDescriptor,
         to_name: OsString,
         events: &mut Vec<Event>,
-        _entries: &mut EntryMap<T>,
+        _entries: &mut EntryMap<TailedFile>,
     ) -> FsResult<()> {
         let from_entry_key = self.get_first_entry(from_watch_descriptor)?;
         let to_entry_key = self.get_first_entry(to_watch_descriptor)?;
@@ -372,7 +368,11 @@ where
             .map(|_| ())
     }
 
-    pub fn resolve_direct_path(&self, entry: &Entry<T>, _entries: &EntryMap<T>) -> PathBuf {
+    pub fn resolve_direct_path(
+        &self,
+        entry: &Entry<TailedFile>,
+        _entries: &EntryMap<TailedFile>,
+    ) -> PathBuf {
         let mut components = Vec::new();
 
         let mut name = entry.name().clone();
@@ -398,7 +398,11 @@ where
         components.into_iter().collect()
     }
 
-    pub fn resolve_valid_paths(&self, entry: &Entry<T>, _entries: &EntryMap<T>) -> Vec<PathBuf> {
+    pub fn resolve_valid_paths(
+        &self,
+        entry: &Entry<TailedFile>,
+        _entries: &EntryMap<TailedFile>,
+    ) -> Vec<PathBuf> {
         let mut paths = Vec::new();
         self.resolve_valid_paths_helper(entry, &mut paths, Vec::new(), _entries);
         paths
@@ -406,10 +410,10 @@ where
 
     fn resolve_valid_paths_helper(
         &self,
-        entry: &Entry<T>,
+        entry: &Entry<TailedFile>,
         paths: &mut Vec<PathBuf>,
         mut components: Vec<OsString>,
-        _entries: &EntryMap<T>,
+        _entries: &EntryMap<TailedFile>,
     ) {
         let mut base_components: Vec<OsString> =
             into_components(&self.resolve_direct_path(entry, _entries));
@@ -456,7 +460,7 @@ where
         &mut self,
         path: &PathBuf,
         events: &mut Vec<Event>,
-        _entries: &mut EntryMap<T>,
+        _entries: &mut EntryMap<TailedFile>,
     ) -> FsResult<Option<EntryKey>> {
         if !self.passes(path, _entries) {
             info!("ignoring {:?}", path);
@@ -517,8 +521,7 @@ where
                     name: component,
                     parent: parent_ref,
                     wd,
-                    data: T::default(),
-                    file_handle: OpenOptions::new().read(true).open(path).unwrap(),
+                    data: TailedFile::new(path).unwrap(),
                 };
 
                 let new_key = self.register_as_child(parent_ref, new_entry, _entries)?;
@@ -558,7 +561,11 @@ where
         }
     }
 
-    fn register(&mut self, entry_ptr: EntryKey, _entries: &mut EntryMap<T>) -> FsResult<()> {
+    fn register(
+        &mut self,
+        entry_ptr: EntryKey,
+        _entries: &mut EntryMap<TailedFile>,
+    ) -> FsResult<()> {
         let entry = _entries.get(entry_ptr).ok_or(Error::Lookup)?;
         let path = self.resolve_direct_path(&entry.borrow(), _entries);
 
@@ -578,7 +585,7 @@ where
         Ok(())
     }
 
-    fn unregister(&mut self, entry_ptr: EntryKey, _entries: &mut EntryMap<T>) {
+    fn unregister(&mut self, entry_ptr: EntryKey, _entries: &mut EntryMap<TailedFile>) {
         if let Some(entry) = _entries.get(entry_ptr) {
             let path = self.resolve_direct_path(&entry.borrow(), _entries);
 
@@ -628,7 +635,7 @@ where
         &mut self,
         path: &PathBuf,
         events: &mut Vec<Event>,
-        _entries: &mut EntryMap<T>,
+        _entries: &mut EntryMap<TailedFile>,
     ) -> FsResult<()> {
         let path_buf = path.parent().ok_or(Error::PathNotValid)?.into();
         let parent = self
@@ -655,7 +662,7 @@ where
         &mut self,
         entry_key: EntryKey,
         events: &mut Vec<Event>,
-        _entries: &mut EntryMap<T>,
+        _entries: &mut EntryMap<TailedFile>,
     ) {
         self.unregister(entry_key, _entries);
         if let Some(entry) = _entries.get(entry_key) {
@@ -701,7 +708,7 @@ where
         from: &PathBuf,
         to: &PathBuf,
         events: &mut Vec<Event>,
-        _entries: &mut EntryMap<T>,
+        _entries: &mut EntryMap<TailedFile>,
     ) -> FsResult<Option<EntryKey>> {
         let parent_path = to.parent().ok_or(Error::ParentNotValid)?;
         let new_parent = self.create_dir(&parent_path.into(), _entries)?;
@@ -741,7 +748,11 @@ where
     // Creates all entries for a directory.
     // If one of the entries already exists, it is skipped over.
     // The returns a linked list of all entries.
-    fn create_dir(&mut self, path: &PathBuf, _entries: &mut EntryMap<T>) -> FsResult<EntryKey> {
+    fn create_dir(
+        &mut self,
+        path: &PathBuf,
+        _entries: &mut EntryMap<TailedFile>,
+    ) -> FsResult<EntryKey> {
         let mut m_entry = self.root;
 
         let components = into_components(path);
@@ -831,8 +842,8 @@ where
     fn register_as_child(
         &mut self,
         parent_key: EntryKey,
-        new_entry: Entry<T>,
-        entries: &mut EntryMap<T>,
+        new_entry: Entry<TailedFile>,
+        entries: &mut EntryMap<TailedFile>,
     ) -> FsResult<EntryKey> {
         let component = new_entry.name().clone();
         let new_key = entries.insert(RefCell::new(new_entry));
@@ -853,7 +864,7 @@ where
 
     /// Returns the entry that represents the supplied path.
     /// When the path is not represented and therefore has no entry then `None` is return.
-    pub fn lookup(&self, path: &PathBuf, _entries: &EntryMap<T>) -> Option<EntryKey> {
+    pub fn lookup(&self, path: &PathBuf, _entries: &EntryMap<TailedFile>) -> Option<EntryKey> {
         let mut parent = self.root;
         let mut components = into_components(path);
         // remove the first component because it will always be the root
@@ -888,7 +899,7 @@ where
             .copied()
     }
 
-    fn follow_links(&self, entry: EntryKey, _entries: &EntryMap<T>) -> Option<EntryKey> {
+    fn follow_links(&self, entry: EntryKey, _entries: &EntryMap<TailedFile>) -> Option<EntryKey> {
         let mut result = entry;
         while let Some(e) = _entries.get(result) {
             if let Some(link) = e.borrow().link() {
@@ -900,7 +911,7 @@ where
         Some(result)
     }
 
-    fn is_symlink_target(&self, path: &PathBuf, _entries: &EntryMap<T>) -> bool {
+    fn is_symlink_target(&self, path: &PathBuf, _entries: &EntryMap<TailedFile>) -> bool {
         for (_, symlink_ptrs) in self.symlinks.iter() {
             for symlink_ptr in symlink_ptrs.iter() {
                 if let Some(symlink) = _entries.get(*symlink_ptr) {
@@ -947,11 +958,16 @@ where
     }
 
     /// Helper method for checking if a path passes exclusion/inclusion rules
-    fn passes(&self, path: &PathBuf, _entries: &EntryMap<T>) -> bool {
+    fn passes(&self, path: &PathBuf, _entries: &EntryMap<TailedFile>) -> bool {
         self.is_initial_dir_target(path) || self.is_symlink_target(path, _entries)
     }
 
-    fn entry_path_passes(&self, entry: EntryKey, name: &OsStr, _entries: &EntryMap<T>) -> bool {
+    fn entry_path_passes(
+        &self,
+        entry: EntryKey,
+        name: &OsStr,
+        _entries: &EntryMap<TailedFile>,
+    ) -> bool {
         if let Some(entry_ref) = _entries.get(entry) {
             let mut path = self.resolve_direct_path(&entry_ref.borrow(), &_entries);
             path.push(name);
@@ -977,7 +993,7 @@ where
 }
 
 // conditionally implement std::fmt::Debug if the underlying type T implements it
-impl<T: fmt::Debug + Clone> fmt::Debug for FileSystem<T> {
+impl fmt::Debug for FileSystem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("FileSystem");
         builder.field("root", &&self.root);
@@ -1103,7 +1119,7 @@ mod tests {
     fn new_fs<T: Default + Clone + std::fmt::Debug>(
         path: PathBuf,
         rules: Option<Rules>,
-    ) -> FileSystem<T> {
+    ) -> FileSystem {
         let rules = rules.unwrap_or_else(|| {
             let mut rules = Rules::new();
             rules.add_inclusion(GlobRule::new(r"**").unwrap());

--- a/common/fs/src/cache/tailed_file.rs
+++ b/common/fs/src/cache/tailed_file.rs
@@ -1,0 +1,109 @@
+use http::types::body::LineBuilder;
+use metrics::Metrics;
+
+use futures::Stream;
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct TailedFile {
+    reader: std::io::BufReader<File>,
+    offset: u64,
+}
+
+impl TailedFile {
+    pub(crate) fn new(path: &Path) -> Result<Self, std::io::Error> {
+        Ok(Self {
+            reader: BufReader::new(OpenOptions::new().read(true).open(path)?),
+            offset: 0,
+        })
+    }
+
+    pub(crate) fn seek(&mut self, offset: u64) -> Result<(), std::io::Error> {
+        if let Err(e) = self.reader.seek(SeekFrom::Start(offset)) {
+            error!("error seeking {:?}", e);
+            return Err(e);
+        }
+        self.offset = offset;
+        Ok(())
+    }
+    // tail a file for new line(s)
+    pub(crate) fn tail(&mut self, paths: &[PathBuf]) -> Option<impl Stream<Item = LineBuilder>> {
+        // get the file len
+        let len = match self.reader.get_ref().metadata().map(|m| m.len()) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("unable to stat {:?}: {:?}", &paths[0], e);
+                return None;
+            }
+        };
+
+        // if we are at the end of the file there's no work to do
+        if self.offset == len {
+            return None;
+        }
+
+        // if the offset is greater than the file's len
+        // it's very likely a truncation occurred
+        if self.offset > len {
+            info!(
+                "{:?} was truncated from {} to {}",
+                &paths[0], self.offset, len
+            );
+            // Reset offset back to the start... ish?
+            // TODO: Work out the purpose of the 8192 something to do with lookback? That seems wrong.
+            self.offset = if len < 8192 { 0 } else { len };
+            // seek to the offset, this creates the "tailing" effect
+            if let Err(e) = self.reader.get_mut().seek(SeekFrom::Start(self.offset)) {
+                error!("error seeking {:?}", e);
+                return None;
+            }
+        }
+
+        let mut line_groups = Vec::new();
+
+        loop {
+            let mut raw_line = Vec::new();
+            // read until a new line returning the line length
+            let line_len = match self.reader.read_until(b'\n', &mut raw_line) {
+                Ok(v) => v as u64,
+                Err(e) => {
+                    error!("error reading from file {:?}: {:?}", &paths[0], e);
+                    break;
+                }
+            };
+            // try to parse the raw data as utf8
+            // if that fails replace invalid chars with blank chars
+            // see String::from_utf8_lossy docs
+            let mut line = String::from_utf8(raw_line)
+                .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).to_string());
+            // if the line doesn't end with a new line we might have read in the middle of a write
+            // so we return in this case
+            if !line.ends_with('\n') {
+                Metrics::fs().increment_partial_reads();
+                break;
+            }
+            // remove the trailing new line
+            line.pop();
+            // increment the offset
+            self.offset += line_len;
+            // send the line upstream, safe to unwrap
+            debug!("tailer sendings lines for {:?}", paths);
+            line_groups.extend(paths.iter().map(|path| {
+                Metrics::fs().increment_lines();
+                Metrics::fs().add_bytes(line_len);
+                LineBuilder::new()
+                    .line(line.clone())
+                    .file(path.to_str().unwrap_or("").to_string())
+            }));
+        }
+
+        if line_groups.is_empty() {
+            None
+        } else {
+            Some(futures::stream::iter(line_groups))
+        }
+    }
+}

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -131,7 +131,6 @@ impl Tailer {
                                 } = entry.borrow_mut().deref_mut()
                                 {
                                     info!("added {:?}", paths[0]);
-                                    data.seek(0).unwrap_or_else(|e| error!("error seeking {:?}", e));
                                     data.tail(&paths)
                                 }
                                 else {

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -5,10 +5,7 @@ use crate::cache::FileSystem;
 use crate::rule::Rules;
 use http::types::body::LineBuilder;
 use metrics::Metrics;
-use std::fs::File;
-use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::ops::{Deref, DerefMut};
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use futures::{Stream, StreamExt};
@@ -55,7 +52,7 @@ impl Default for Lookback {
 /// Tails files on a filesystem by inheriting events from a Watcher
 pub struct Tailer {
     lookback_config: Lookback,
-    fs_cache: Arc<Mutex<FileSystem<u64>>>,
+    fs_cache: Arc<Mutex<FileSystem>>,
 }
 
 impl Tailer {
@@ -70,7 +67,7 @@ impl Tailer {
     pub fn process<'a>(
         &mut self,
         buf: &'a mut [u8],
-    ) -> Result<impl Stream<Item = Vec<LineBuilder>> + 'a, std::io::Error> {
+    ) -> Result<impl Stream<Item = LineBuilder> + 'a, std::io::Error> {
         let events = {
             match FileSystem::stream_events(self.fs_cache.clone(), buf) {
                 Ok(event) => event,
@@ -85,8 +82,6 @@ impl Tailer {
             let fs = self.fs_cache.clone();
             let lookback_config = self.lookback_config.clone();
             move |event| {
-                let mut final_lines = Vec::new();
-
                 let fs = fs.lock().expect("Couldn't lock fs");
                 match event {
                     Event::Initialize(entry_ptr) => {
@@ -96,10 +91,10 @@ impl Tailer {
                             debug!("Initialise Event");
 
                             if let Entry::File { ref mut data, .. } = entry.borrow_mut().deref_mut() {
-                                *data = match lookback_config {
+                                match lookback_config {
                                     Lookback::Start => {
                                         info!("initialized {:?} with offset {}", path, 0);
-                                        0
+                                        data.seek(0).unwrap_or_else(|e| error!("error seeking {:?}", e))
                                     },
                                     Lookback::SmallFiles => {
                                         let mut len = path.metadata().map(|m| m.len()).unwrap_or(0);
@@ -109,16 +104,19 @@ impl Tailer {
                                         } else{
                                             info!("initialized {:?} with offset {}", path, len);
                                         }
-                                        len
+
+                                        data.seek(len).unwrap_or_else(|e| error!("error seeking {:?}", e))
                                     },
                                     Lookback::None => {
                                         let len = path.metadata().map(|m| m.len()).unwrap_or(0);
                                         info!("initialized {:?} with offset {}", path, len);
-                                        len
+
+                                        data.seek(len).unwrap_or_else(|e| error!("error seeking {:?}", e))
                                     }
                                 }
                             }
                         };
+                        None
                     }
                     Event::New(entry_ptr) => {
                         Metrics::fs().increment_creates();
@@ -129,19 +127,23 @@ impl Tailer {
                             if !paths.is_empty() {
                                 if let Entry::File {
                                     ref mut data,
-                                    file_handle,
                                     ..
                                 } = entry.borrow_mut().deref_mut()
                                 {
                                     info!("added {:?}", paths[0]);
-                                    *data = 0;
-                                    if let Some(mut lines) = Tailer::tail(file_handle, &paths, data) {
-                                        final_lines.append(&mut lines);
-                                    }
+                                    data.seek(0).unwrap_or_else(|e| error!("error seeking {:?}", e));
+                                    data.tail(&paths)
                                 }
-                            }
-                        }
+                                else {
+                                    None
+                                }
 
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
 
                     }
                     Event::Write(entry_ptr) => {
@@ -153,21 +155,25 @@ impl Tailer {
 
                                 if let  Entry::File {
                                     ref mut data,
-                                    file_handle,
                                     ..
                                 } = entry.borrow_mut().deref_mut()
                                 {
-                                    if let Some(mut lines) = Tailer::tail(file_handle, &paths, data) {
-                                        final_lines.append(&mut lines);
-                                    }
+                                    data.tail(&paths)
+                                } else {
+                                    None
                                 }
 
+                            } else {
+                                None
                             }
+                        } else {
+                            None
                         }
+
                     }
                     Event::Delete(entry_ptr) => {
                         Metrics::fs().increment_deletes();
-                        {
+                        let ret = {
                             let entries = fs.entries.borrow();
                             if let Some(mut entry) = entries.get(entry_ptr){
                                 let paths = fs.resolve_valid_paths(&entry.borrow(), &entries);
@@ -185,17 +191,22 @@ impl Tailer {
 
                                     if let Entry::File {
                                         ref mut data,
-                                        file_handle,
                                         ..
                                     } = entry.borrow_mut().deref_mut()
                                     {
-                                        if let Some(mut lines) = Tailer::tail(file_handle, &paths, data) {
-                                            final_lines.append(&mut lines);
-                                        }
+                                        data.tail(&paths)
+                                    } else {
+                                        None
                                     }
+                                }else {
+                                    None
                                 }
+
+                            }else {
+                                None
                             }
-                        }
+
+                        };
                         {
                             // At this point, the entry should not longer be used
                             // and removed from the map to allow the file handle to be dropped.
@@ -209,94 +220,10 @@ impl Tailer {
                                     entries.len());
                             }
                         }
+                        ret
                     }
-                };
-                futures::stream::iter(final_lines)
-            }}).flatten())
-    }
-
-    // tail a file for new line(s)
-    fn tail(
-        file_handle: &File,
-        paths: &[PathBuf],
-        offset: &mut u64,
-    ) -> Option<Vec<Vec<LineBuilder>>> {
-        // get the file len
-        let len = match file_handle.metadata().map(|m| m.len()) {
-            Ok(v) => v,
-            Err(e) => {
-                error!("unable to stat {:?}: {:?}", &paths[0], e);
-                return None;
-            }
-        };
-
-        // if we are at the end of the file there's no work to do
-        if *offset == len {
-            return None;
-        }
-        // open the file, create a reader
-        let mut reader = BufReader::new(file_handle);
-        // if the offset is greater than the file's len
-        // it's very likely a truncation occurred
-        if *offset > len {
-            info!("{:?} was truncated from {} to {}", &paths[0], *offset, len);
-            *offset = if len < 8192 { 0 } else { len };
-            return None;
-        }
-        // seek to the offset, this creates the "tailing" effect
-        if let Err(e) = reader.seek(SeekFrom::Start(*offset)) {
-            error!("error seeking {:?}", e);
-            return None;
-        }
-
-        let mut line_groups = Vec::new();
-
-        loop {
-            let mut raw_line = Vec::new();
-            // read until a new line returning the line length
-            let line_len = match reader.read_until(b'\n', &mut raw_line) {
-                Ok(v) => v as u64,
-                Err(e) => {
-                    error!("error reading from file {:?}: {:?}", &paths[0], e);
-                    break;
                 }
-            };
-            // try to parse the raw data as utf8
-            // if that fails replace invalid chars with blank chars
-            // see String::from_utf8_lossy docs
-            let mut line = String::from_utf8(raw_line)
-                .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).to_string());
-            // if the line doesn't end with a new line we might have read in the middle of a write
-            // so we return in this case
-            if !line.ends_with('\n') {
-                Metrics::fs().increment_partial_reads();
-                break;
-            }
-            // remove the trailing new line
-            line.pop();
-            // increment the offset
-            *offset += line_len;
-            // send the line upstream, safe to unwrap
-            debug!("tailer sendings lines for {:?}", paths);
-            line_groups.push(
-                paths
-                    .iter()
-                    .map(|path| {
-                        Metrics::fs().increment_lines();
-                        Metrics::fs().add_bytes(line_len);
-                        LineBuilder::new()
-                            .line(line.clone())
-                            .file(path.to_str().unwrap_or("").to_string())
-                    })
-                    .collect(),
-            );
-        }
-
-        if line_groups.is_empty() {
-            None
-        } else {
-            Some(line_groups)
-        }
+            }}).filter_map(|x|async move {x}).flatten())
     }
 }
 
@@ -306,6 +233,7 @@ mod test {
     use crate::rule::{GlobRule, Rules};
     use crate::test::LOGGER;
     use std::convert::TryInto;
+    use std::fs::File;
     use std::io::Write;
     use std::panic;
     use tempfile::tempdir;

--- a/common/journald/src/source.rs
+++ b/common/journald/src/source.rs
@@ -4,7 +4,7 @@ use http::types::body::LineBuilder;
 use log::{info, warn};
 use std::path::PathBuf;
 
-pub fn create_source(paths: &[PathBuf]) -> impl FutureStream<Item = Vec<LineBuilder>> {
+pub fn create_source(paths: &[PathBuf]) -> impl FutureStream<Item = LineBuilder> {
     let mut journal_files: Vec<PathBuf> = Vec::new();
     let mut journal_directories: Vec<PathBuf> = Vec::new();
     for path in paths {

--- a/common/k8s/src/event_source.rs
+++ b/common/k8s/src/event_source.rs
@@ -261,7 +261,7 @@ impl K8sEventStream {
         Self::new(config, pod_name, namespace)
     }
 
-    pub async fn event_stream(self) -> Result<impl Stream<Item = Vec<LineBuilder>> + Send, String> {
+    pub async fn event_stream(self) -> Result<impl Stream<Item = LineBuilder> + Send, String> {
         let client = std::sync::Arc::new(self.client.clone());
 
         let latest_event_time: Arc<AtomicCell<Option<NonZeroI64>>> =
@@ -431,7 +431,7 @@ impl K8sEventStream {
 
                                 let ret = LineBuilder::try_from(EventLog::from(e)).map(|l| {
                                     Metrics::k8s().increment_lines();
-                                    vec![l]
+                                    l
                                 });
                                 if ret.is_ok() {
                                     latest_event_time.store(this_event_time)

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -180,18 +180,16 @@ impl Middleware for K8sMetadata {
         });
     }
 
-    fn process(&self, mut lines: Vec<LineBuilder>) -> Status {
-        for line in lines.iter_mut() {
-            if let Some(ref file_name) = line.file {
-                if let Some(key) = parse_container_path(&file_name) {
-                    if let Some(pod_meta_data) = self.metadata.lock().get(&key) {
-                        line.annotations = pod_meta_data.annotations.clone().into();
-                        line.labels = pod_meta_data.labels.clone().into();
-                    }
+    fn process(&self, mut line: LineBuilder) -> Status {
+        if let Some(ref file_name) = line.file {
+            if let Some(key) = parse_container_path(&file_name) {
+                if let Some(pod_meta_data) = self.metadata.lock().get(&key) {
+                    line.annotations = pod_meta_data.annotations.clone().into();
+                    line.labels = pod_meta_data.labels.clone().into();
                 }
             }
         }
-        Status::Ok(lines)
+        Status::Ok(line)
     }
 }
 


### PR DESCRIPTION
This is the first step toward stateful lookback.

It changes the tailer into a true multiplexed stream of lines from the various files the agent is tracking