### PR TITLE
Test killing the agent with stateful lookback

### DIFF
--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -220,7 +220,7 @@ where
     let mut lines_buffer = String::new();
     for _safeguard in 0..100_000 {
         reader.read_line(&mut line).unwrap();
-        debug!("{}", line.trim());
+        eprintln!("--line {}", line.trim());
         lines_buffer.push_str(&line);
         lines_buffer.push('\n');
         if condition(&line) {

--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -106,7 +106,7 @@ pub fn truncate_file(file_path: &PathBuf) -> Result<(), std::io::Error> {
     Ok(())
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct AgentSettings<'a> {
     pub log_dirs: &'a str,
     pub exclusion_regex: Option<&'a str>,

--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -220,7 +220,7 @@ where
     let mut lines_buffer = String::new();
     for _safeguard in 0..100_000 {
         reader.read_line(&mut line).unwrap();
-        eprintln!("--line {}", line.trim());
+        debug!("{}", line.trim());
         lines_buffer.push_str(&line);
         lines_buffer.push('\n');
         if condition(&line) {
@@ -318,10 +318,22 @@ pub fn start_http_ingester() -> (
     impl FnOnce(),
     String,
 ) {
+    start_http_ingester_with_delay(0)
+}
+
+/// Starts the http ingester that introduces an artificial delay between request and response.
+pub fn start_http_ingester_with_delay(
+    delay_ms: u64,
+) -> (
+    impl Future<Output = std::result::Result<(), HyperError>>,
+    FileLineCounter,
+    impl FnOnce(),
+    String,
+) {
     let port = get_available_port().expect("No ports free");
     let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
 
-    let (server, received, shutdown_handle) = http_ingester(address);
+    let (server, received, shutdown_handle) = http_ingester(address, delay_ms);
     (
         server,
         received,

--- a/common/test/mock-ingester/src/bin/http_ingester.rs
+++ b/common/test/mock-ingester/src/bin/http_ingester.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "0.0.0.0:1337".parse()?;
     info!("Listening on http://{}", addr);
 
-    let (server, _, shutdown_handle) = http_ingester(addr);
+    let (server, _, shutdown_handle) = http_ingester(addr, 0);
     tokio::join!(
         async {
             tokio::time::delay_for(tokio::time::Duration::from_millis(5000)).await;

--- a/common/test/mock-ingester/src/lib.rs
+++ b/common/test/mock-ingester/src/lib.rs
@@ -62,7 +62,7 @@ impl Service<Request<Body>> for Svc {
     }
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
-        info!("Received {:?}", req);
+        eprintln!("_!_! INGESTER: Received {:?}", req);
         let files = self.files.clone();
         Box::pin(async move {
             let rsp = Response::builder();
@@ -114,6 +114,8 @@ impl Service<Request<Body>> for Svc {
                     return Ok(rsp.status(500).body(Body::empty()).unwrap());
                 }
             };
+
+            eprintln!("!_!_! Obtained {} lines", ingest_body.lines.len());
 
             for line in ingest_body.lines {
                 if let Some(mut raw_line) = line.line {
@@ -189,6 +191,7 @@ pub fn http_ingester(
     let (tx, rx) = tokio::sync::oneshot::channel::<()>();
     let mk_svc = MakeSvc::new();
     let received = mk_svc.files.clone();
+    eprintln!("----------STARTING INGESTER");
     (
         async move {
             // Create a TCP listener via tokio.

--- a/common/test/mock-ingester/src/lib.rs
+++ b/common/test/mock-ingester/src/lib.rs
@@ -47,6 +47,7 @@ struct Line {
 #[derive(Debug)]
 pub struct Svc {
     files: FileLineCounter,
+    delay_ms: u64,
 }
 
 impl Unpin for Svc {}
@@ -62,8 +63,9 @@ impl Service<Request<Body>> for Svc {
     }
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
-        eprintln!("_!_! INGESTER: Received {:?}", req);
+        info!("Received {:?}", req);
         let files = self.files.clone();
+        let delay = self.delay_ms;
         Box::pin(async move {
             let rsp = Response::builder();
 
@@ -115,8 +117,12 @@ impl Service<Request<Body>> for Svc {
                 }
             };
 
-            eprintln!("!_!_! Obtained {} lines", ingest_body.lines.len());
-            std::thread::sleep(core::time::Duration::from_millis(200));
+            info!("Obtained {} lines", ingest_body.lines.len());
+
+            if delay > 0 {
+                tokio::time::delay_for(tokio::time::Duration::from_millis(delay)).await;
+                // std::thread::sleep(core::time::Duration::from_millis(delay));
+            }
 
             for line in ingest_body.lines {
                 if let Some(mut raw_line) = line.line {
@@ -150,19 +156,21 @@ impl Service<Request<Body>> for Svc {
 
 pub struct MakeSvc {
     files: FileLineCounter,
+    delay_ms: u64,
 }
 
 impl MakeSvc {
-    pub fn new() -> Self {
+    pub fn new(delay_ms: u64) -> Self {
         MakeSvc {
             files: Arc::new(Mutex::new(HashMap::new())),
+            delay_ms,
         }
     }
 }
 
 impl Default for MakeSvc {
     fn default() -> Self {
-        Self::new()
+        Self::new(0)
     }
 }
 
@@ -178,21 +186,22 @@ impl<T> Service<T> for MakeSvc {
     fn call(&mut self, _: T) -> Self::Future {
         future::ok(Svc {
             files: self.files.clone(),
+            delay_ms: self.delay_ms,
         })
     }
 }
 
 pub fn http_ingester(
     addr: SocketAddr,
+    delay_ms: u64,
 ) -> (
     impl Future<Output = std::result::Result<(), HyperError>>,
     FileLineCounter,
     impl FnOnce(),
 ) {
     let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-    let mk_svc = MakeSvc::new();
+    let mk_svc = MakeSvc::new(delay_ms);
     let received = mk_svc.files.clone();
-    eprintln!("----------STARTING INGESTER");
     (
         async move {
             // Create a TCP listener via tokio.
@@ -233,7 +242,7 @@ pub fn https_ingester(
 ) {
     info!("creating https_ingester");
     let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-    let mk_svc = MakeSvc::new();
+    let mk_svc = MakeSvc::new(0);
     let received = mk_svc.files.clone();
     (
         async move {

--- a/common/test/mock-ingester/src/lib.rs
+++ b/common/test/mock-ingester/src/lib.rs
@@ -116,6 +116,7 @@ impl Service<Request<Body>> for Svc {
             };
 
             eprintln!("!_!_! Obtained {} lines", ingest_body.lines.len());
+            std::thread::sleep(core::time::Duration::from_millis(200));
 
             for line in ingest_body.lines {
                 if let Some(mut raw_line) = line.line {


### PR DESCRIPTION
Use artificial delay to slow down the mock ingester in order to reproduce.