### PR TITLE
3.1: Ignore new clippy errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ lint-format: ## Checks for formatting errors
 
 .PHONY:lint-clippy
 lint-clippy: ## Checks for code errors
-	$(RUST_COMMAND) "--env RUST_BACKTRACE=full" "cargo clippy --all-targets -- -D warnings"
+	$(RUST_COMMAND) "--env RUST_BACKTRACE=full" "cargo clippy --all-targets -- -D warnings -A clippy::upper-case-acronyms -A clippy::ptr-arg -A clippy::from-over-into"
 
 .PHONY:lint-audit
 lint-audit: ## Audits packages for issues

--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -370,7 +370,8 @@ fn test_files_other_than_dot_log_should_be_not_included_by_default() {
         let matches_excluded_file = predicate::str::is_match(regex).unwrap();
         assert!(
             !matches_excluded_file.eval(&lines),
-            format!("{} should not been included", file_name)
+            "{} should not been included",
+            file_name
         );
     }
 


### PR DESCRIPTION
With the build image update, clippy is complaining about rule changes.

For 3.1 branch, ignore the new rules to prevent a binary change.