### PR TITLE
3.1 handle symlink init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,8 +1580,8 @@ dependencies = [
 
 [[package]]
 name = "logdna-client"
-version = "0.4.0"
-source = "git+https://github.com/logdna/logdna-rust.git?tag=0.4.0#9df87c840b774c2385a099e5d031d05ecc129438"
+version = "0.4.1"
+source = "git+https://github.com/logdna/logdna-rust.git?tag=0.4.1#09a8aea1006a2c793d96692f135125d9b23d0c3b"
 dependencies = [
  "async-buf-pool",
  "async-compression",

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
                     match offsets {
                         Ok(os) => {
                             initial_offsets =
-                                Some(os.into_iter().map(|fo| (fo.key, fo.offset)).collect())
+                                Some(os.into_iter().map(|fo| (fo.key, fo.offset)).collect());
                         }
                         Err(e) => warn!("couldn't retrieve offsets from agent state, {:?}", e),
                     }

--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -467,7 +467,7 @@ fn test_directory_symlinks_delete() {
 
     std::os::unix::fs::symlink(&dir_1_path, &symlink_path).unwrap();
 
-    eprintln!("waiting for initialized");
+    debug!("waiting for initialized");
     common::wait_for_file_event("watching", &symlink_path, &mut stderr_reader);
 
     common::append_to_file(&file1_path, 1_000, 50).expect("Could not append");
@@ -476,7 +476,7 @@ fn test_directory_symlinks_delete() {
 
     fs::remove_file(&symlink_path).expect("Could not remove symlink");
 
-    eprintln!("waiting for unwatching");
+    debug!("waiting for unwatching");
     common::wait_for_file_event("unwatching", &file3_path, &mut stderr_reader);
 
     common::assert_agent_running(&mut agent_handle);
@@ -784,6 +784,7 @@ async fn test_tags() {
 #[tokio::test]
 #[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_lookback_restarting_agent() {
+    let _ = env_logger::Builder::from_default_env().try_init();
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
@@ -902,7 +903,7 @@ async fn test_symlink_initialization_both_included() {
         // Wait for the data to be received by the mock ingester
         tokio::time::delay_for(tokio::time::Duration::from_millis(2000)).await;
         let map = received.lock().await;
-        eprintln!("--TEST MAP KEYS: {:?}", map.keys());
+        debug!("--TEST MAP KEYS: {:?}", map.keys());
         let file_info = map
             .get(file_path.to_str().unwrap())
             .expect("lines for file not found");
@@ -958,7 +959,6 @@ async fn test_symlink_initialization_excluded_file() {
         // Wait for the data to be received by the mock ingester
         tokio::time::delay_for(tokio::time::Duration::from_millis(2000)).await;
         let map = received.lock().await;
-        eprintln!("--TEST MAP KEYS: {:?}", map.keys());
         let file_info = map
             .get(symlink_path.to_str().unwrap())
             .expect("symlink not found");
@@ -1010,7 +1010,6 @@ async fn test_symlink_to_symlink_initialization_excluded_file() {
         // Wait for the data to be received by the mock ingester
         tokio::time::delay_for(tokio::time::Duration::from_millis(2000)).await;
         let map = received.lock().await;
-        eprintln!("--TEST MAP KEYS: {:?}", map.keys());
         let file_info = map
             .get(symlink_path.to_str().unwrap())
             .expect("symlink not found");
@@ -1065,7 +1064,6 @@ async fn test_symlink_initialization_with_stateful_lookback() {
             tokio::time::delay_for(tokio::time::Duration::from_millis(5000)).await;
 
             let map = received.lock().await;
-            eprintln!("Map: {:?}", map);
             let file_info = map
                 .get(symlink_path.to_str().unwrap())
                 .expect("symlink not found");

--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -868,7 +868,60 @@ async fn test_lookback_restarting_agent() {
 #[tokio::test]
 #[cfg_attr(not(feature = "integration_tests"), ignore)]
 #[cfg_attr(not(target_os = "linux"), ignore)]
-async fn test_symlink_initialization() {
+async fn test_symlink_initialization_2() {
+    let log_dir = tempdir().expect("Couldn't create temp dir...").into_path();
+    let excluded_dir = tempdir().expect("Couldn't create temp dir...").into_path();
+    let (server, received, shutdown_handle, addr) = common::start_http_ingester();
+    let file_path = excluded_dir.join("test.log");
+    let symlink_path = log_dir.join("test-symlink.log");
+    File::create(&file_path).expect("Couldn't create temp log file...");
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&file_path)
+        .unwrap();
+    for i in 0..10 {
+        writeln!(file, "SAMPLE {}", i).unwrap();
+    }
+    file.sync_all().unwrap();
+    std::os::unix::fs::symlink(&file_path, &symlink_path).unwrap();
+    tokio::time::delay_for(tokio::time::Duration::from_millis(1000)).await;
+    let (server_result, _) = tokio::join!(server, async {
+        let settings = AgentSettings::with_mock_ingester(&log_dir.to_str().unwrap(), &addr);
+        let mut agent_handle = common::spawn_agent(settings);
+        let stderr_reader = std::io::BufReader::new(agent_handle.stderr.take().unwrap());
+        // Consume output
+        std::thread::spawn(move || {
+            stderr_reader.lines().for_each(|line| {
+                eprintln!("---- line: {}", line.unwrap());
+            });
+        });
+        tokio::time::delay_for(tokio::time::Duration::from_millis(2000)).await;
+        for i in 10..20 {
+            writeln!(file, "SAMPLE {}", i).unwrap();
+        }
+        file.sync_all().unwrap();
+        common::force_client_to_flush(&log_dir).await;
+        // Wait for the data to be received by the mock ingester
+        tokio::time::delay_for(tokio::time::Duration::from_millis(2000)).await;
+        let map = received.lock().await;
+        eprintln!("--TEST MAP KEYS: {:?}", map.keys());
+        let file_info = map
+            .get(symlink_path.to_str().unwrap())
+            .expect("symlink not found");
+        for i in 0..20 {
+            assert_eq!(file_info.values[i], format!("SAMPLE {}\n", i));
+        }
+        agent_handle.kill().expect("Could not kill process");
+        shutdown_handle();
+    });
+    server_result.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
+#[cfg_attr(not(target_os = "linux"), ignore)]
+async fn test_symlink_initialization_with_stateful_lookback() {
     let log_dir = tempdir().expect("Couldn't create temp dir...").into_path();
     let excluded_dir = tempdir().expect("Couldn't create temp dir...").into_path();
 

--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -907,13 +907,13 @@ async fn test_symlink_initialization_both_included() {
         eprintln!("--TEST MAP KEYS: {:?}", map.keys());
         let file_info = map
             .get(file_path.to_str().unwrap())
-            .expect("symlink not found");
+            .expect("lines for file not found");
         for i in 0..20 {
             assert_eq!(file_info.values[i], format!("SAMPLE {}\n", i));
         }
         let file_info = map
             .get(symlink_path.to_str().unwrap())
-            .expect("symlink not found");
+            .expect("lines for symlink not found");
         for i in 0..20 {
             assert_eq!(file_info.values[i], format!("SAMPLE {}\n", i));
         }

--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -980,6 +980,61 @@ async fn test_symlink_initialization_excluded_file() {
 #[tokio::test]
 #[cfg_attr(not(feature = "integration_tests"), ignore)]
 #[cfg_attr(not(target_os = "linux"), ignore)]
+async fn test_symlink_to_symlink_initialization_excluded_file() {
+    let log_dir = tempdir().expect("Couldn't create temp dir...").into_path();
+    let excluded_dir = tempdir().expect("Couldn't create temp dir...").into_path();
+    let (server, received, shutdown_handle, addr) = common::start_http_ingester();
+    let file_path = excluded_dir.join("test.log");
+    let excluded_symlink_path = excluded_dir.join("test-symlink.log");
+    let symlink_path = log_dir.join("test-symlink.log");
+    File::create(&file_path).expect("Couldn't create temp log file...");
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&file_path)
+        .unwrap();
+    for i in 0..10 {
+        writeln!(file, "SAMPLE {}", i).unwrap();
+    }
+    file.sync_all().unwrap();
+    std::os::unix::fs::symlink(&file_path, &excluded_symlink_path).unwrap();
+    std::os::unix::fs::symlink(&excluded_symlink_path, &symlink_path).unwrap();
+    tokio::time::delay_for(tokio::time::Duration::from_millis(1000)).await;
+    let (server_result, _) = tokio::join!(server, async {
+        let settings = AgentSettings::with_mock_ingester(&log_dir.to_str().unwrap(), &addr);
+        let mut agent_handle = common::spawn_agent(settings);
+        let stderr_reader = std::io::BufReader::new(agent_handle.stderr.take().unwrap());
+        // Consume output
+        std::thread::spawn(move || {
+            stderr_reader.lines().for_each(|line| {
+                eprintln!("---- line: {}", line.unwrap());
+            });
+        });
+        tokio::time::delay_for(tokio::time::Duration::from_millis(2000)).await;
+        for i in 10..20 {
+            writeln!(file, "SAMPLE {}", i).unwrap();
+        }
+        file.sync_all().unwrap();
+        common::force_client_to_flush(&log_dir).await;
+        // Wait for the data to be received by the mock ingester
+        tokio::time::delay_for(tokio::time::Duration::from_millis(2000)).await;
+        let map = received.lock().await;
+        eprintln!("--TEST MAP KEYS: {:?}", map.keys());
+        let file_info = map
+            .get(symlink_path.to_str().unwrap())
+            .expect("symlink not found");
+        for i in 0..20 {
+            assert_eq!(file_info.values[i], format!("SAMPLE {}\n", i));
+        }
+        agent_handle.kill().expect("Could not kill process");
+        shutdown_handle();
+    });
+    server_result.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
+#[cfg_attr(not(target_os = "linux"), ignore)]
 async fn test_symlink_initialization_with_stateful_lookback() {
     let log_dir = tempdir().expect("Couldn't create temp dir...").into_path();
     let excluded_dir = tempdir().expect("Couldn't create temp dir...").into_path();

--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -106,7 +106,7 @@ pub fn truncate_file(file_path: &PathBuf) -> Result<(), std::io::Error> {
     Ok(())
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct AgentSettings<'a> {
     pub log_dirs: &'a str,
     pub exclusion_regex: Option<&'a str>,

--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -329,3 +329,12 @@ pub fn start_http_ingester() -> (
         format!("localhost:{}", port),
     )
 }
+
+pub fn consume_output(stderr_handle: std::process::ChildStderr) {
+    let stderr_reader = std::io::BufReader::new(stderr_handle);
+    std::thread::spawn(move || {
+        for line in stderr_reader.lines() {
+            debug!("{:?}", line);
+        }
+    });
+}

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -918,7 +918,7 @@ impl FileSystem {
 
     /// Determines whether the path is within the initial dir
     /// and either passes the master rules (e.g. "*.log") or it's a directory
-    fn is_initial_dir_target(&self, path: &PathBuf) -> bool {
+    pub(crate) fn is_initial_dir_target(&self, path: &PathBuf) -> bool {
         // Must be within the initial dir
         if self.initial_dir_rules.passes(path) != Status::Ok {
             return false;

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -150,7 +150,14 @@ impl FileSystem {
                 } else {
                     for event in events {
                         match event {
-                            Event::New(entry) => fs.initial_events.push(Event::Initialize(entry)),
+                            Event::New(entry_key) => {
+                                if let Some(entry) = entries.get(entry_key) {
+                                    let path = fs.resolve_direct_path(entry, &entries);
+                                    if fs.is_initial_dir_target(&path) {
+                                        fs.initial_events.push(Event::Initialize(entry_key))
+                                    }
+                                }
+                            }
                             _ => panic!("unexpected event in initialization"),
                         };
                     }

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -202,12 +202,7 @@ impl Tailer {
                                                             data.borrow_mut().deref_mut().seek(len).await.unwrap_or_else(|e| error!("error seeking {:?}", e))
                                                         }
                                                     }
-                                                    if !fs.is_initial_dir_target(link) {
-                                                        debug!("symlink target is excluded, tailing it");
-                                                        data.borrow_mut().tail(vec![sym_path]).await
-                                                    } else {
-                                                        None
-                                                    }
+                                                    data.borrow_mut().tail(vec![sym_path]).await
                                                 } else {
                                                     None
                                                 }

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -106,49 +106,124 @@ impl Tailer {
                             // will initiate a file to it's current length
                             if let Some(entry) = fs.entries.borrow().get(entry_ptr){
                                 let path = fs.resolve_direct_path(&entry, &fs.entries.borrow());
-                                if let Entry::File { data, .. } = entry {
-                                    match lookback_config {
-                                        Lookback::Start => {
-                                            let offset = match initial_offsets.as_ref() {
-                                                Some(initial_offsets) => {
-                                                    initial_offsets.get(&path.as_os_str().as_bytes().into()).copied().unwrap_or(0)
-                                                }
-                                                None => 0
-                                            };
-                                            info!("initialized {:?} with offset {}", path, offset);
-                                            data.borrow_mut().deref_mut().seek(offset).await.unwrap_or_else(|e| error!("error seeking {:?}", e))
-                                        },
-                                        Lookback::SmallFiles => {
-                                            let offset = match initial_offsets.as_ref() {
-                                                Some(initial_offsets) => {
-                                                    initial_offsets.get(&path.as_os_str().as_bytes().into()).copied().unwrap_or(0)
-                                                }
-                                                None => {
-                                                    let len = path.metadata().map(|m| m.len()).unwrap_or(0);
-                                                    if len < 8192 {
-                                                        0
-                                                    } else{
-                                                        len
+                                match entry {
+                                    Entry::File { name, data, .. } => {
+                                        match lookback_config {
+                                            Lookback::Start => {
+                                                let offset = match initial_offsets.as_ref() {
+                                                    Some(initial_offsets) => {
+                                                        let offset = initial_offsets.get(&path.as_os_str().as_bytes().into()).copied().unwrap_or(0);
+                                                        debug!("Got offset {} from state for {:?} using key {:?}", offset, name, path);
+                                                        offset
                                                     }
-                                                }
-                                            };
-                                            info!("initialized {:?} with offset {}", path, offset);
-                                            data.borrow_mut().deref_mut().seek(offset).await.unwrap_or_else(|e| error!("error seeking {:?}", e))
-                                        },
-                                        Lookback::None => {
-                                            let len = path.metadata().map(|m| m.len()).unwrap_or(0);
-                                            info!("initialized {:?} with offset {}", path, len);
-                                            data.borrow_mut().deref_mut().seek(len).await.unwrap_or_else(|e| error!("error seeking {:?}", e))
+                                                    None => 0
+                                                };
+                                                info!("initialized {:?} with offset {}", path, offset);
+                                                data.borrow_mut().deref_mut().seek(offset).await.unwrap_or_else(|e| error!("error seeking {:?}", e))
+                                            },
+                                            Lookback::SmallFiles => {
+                                                let offset = match initial_offsets.as_ref() {
+                                                    Some(initial_offsets) => {
+                                                        let offset = initial_offsets.get(&path.as_os_str().as_bytes().into()).copied().unwrap_or(0);
+                                                        debug!("Got offset {} from state for {:?} using key {:?}", offset, name, path);
+                                                        offset
+                                                    }
+                                                    None => {
+                                                        let len = path.metadata().map(|m| m.len()).unwrap_or(0);
+                                                        debug!("Smallfiles lookback {} from state for {:?} using key {:?}", len, name, path);
+                                                        if len < 8192 {
+                                                            0
+                                                        } else{
+                                                            len
+                                                        }
+                                                    }
+                                                };
+                                                info!("initialized {:?} with offset {}", path, offset);
+                                                data.borrow_mut().deref_mut().seek(offset).await.unwrap_or_else(|e| error!("error seeking {:?}", e))
+                                            },
+                                            Lookback::None => {
+                                                let len = path.metadata().map(|m| m.len()).unwrap_or(0);
+                                                info!("initialized {:?} with offset {}", path, len);
+                                                data.borrow_mut().deref_mut().seek(len).await.unwrap_or_else(|e| error!("error seeking {:?}", e))
+                                            }
+                                        }
+                                        if fs.is_initial_dir_target(&path) {
+                                            debug!("File is in initial dirs");
+                                            data.borrow_mut().tail(vec![path]).await
+                                        } else {
+                                            None
                                         }
                                     }
-                                    data.borrow_mut().tail(vec![path]).await
-                                } else {
-                                    None
+                                    Entry::Symlink { name, link, .. } => {
+                                        let sym_path = path.clone();
+                                        let sym_name = name;
+                                        info!("Initialise event for symlink {:?}, target {:?}", name, link);
+                                        if let Some(real_entry) = fs.lookup(link, &fs.entries.borrow()) {
+                                            if let Some(entry) = &fs.entries.borrow().get(real_entry) {
+                                                let path = fs.resolve_direct_path(entry, &fs.entries.borrow());
+                                                if let Entry::File { data, .. } = entry {
+                                                    match lookback_config {
+                                                        Lookback::Start => {
+                                                            let offset = match initial_offsets.as_ref() {
+                                                                Some(initial_offsets) => {
+                                                                    let offset = initial_offsets.get(&path.as_os_str().as_bytes().into()).copied().unwrap_or(0);
+                                                                    debug!("Got offset {} from state for {:?} using key {:?}", offset, sym_name, path);
+                                                                    offset
+                                                                }
+                                                                None => 0
+                                                            };
+                                                            info!("initialized symlink {:?} with offset {}", sym_name, offset);
+                                                            data.borrow_mut().deref_mut().seek(offset).await.unwrap_or_else(|e| error!("error seeking {:?}", e))
+                                                        },
+                                                        Lookback::SmallFiles => {
+                                                            let offset = match initial_offsets.as_ref() {
+                                                                Some(initial_offsets) => {
+                                                                    let offset = initial_offsets.get(&path.as_os_str().as_bytes().into()).copied().unwrap_or(0);
+                                                                    debug!("Got offset {} from state for {:?} using key {:?}", offset, sym_name, path);
+                                                                    offset
+                                                                }
+                                                                None => {
+                                                                    // Check the actual file len
+                                                                    let len = path.metadata().map(|m| m.len()).unwrap_or(0);
+                                                                    debug!("Smallfiles lookback {} from state for {:?} using key {:?}", len, sym_name, path);
+                                                                    if len < 8192 {
+                                                                        0
+                                                                    } else{
+                                                                        len
+                                                                    }
+                                                                }
+                                                            };
+                                                            info!("initialized symlink {:?} with offset {}", sym_name, offset);
+                                                            data.borrow_mut().deref_mut().seek(offset).await.unwrap_or_else(|e| error!("error seeking {:?}", e))
+                                                        },
+                                                        Lookback::None => {
+                                                            let len = path.metadata().map(|m| m.len()).unwrap_or(0);
+                                                            info!("initialized symlink {:?} with offset {}", sym_name, len);
+                                                            data.borrow_mut().deref_mut().seek(len).await.unwrap_or_else(|e| error!("error seeking {:?}", e))
+                                                        }
+                                                    }
+                                                    if !fs.is_initial_dir_target(link) {
+                                                        debug!("symlink target is excluded, tailing it");
+                                                        data.borrow_mut().tail(vec![sym_path]).await
+                                                    } else {
+                                                        None
+                                                    }
+                                                } else {
+                                                    None
+                                                }
+                                            } else {
+                                                None
+                                            }
+                                        } else {
+                                            info!("can't initialize symlink - pointed to file / directory doesn't exist: {:?}", path);
+                                            None
+                                        }
+                                    }
+                                    _ => None
                                 }
                             } else {
                                 None
                             }
-
                         }
                         Event::New(entry_ptr) => {
                             Metrics::fs().increment_creates();

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -102,7 +102,7 @@ impl Tailer {
                     let fs = fs.lock().expect("Couldn't lock fs");
                     match event {
                         Event::Initialize(entry_ptr) => {
-                            debug!("Initialise Event");
+                            debug!("initialize Event");
                             // will initiate a file to it's current length
                             if let Some(entry) = fs.entries.borrow().get(entry_ptr){
                                 let path = fs.resolve_direct_path(&entry, &fs.entries.borrow());
@@ -157,7 +157,7 @@ impl Tailer {
                                     Entry::Symlink { name, link, .. } => {
                                         let sym_path = path.clone();
                                         let sym_name = name;
-                                        info!("Initialise event for symlink {:?}, target {:?}", name, link);
+                                        info!("initialize event for symlink {:?}, target {:?}", name, link);
                                         if let Some(real_entry) = fs.lookup(link, &fs.entries.borrow()) {
                                             if let Some(entry) = &fs.entries.borrow().get(real_entry) {
                                                 let path = fs.resolve_direct_path(entry, &fs.entries.borrow());

--- a/common/http/Cargo.toml
+++ b/common/http/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 metrics = { package = "metrics", path = "../metrics" }
 state = { package = "state", path = "../state" }
 #http
-logdna-client = { git ="https://github.com/logdna/logdna-rust.git", tag="0.4.0" }
+logdna-client = { git ="https://github.com/logdna/logdna-rust.git", tag="0.4.1" }
 
 #io
 tokio = "0.2"

--- a/common/http/src/client.rs
+++ b/common/http/src/client.rs
@@ -86,6 +86,7 @@ impl Client {
                 Ok((offsets, Some(body))) => {
                     if let (Some(sw), Some(offsets)) = (self.state_write.as_ref(), &offsets) {
                         for (file_name, offset) in offsets {
+                            debug!("Updating offset for {:?} to {}", file_name, *offset);
                             if let Err(e) = sw.update(file_name, *offset).await {
                                 error!("Unable to write offsets. error: {}", e);
                             };
@@ -116,6 +117,7 @@ impl Client {
             Ok(_) => {
                 if let Some(wh) = self.state_write.as_ref() {
                     if let (Some(key), Some(offset)) = (key.as_ref(), offset) {
+                        debug!("Updating offset for {:?} to {}", key, offset);
                         wh.update(key, offset).await.unwrap();
                     }
                 }

--- a/common/state/src/lib.rs
+++ b/common/state/src/lib.rs
@@ -95,7 +95,7 @@ impl AgentState {
     }
 }
 
-#[derive(Hash, Clone, PartialEq, Eq)]
+#[derive(Debug, Hash, Clone, PartialEq, Eq)]
 pub struct FileName(bytes::Bytes);
 
 impl FileName {

--- a/common/state/src/lib.rs
+++ b/common/state/src/lib.rs
@@ -98,6 +98,12 @@ impl AgentState {
 #[derive(Hash, Clone, PartialEq, Eq)]
 pub struct FileName(bytes::Bytes);
 
+impl FileName {
+    pub fn bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 impl<T> From<T> for FileName
 where
     T: AsRef<[u8]>,


### PR DESCRIPTION
This updates the Tailer to handle initialization of symlinks where their target files that are outside the tracked folders