### PR TITLE
Integration test for retries

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -97,7 +97,12 @@ fn main() {
     let handles = offset_state
         .as_ref()
         .map(|os| (os.write_handle(), os.flush_handle()));
-    let client = Rc::new(RefCell::new(Client::new(config.http.template, handles)));
+    let client = Rc::new(RefCell::new(Client::new(
+        config.http.template,
+        handles,
+        config.http.retry_base_delay,
+        config.http.retry_step_delay,
+    )));
     client
         .borrow_mut()
         .set_max_buffer_size(config.http.body_size);

--- a/bin/tests/retries.rs
+++ b/bin/tests/retries.rs
@@ -1,7 +1,7 @@
 use common::AgentSettings;
 pub use common::*;
 use logdna_mock_ingester::{
-    http_ingester_with_processors, FileLineCounter, IngestBody, IngestError,
+    http_ingester_with_processors, FileLineCounter, IngestError, ProcessFn,
 };
 use std::fs::File;
 use std::future::Future;
@@ -176,7 +176,7 @@ journald: {{}}
 }
 
 fn start_ingester(
-    process_fn: Box<dyn Fn(&IngestBody) + Send>,
+    process_fn: ProcessFn,
 ) -> (
     impl Future<Output = std::result::Result<(), IngestError>>,
     FileLineCounter,

--- a/bin/tests/retries.rs
+++ b/bin/tests/retries.rs
@@ -1,0 +1,196 @@
+use common::AgentSettings;
+pub use common::*;
+use logdna_mock_ingester::{
+    http_ingester_with_processors, FileLineCounter, IngestBody, IngestError,
+};
+use std::fs::File;
+use std::future::Future;
+use std::io::Write;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use tempfile::tempdir;
+
+mod common;
+
+#[tokio::test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
+async fn test_retry_after_timeout() {
+    let timeout = 200;
+    let base_delay_ms = 300;
+    let step_delay_ms = 100;
+    let attempts = 10;
+    let config_file_path = get_config_file(timeout, base_delay_ms, step_delay_ms);
+
+    let dir = tempdir().unwrap().into_path();
+    let file_path = dir.join("test.log");
+    let mut file = File::create(&file_path).expect("Couldn't create temp log file...");
+
+    let attempts_counter = Arc::new(Mutex::new(0));
+    let counter = attempts_counter.clone();
+    let (server, received, shutdown_handle, address) = start_ingester(Box::new(move |body| {
+        if body
+            .lines
+            .iter()
+            .any(|l| l.file.as_deref().unwrap().contains("test.log"))
+        {
+            let mut counter = counter.lock().unwrap();
+            *counter += 1;
+            if *counter < attempts {
+                // Sleep enough time to mark the request as timed out by the client
+                thread::sleep(Duration::from_millis(timeout + 20));
+            }
+        }
+    }));
+
+    let mut settings = AgentSettings::with_mock_ingester(&dir.to_str().unwrap(), &address);
+    settings.config_file = config_file_path.to_str();
+    let mut agent_handle = common::spawn_agent(settings);
+    let agent_stderr = agent_handle.stderr.take().unwrap();
+    common::consume_output(agent_stderr);
+
+    let (server_result, _) = tokio::join!(server, async move {
+        // Wait for the server to catch up
+        tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+
+        let file_lines = &["hello\n", " world\n", " world2\n", " world3\n", " world4\n"];
+        for item in file_lines {
+            write!(file, "{}", item).unwrap();
+        }
+
+        // Wait for the data to be received by the mock ingester
+        tokio::time::sleep(tokio::time::Duration::from_millis(
+            base_delay_ms + (timeout + step_delay_ms) * attempts,
+        ))
+        .await;
+
+        let map = received.lock().await;
+        let file_info = map.get(file_path.to_str().unwrap()).unwrap();
+        // Received it multiple times
+        assert!(file_info.values.len() >= file_lines.len());
+
+        let attempts_made = attempts_counter.lock().unwrap();
+        // It retried multiple times
+        assert_eq!(*attempts_made, attempts);
+        shutdown_handle();
+    });
+
+    server_result.unwrap();
+    agent_handle.kill().unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
+async fn test_retry_is_not_made_before_retry_base_delay_ms() {
+    // Use a large base delay
+    let base_delay_ms = 300_000;
+    let timeout = 200;
+    let config_file_path = get_config_file(timeout, base_delay_ms, 100);
+
+    let dir = tempdir().unwrap().into_path();
+    let file_path = dir.join("test.log");
+    let mut file = File::create(&file_path).expect("Couldn't create temp log file...");
+
+    let attempts_counter = Arc::new(Mutex::new(0));
+    let counter = attempts_counter.clone();
+    let (server, _, shutdown_handle, address) = start_ingester(Box::new(move |body| {
+        if body
+            .lines
+            .iter()
+            .any(|l| l.file.as_deref().unwrap().contains("test.log"))
+        {
+            let mut counter = counter.lock().unwrap();
+            *counter += 1;
+            // Sleep enough time to mark the request as timed out by the client
+            thread::sleep(Duration::from_millis(timeout + 20));
+        }
+    }));
+
+    let mut settings = AgentSettings::with_mock_ingester(&dir.to_str().unwrap(), &address);
+    settings.config_file = config_file_path.to_str();
+    let mut agent_handle = common::spawn_agent(settings);
+    let agent_stderr = agent_handle.stderr.take().unwrap();
+    common::consume_output(agent_stderr);
+
+    let (server_result, _) = tokio::join!(server, async move {
+        // Wait for the server to catch up
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        write!(file, "hello\nworld\n").unwrap();
+
+        // Wait for the data to be received by the mock ingester / retried
+        tokio::time::sleep(tokio::time::Duration::from_secs(4)).await;
+        let attempts_made = attempts_counter.lock().unwrap();
+        // It was not retried
+        assert_eq!(*attempts_made, 1);
+        shutdown_handle();
+    });
+
+    server_result.unwrap();
+    agent_handle.kill().unwrap();
+}
+
+/// Creates a temp config file with required fields and the provided parameters
+fn get_config_file(timeout: u64, retry_base_delay_ms: u64, retry_step_delay_ms: u64) -> PathBuf {
+    let config_dir = tempdir().unwrap().into_path();
+    let config_file_path = config_dir.join("config.yaml");
+    let mut config_file = File::create(&config_file_path).unwrap();
+
+    write!(
+        config_file,
+        "
+http:
+  timeout: {}
+  endpoint: /logs/agent
+  use_ssl: false
+  use_compression: true
+  gzip_level: 2
+  params:
+    hostname: abc
+    tags: tag1
+    now: 0
+  body_size: 2097152
+  retry_base_delay_ms: {}
+  retry_step_delay_ms: {}
+log:
+  dirs:
+  - /var/log/
+  include:
+    glob:
+      - \"*.log\"
+    regex: []
+  exclude:
+    glob:
+      - /var/log/wtmp
+      - /var/log/btmp
+    regex: []
+journald: {{}}
+",
+        timeout, retry_base_delay_ms, retry_step_delay_ms
+    )
+    .unwrap();
+
+    config_file_path
+}
+
+fn start_ingester(
+    process_fn: Box<dyn Fn(&IngestBody) + Send>,
+) -> (
+    impl Future<Output = std::result::Result<(), IngestError>>,
+    FileLineCounter,
+    impl FnOnce(),
+    String,
+) {
+    let port = common::get_available_port().expect("No ports free");
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
+
+    let (server, received, shutdown_handle) = http_ingester_with_processors(address, process_fn);
+    (
+        server,
+        received,
+        shutdown_handle,
+        format!("localhost:{}", port),
+    )
+}

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -41,6 +41,10 @@ pub struct HttpConfig {
     pub template: RequestTemplate,
     pub timeout: Duration,
     pub body_size: usize,
+
+    // Development only settings
+    pub retry_base_delay: Duration,
+    pub retry_step_delay: Duration,
 }
 
 #[derive(Debug)]
@@ -181,6 +185,12 @@ impl TryFrom<RawConfig> for Config {
                 .http
                 .body_size
                 .ok_or(ConfigError::MissingField("http.body_size"))?,
+            retry_base_delay: Duration::from_millis(
+                raw.http.retry_base_delay_ms.unwrap_or(15_000) as u64
+            ),
+            retry_step_delay: Duration::from_millis(
+                raw.http.retry_step_delay_ms.unwrap_or(3_000) as u64
+            ),
         };
 
         let mut log = LogConfig {

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -40,6 +40,13 @@ pub struct HttpConfig {
     pub params: Option<Params>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body_size: Option<usize>,
+
+    // Mostly for development, these settings are hidden from the user
+    // There's no guarantee that these settings will exist in the future
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_base_delay_ms: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_step_delay_ms: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
@@ -100,6 +107,8 @@ impl Default for HttpConfig {
                 .build()
                 .ok(),
             body_size: Some(2 * 1024 * 1024),
+            retry_base_delay_ms: None,
+            retry_step_delay_ms: None,
         }
     }
 }

--- a/common/test/mock-ingester/src/lib.rs
+++ b/common/test/mock-ingester/src/lib.rs
@@ -25,6 +25,7 @@ use tokio_stream::wrappers::TcpListenerStream;
 const ROOT: &str = "/logs/agent";
 
 pub type FileLineCounter = Arc<Mutex<HashMap<String, FileInfo>>>;
+pub type ProcessFn = Arc<Mutex<Box<dyn Fn(&IngestBody) + Send>>>;
 
 #[derive(Debug)]
 pub struct FileInfo {
@@ -44,22 +45,23 @@ pub enum IngestError {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct IngestBody {
-    lines: Vec<Line>,
+pub struct IngestBody {
+    pub lines: Vec<Line>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct Line {
-    line: Option<String>,
+pub struct Line {
+    pub line: Option<String>,
     tags: Option<String>,
-    file: Option<String>,
+    pub file: Option<String>,
     annotation: Option<HashMap<String, String>>,
     label: Option<HashMap<String, String>>,
 }
 
-#[derive(Debug)]
+// #[derive(Debug)]
 pub struct Svc {
     files: FileLineCounter,
+    process_fn: ProcessFn,
 }
 
 impl Unpin for Svc {}
@@ -77,6 +79,7 @@ impl Service<Request<Body>> for Svc {
     fn call(&mut self, req: Request<Body>) -> Self::Future {
         info!("Received {:?}", req);
         let files = self.files.clone();
+        let process_fn = self.process_fn.clone();
         Box::pin(async move {
             let rsp = Response::builder();
 
@@ -121,9 +124,19 @@ impl Service<Request<Body>> for Svc {
                 Ok(lines) => lines,
                 Err(e) => {
                     error!("{}", e);
-                    return Ok(rsp.status(500).body(Body::empty()).unwrap());
+                    return Ok(rsp
+                        .status(500)
+                        .body(Body::from(format!(
+                            "Ingest body could not be parsed: {}\n{}",
+                            e,
+                            std::str::from_utf8(&bytes).unwrap(),
+                        )))
+                        .unwrap());
                 }
             };
+
+            let process_fn = process_fn.lock().await;
+            process_fn(&ingest_body);
 
             for line in ingest_body.lines {
                 if let Some(mut raw_line) = line.line {
@@ -161,19 +174,21 @@ impl Service<Request<Body>> for Svc {
 
 pub struct MakeSvc {
     files: FileLineCounter,
+    process_fn: ProcessFn,
 }
 
 impl MakeSvc {
-    pub fn new() -> Self {
+    pub fn new(process_fn: Box<dyn Fn(&IngestBody) + Send>) -> Self {
         MakeSvc {
             files: Arc::new(Mutex::new(HashMap::new())),
+            process_fn: Arc::new(Mutex::new(process_fn)),
         }
     }
 }
 
 impl Default for MakeSvc {
     fn default() -> Self {
-        Self::new()
+        Self::new(Box::new(|_| {}))
     }
 }
 
@@ -189,6 +204,7 @@ impl<T> Service<T> for MakeSvc {
     fn call(&mut self, _: T) -> Self::Future {
         future::ok(Svc {
             files: self.files.clone(),
+            process_fn: self.process_fn.clone(),
         })
     }
 }
@@ -200,8 +216,19 @@ pub fn http_ingester(
     FileLineCounter,
     impl FnOnce(),
 ) {
+    http_ingester_with_processors(addr, Box::new(|_| {}))
+}
+
+pub fn http_ingester_with_processors(
+    addr: SocketAddr,
+    process_fn: Box<dyn Fn(&IngestBody) + Send>,
+) -> (
+    impl Future<Output = std::result::Result<(), IngestError>>,
+    FileLineCounter,
+    impl FnOnce(),
+) {
     let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-    let mk_svc = MakeSvc::new();
+    let mk_svc = MakeSvc::new(process_fn);
     let received = mk_svc.files.clone();
     (
         async move {
@@ -243,7 +270,7 @@ pub fn https_ingester(
 ) {
     info!("creating https_ingester");
     let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-    let mk_svc = MakeSvc::new();
+    let mk_svc = MakeSvc::new(Box::new(|_| {}));
     let received = mk_svc.files.clone();
     (
         async move {


### PR DESCRIPTION
It adds basic integration test coverage for retries by adding artificial delays to mock ingester responses.

I've added minor modifications to the client wrapper and to retry mod to support setting the retry parameters in the test.