### PR TITLE
Increment lines on lazy line codepath

### DIFF
--- a/common/fs/src/cache/tailed_file.rs
+++ b/common/fs/src/cache/tailed_file.rs
@@ -449,7 +449,9 @@ impl Stream for LazyLines {
                     // Got a line
                     debug_assert_eq!(*read, 0);
                     debug!("tailer sendings lines for {:?}", &paths);
-                    *offset += TryInto::<u64>::try_into(count.get()).unwrap();
+                    let count = TryInto::<u64>::try_into(count.get()).unwrap();
+                    Metrics::fs().add_bytes(count);
+                    *offset += count;
                     *current_offset = Some((
                         bytes::Bytes::copy_from_slice(file_path.as_os_str().as_bytes()),
                         *offset,

--- a/common/fs/src/cache/tailed_file.rs
+++ b/common/fs/src/cache/tailed_file.rs
@@ -423,6 +423,7 @@ impl Stream for LazyLines {
                     current_offset.clone().unwrap(),
                 );
                 *path += 1;
+                Metrics::fs().increment_lines();
                 break Poll::Ready(Some(ret));
             }
             // Get the next line


### PR DESCRIPTION
The new lazy lines tailer wasn't incrementing the lines metric.