### PR TITLE
Use stable rbac.authorization.k8s.io/v1 API

### DIFF
--- a/k8s/agent-resources-openshift-supertenant.yaml
+++ b/k8s/agent-resources-openshift-supertenant.yaml
@@ -32,7 +32,7 @@ subjects:
     namespace: logdna-agent
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: logdna-agent
   labels:
@@ -47,7 +47,7 @@ rules:
     resources: ["pods"]
     verbs: ["get","list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logdna-agent

--- a/k8s/agent-resources-openshift.yaml
+++ b/k8s/agent-resources-openshift.yaml
@@ -32,7 +32,7 @@ subjects:
     namespace: logdna-agent
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: logdna-agent
   labels:
@@ -47,7 +47,7 @@ rules:
     resources: ["pods"]
     verbs: ["get","list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logdna-agent

--- a/k8s/agent-resources-supertenant.yaml
+++ b/k8s/agent-resources-supertenant.yaml
@@ -42,7 +42,7 @@ subjects:
     namespace: logdna-agent
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: logdna-agent
   labels:
@@ -57,7 +57,7 @@ rules:
     resources: ["pods"]
     verbs: ["get","list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logdna-agent

--- a/k8s/agent-resources.yaml
+++ b/k8s/agent-resources.yaml
@@ -42,7 +42,7 @@ subjects:
     namespace: logdna-agent
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: logdna-agent
   labels:
@@ -57,7 +57,7 @@ rules:
     resources: ["pods"]
     verbs: ["get","list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logdna-agent

--- a/k8s/mock-ingester.yaml
+++ b/k8s/mock-ingester.yaml
@@ -51,7 +51,7 @@ subjects:
     namespace: logdna-agent
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: logdna-agent
   labels:
@@ -66,7 +66,7 @@ rules:
     resources: ["pods"]
     verbs: ["get","list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logdna-agent


### PR DESCRIPTION
RBAC mode is stable since k8s v1.8.

We should also update the helm charts.