### PR TITLE
Use inode instead of filepath as lookback key

### DIFF
--- a/bin/src/stream_adapter.rs
+++ b/bin/src/stream_adapter.rs
@@ -183,7 +183,7 @@ impl GetOffset for StrictOrLazyLines<'_> {
         }
     }
 
-    fn get_key(&self) -> Option<&[u8]> {
+    fn get_key(&self) -> Option<u64> {
         match self {
             StrictOrLazyLines::Strict(_) => None,
             StrictOrLazyLines::Lazy(line) => line.get_key(),

--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -6,6 +6,7 @@ use proptest::prelude::*;
 use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::fs::MetadataExt;
 use std::process::Command;
 use std::thread::{self, sleep};
 use std::time::Duration;
@@ -1017,6 +1018,152 @@ async fn test_symlink_to_symlink_initialization_excluded_file() {
             assert_eq!(file_info.values[i], format!("SAMPLE {}\n", i));
         }
         agent_handle.kill().expect("Could not kill process");
+        shutdown_handle();
+    });
+    server_result.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
+#[cfg_attr(not(target_os = "linux"), ignore)]
+async fn test_symlink_to_hardlink_initialization_excluded_file() {
+    let _ = env_logger::Builder::from_default_env().try_init();
+
+    let db_dir = tempdir().expect("Couldn't create temp dir...");
+    let db_dir_path = db_dir.path();
+
+    let (server, received, shutdown_handle, cert_file, addr) = common::self_signed_https_ingester();
+
+    let log_dir = tempdir().expect("Couldn't create temp dir...").into_path();
+    let excluded_dir = tempdir().expect("Couldn't create temp dir...").into_path();
+    let file_path = excluded_dir.join("test.log");
+    let excluded_hardlink_path = excluded_dir.join("test-hardlink.log");
+    let excluded_symlink_path = excluded_dir.join("test-symlink.log");
+    let symlink_path = log_dir.join("test-symlink.log");
+
+    File::create(&file_path).expect("Couldn't create temp log file...");
+    std::fs::hard_link(&file_path, &excluded_hardlink_path).unwrap();
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&file_path)
+        .unwrap();
+    for i in 0..10 {
+        writeln!(file, "SAMPLE {}", i).unwrap();
+    }
+    file.sync_all().unwrap();
+    std::os::unix::fs::symlink(&file_path, &excluded_symlink_path).unwrap();
+    std::os::unix::fs::symlink(&excluded_symlink_path, &symlink_path).unwrap();
+
+    debug!(
+        "----{:?}: {}",
+        file_path,
+        file_path.metadata().unwrap().ino()
+    );
+    debug!(
+        "----{:?}: {}",
+        excluded_hardlink_path,
+        excluded_hardlink_path.metadata().unwrap().ino()
+    );
+    debug!(
+        "----{:?}: {}",
+        excluded_symlink_path,
+        excluded_symlink_path.metadata().unwrap().ino()
+    );
+    debug!(
+        "----{:?}: {}",
+        symlink_path,
+        symlink_path.metadata().unwrap().ino()
+    );
+
+    let (server_result, _) = tokio::join!(server, async {
+        tokio::time::delay_for(tokio::time::Duration::from_millis(1000)).await;
+
+        let settings = AgentSettings {
+            log_dirs: &log_dir.to_str().unwrap(),
+            exclusion_regex: Some(r"/var\w*"),
+            ssl_cert_file: Some(cert_file.path()),
+            lookback: Some("start"),
+            state_db_dir: Some(&db_dir_path),
+            host: Some(&addr),
+            ..Default::default()
+        };
+
+        let mut agent_handle = common::spawn_agent(settings.clone());
+        let stderr_reader = agent_handle.stderr.take().unwrap();
+        // Consume output
+        consume_output(stderr_reader);
+        tokio::time::delay_for(tokio::time::Duration::from_millis(2000)).await;
+        for i in 10..20 {
+            writeln!(file, "SAMPLE {}", i).unwrap();
+        }
+        file.sync_all().unwrap();
+        common::force_client_to_flush(&log_dir).await;
+        // Wait for the data to be received by the mock ingester
+        tokio::time::delay_for(tokio::time::Duration::from_millis(2000)).await;
+        {
+            let map = received.lock().await;
+            let file_info = map
+                .get(symlink_path.to_str().unwrap())
+                .expect("symlink not found");
+            for i in 0..20 {
+                assert_eq!(file_info.values[i], format!("SAMPLE {}\n", i));
+            }
+        }
+        agent_handle.kill().expect("Could not kill process");
+
+        tokio::time::delay_for(tokio::time::Duration::from_millis(1000)).await;
+
+        // move 2nd symlink to point to hardlink
+        std::fs::remove_file(&excluded_symlink_path).unwrap();
+        std::os::unix::fs::symlink(&excluded_hardlink_path, &excluded_symlink_path).unwrap();
+
+        debug!(
+            "----{:?}: {}",
+            file_path,
+            file_path.metadata().unwrap().ino()
+        );
+        debug!(
+            "----{:?}: {}",
+            excluded_hardlink_path,
+            excluded_hardlink_path.metadata().unwrap().ino()
+        );
+        debug!(
+            "----{:?}: {}",
+            excluded_symlink_path,
+            excluded_symlink_path.metadata().unwrap().ino()
+        );
+        debug!(
+            "----{:?}: {}",
+            symlink_path,
+            symlink_path.metadata().unwrap().ino()
+        );
+
+        let mut agent_handle = common::spawn_agent(settings);
+        let stderr_reader = agent_handle.stderr.take().unwrap();
+        // Consume output
+        consume_output(stderr_reader);
+        tokio::time::delay_for(tokio::time::Duration::from_millis(2000)).await;
+        for i in 20..30 {
+            writeln!(file, "SAMPLE {}", i).unwrap();
+        }
+        file.sync_all().unwrap();
+        common::force_client_to_flush(&log_dir).await;
+        // Wait for the data to be received by the mock ingester
+        tokio::time::delay_for(tokio::time::Duration::from_millis(2000)).await;
+        let map = received.lock().await;
+        let file_info = map
+            .get(symlink_path.to_str().unwrap())
+            .expect("symlink not found");
+
+        for v in file_info.values.iter() {
+            debug!("line: {:?}", v);
+        }
+        for i in 0..30 {
+            assert_eq!(file_info.values[i], format!("SAMPLE {}\n", i));
+        }
+        agent_handle.kill().expect("Could not kill process");
+        tokio::time::delay_for(tokio::time::Duration::from_millis(1000)).await;
         shutdown_handle();
     });
     server_result.unwrap();

--- a/common/http/src/client.rs
+++ b/common/http/src/client.rs
@@ -109,7 +109,7 @@ impl Client {
         line: impl IngestLineSerialize<String, bytes::Bytes, HashMap<String, String>, Ok = ()>
             + GetOffset,
     ) {
-        let key = line.get_key().map(bytes::Bytes::copy_from_slice);
+        let key = line.get_key();
         let offset = line.get_offset();
         self.poll().await;
         match self.buffer.as_mut().unwrap(/* poll will panic if this isn't set */).write_line(line).await

--- a/common/http/src/lib.rs
+++ b/common/http/src/lib.rs
@@ -9,4 +9,4 @@ pub mod types {
     pub use logdna_client::*;
 }
 
-type Offset = (Box<[u8]>, u64);
+type Offset = (u64, u64);

--- a/common/state/src/lib.rs
+++ b/common/state/src/lib.rs
@@ -96,20 +96,11 @@ impl AgentState {
 }
 
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
-pub struct FileName(bytes::Bytes);
+pub struct FileId(u64);
 
-impl FileName {
-    pub fn bytes(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl<T> From<T> for FileName
-where
-    T: AsRef<[u8]>,
-{
-    fn from(b: T) -> FileName {
-        FileName(bytes::Bytes::copy_from_slice(b.as_ref()))
+impl From<&u64> for FileId {
+    fn from(i: &u64) -> FileId {
+        FileId(*i)
     }
 }
 
@@ -128,13 +119,13 @@ pub enum FileOffsetStateError {
 }
 
 pub struct FileOffset {
-    pub key: FileName,
+    pub key: FileId,
     pub offset: u64,
 }
 
 pub enum FileOffsetUpdate {
     Update(FileOffset),
-    Delete(FileName),
+    Delete(FileId),
 }
 
 pub enum FileOffsetEvent {
@@ -151,7 +142,7 @@ pub struct FileOffsetWriteHandle {
 impl FileOffsetWriteHandle {
     pub async fn update(
         &self,
-        file_name: impl Into<FileName>,
+        file_name: impl Into<FileId>,
         offset: u64,
     ) -> Result<(), FileOffsetStateError> {
         Ok(self
@@ -165,7 +156,7 @@ impl FileOffsetWriteHandle {
             .await?)
     }
 
-    pub async fn delete(&self, file_name: impl Into<FileName>) -> Result<(), FileOffsetStateError> {
+    pub async fn delete(&self, file_name: impl Into<FileId>) -> Result<(), FileOffsetStateError> {
         Ok(self
             .tx
             .send(FileOffsetEvent::Update(FileOffsetUpdate::Delete(
@@ -229,10 +220,11 @@ impl FileOffsetState {
             .db
             .iterator_cf(cf_handle, IteratorMode::Start)
             .map(|(k, v)| {
-                let (int_bytes, _) = v.split_at(std::mem::size_of::<u64>());
+                let (k_bytes, _) = k.split_at(std::mem::size_of::<u64>());
+                let (v_bytes, _) = v.split_at(std::mem::size_of::<u64>());
                 FileOffset {
-                    key: FileName(bytes::Bytes::copy_from_slice(k.as_ref())),
-                    offset: u64::from_be_bytes(int_bytes.try_into().unwrap_or([0; 8])),
+                    key: FileId(u64::from_be_bytes(k_bytes.try_into().unwrap_or([0; 8]))),
+                    offset: u64::from_be_bytes(v_bytes.try_into().unwrap_or([0; 8])),
                 }
             })
             .collect::<Vec<_>>())
@@ -283,10 +275,15 @@ impl FileOffsetState {
                             (wb, FileOffsetEvent::Update(e)) => {
                                 let mut wb = wb.unwrap_or_default();
                                 match e {
-                                    FileOffsetUpdate::Update(FileOffset { key, offset }) => {
-                                        wb.put_cf(cf_handle, key.0, u64::to_be_bytes(offset))
+                                    FileOffsetUpdate::Update(FileOffset { key, offset }) => wb
+                                        .put_cf(
+                                            cf_handle,
+                                            u64::to_be_bytes(key.0),
+                                            u64::to_be_bytes(offset),
+                                        ),
+                                    FileOffsetUpdate::Delete(key) => {
+                                        wb.delete_cf(cf_handle, u64::to_be_bytes(key.0))
                                     }
-                                    FileOffsetUpdate::Delete(key) => wb.delete_cf(cf_handle, key.0),
                                 };
                                 Ok(Some(wb))
                             }
@@ -304,7 +301,7 @@ impl FileOffsetState {
 }
 
 pub trait GetOffset {
-    fn get_key(&self) -> Option<&[u8]>;
+    fn get_key(&self) -> Option<u64>;
     fn get_offset(&self) -> Option<u64>;
 }
 
@@ -330,7 +327,7 @@ mod test {
             let sh = offset_state.shutdown_handle().unwrap();
             assert_eq!(initial_count, offset_state.offsets().unwrap().len());
 
-            let paths = ["path1", "path2", "path3", "path04"];
+            let paths = [1, 2, 3, 4];
 
             tokio_test::block_on(async {
                 let _ = tokio::join!(
@@ -355,19 +352,19 @@ mod test {
                     async move {
                         tokio::time::delay_for(tokio::time::Duration::from_millis(100)).await;
                         for path in paths.iter() {
-                            wh.update(path.as_bytes(), 13).await.unwrap();
+                            wh.update(path, 13).await.unwrap();
                         }
                         fh.flush().await.unwrap();
                         tokio::time::delay_for(tokio::time::Duration::from_millis(200)).await;
 
                         for path in paths[..2].iter() {
-                            wh.update(path.as_bytes(), 14).await.unwrap();
+                            wh.update(path, 14).await.unwrap();
                         }
                         fh.flush().await.unwrap();
                         tokio::time::delay_for(tokio::time::Duration::from_millis(200)).await;
 
                         for path in paths[..2].iter() {
-                            wh.delete(path.as_bytes()).await.unwrap();
+                            wh.delete(path).await.unwrap();
                         }
                         fh.flush().await.unwrap();
                     },


### PR DESCRIPTION
This resolves an issue where symlinks to different hardlinks to the same underlying file were not being treated as the same file by the stateful lookback mechanism