### PR TITLE
Tags integration test: verify each line contents

### DIFF
--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -769,6 +769,7 @@ async fn test_tags() {
         let map = received.lock().await;
         let file_info = map.get(file_path.to_str().unwrap()).unwrap();
         assert_eq!(file_info.lines, 10);
+        assert_eq!(file_info.values, vec![common::LINE.to_owned() + "\n"; 10]);
         assert_eq!(file_info.tags, Some(tag.to_string()));
         shutdown_handle();
     });

--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -20,7 +20,7 @@ use logdna_mock_ingester::{http_ingester, https_ingester, FileLineCounter, Hyper
 use rcgen::generate_simple_self_signed;
 use rustls::internal::pemfile;
 
-static LINE: &str = "Nov 30 09:14:47 sample-host-name sampleprocess[1204]: Hello from process";
+pub static LINE: &str = "Nov 30 09:14:47 sample-host-name sampleprocess[1204]: Hello from process";
 
 pub struct FileContext {
     pub file_path: PathBuf,


### PR DESCRIPTION
Verifies the content of each line on `test_tags()`.