### PR TITLE
Fix redaction insert index

### DIFF
--- a/common/middleware/src/line_rules.rs
+++ b/common/middleware/src/line_rules.rs
@@ -289,10 +289,7 @@ mod tests {
 
     #[test]
     fn should_support_redactions_changing_length() {
-        let redact = &vec![
-            s!(r"(?:123)"),
-            s!(r"(?:def)"),
-        ];
+        let redact = &vec![s!(r"(?:123)"), s!(r"(?:def)")];
         let p = LineRules::new(&[], &[], redact).unwrap();
         redact_match!(p, "Hello INFO not redacted", "Hello INFO not redacted");
         redact_match!(

--- a/common/middleware/src/line_rules.rs
+++ b/common/middleware/src/line_rules.rs
@@ -91,6 +91,8 @@ impl LineRules {
 
                     if m.start() < existing.0 {
                         insert_index = Some(i);
+                        // Order is guaranteed so there's no need to continue processing
+                        break;
                     }
                 }
 
@@ -282,6 +284,21 @@ mod tests {
             p,
             "Si, this is sensitive, supersensitive and sensible.",
             "[REDACTED], this is [REDACTED], [REDACTED] and [REDACTED]."
+        );
+    }
+
+    #[test]
+    fn should_support_redactions_changing_length() {
+        let redact = &vec![
+            s!(r"(?:123)"),
+            s!(r"(?:def)"),
+        ];
+        let p = LineRules::new(&[], &[], redact).unwrap();
+        redact_match!(p, "Hello INFO not redacted", "Hello INFO not redacted");
+        redact_match!(
+            p,
+            "count def 123 hello hello hello hello 123 def def",
+            "count [REDACTED] [REDACTED] hello hello hello hello [REDACTED] [REDACTED] [REDACTED]"
         );
     }
 


### PR DESCRIPTION
Break early when insert index is defined.

It fixes an edge case when multiple redactions are defined and multiple matches appear in the same line in a specific order.
It includes a unit test that was failing before the fix.