### PR TITLE
Handle new clippy warnings

### DIFF
--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -370,7 +370,8 @@ fn test_files_other_than_dot_log_should_be_not_included_by_default() {
         let matches_excluded_file = predicate::str::is_match(regex).unwrap();
         assert!(
             !matches_excluded_file.eval(&lines),
-            format!("{} should not been included", file_name)
+            "{} should not been included",
+            file_name
         );
     }
 

--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -97,11 +97,11 @@ pub async fn force_client_to_flush(dir_path: &Path) {
     append_to_file(&dir_path.join("force_flush.log"), 1, 1).unwrap();
 }
 
-pub fn truncate_file(file_path: &PathBuf) -> Result<(), std::io::Error> {
+pub fn truncate_file(file_path: &Path) -> Result<(), std::io::Error> {
     OpenOptions::new()
         .read(true)
         .write(true)
-        .open(&file_path)?
+        .open(file_path)?
         .set_len(0)?;
     Ok(())
 }
@@ -246,7 +246,7 @@ pub fn create_dirs<P: AsRef<Path>>(dirs: &[P]) {
     }
 }
 
-pub fn open_files_include(id: u32, file: &PathBuf) -> Option<String> {
+pub fn open_files_include(id: u32, file: &Path) -> Option<String> {
     let child = Command::new("lsof")
         .args(&["-l", "-p", &id.to_string()])
         .stdout(Stdio::piped())

--- a/common/fs/src/cache/dir_path.rs
+++ b/common/fs/src/cache/dir_path.rs
@@ -55,8 +55,8 @@ impl std::convert::AsRef<Path> for DirPathBuf {
     }
 }
 
-impl std::convert::Into<PathBuf> for DirPathBuf {
-    fn into(self) -> PathBuf {
-        self.inner
+impl From<DirPathBuf> for PathBuf {
+    fn from(d: DirPathBuf) -> PathBuf {
+        d.inner
     }
 }

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -73,7 +73,7 @@ impl Tailer {
         }
     }
 
-    fn get_file_for_path(fs: &FileSystem, next_path: &std::path::PathBuf) -> Option<EntryKey> {
+    fn get_file_for_path(fs: &FileSystem, next_path: &std::path::Path) -> Option<EntryKey> {
         let entries = fs.entries.borrow();
         let mut next_path = next_path;
         loop {

--- a/common/http/src/retry.rs
+++ b/common/http/src/retry.rs
@@ -10,7 +10,7 @@ use crate::types::body::{IngestBody, IngestBodyBuffer, IntoIngestBodyBuffer};
 use crate::Offset;
 use metrics::Metrics;
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
@@ -25,7 +25,7 @@ pub enum Error {
     #[error(transparent)]
     Send(#[from] crossbeam::channel::SendError<Box<IngestBodyBuffer>>),
     #[error("{0:?} is not valid utf8")]
-    NonUTF8(std::path::PathBuf),
+    NonUtf8(std::path::PathBuf),
     #[error("{0} is not a valid file name")]
     InvalidFileName(std::string::String),
 }
@@ -101,7 +101,7 @@ impl Retry {
                 .file_name()
                 .and_then(|s| s.to_str())
                 .map(|s| s.to_string())
-                .ok_or_else(|| Error::NonUTF8(path.clone()))?;
+                .ok_or_else(|| Error::NonUtf8(path.clone()))?;
 
             let timestamp: i64 = file_name
                 .split('_')
@@ -121,7 +121,7 @@ impl Retry {
         Ok(())
     }
 
-    fn read_from_disk(path: &PathBuf) -> Result<(Option<Vec<Offset>>, IngestBody), Error> {
+    fn read_from_disk(path: &Path) -> Result<(Option<Vec<Offset>>, IngestBody), Error> {
         let mut file = File::open(path)?;
         let mut data = String::new();
         file.read_to_string(&mut data)?;


### PR DESCRIPTION
Fix `from-over-into`, `ptr-arg` and `upper-case-acronyms` in `fs` and `http` crates

Relates to #127.