### PR TITLE
Fix redaction insert index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "logdna-agent"
-version = "3.2.0-beta.1"
+version = "3.3.0-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/common/middleware/src/line_rules.rs
+++ b/common/middleware/src/line_rules.rs
@@ -91,6 +91,8 @@ impl LineRules {
 
                     if m.start() < existing.0 {
                         insert_index = Some(i);
+                        // Order is guaranteed so there's no need to continue processing
+                        break;
                     }
                 }
 
@@ -282,6 +284,18 @@ mod tests {
             p,
             "Si, this is sensitive, supersensitive and sensible.",
             "[REDACTED], this is [REDACTED], [REDACTED] and [REDACTED]."
+        );
+    }
+
+    #[test]
+    fn should_support_redactions_changing_length() {
+        let redact = &vec![s!(r"(?:123)"), s!(r"(?:def)")];
+        let p = LineRules::new(&[], &[], redact).unwrap();
+        redact_match!(p, "Hello INFO not redacted", "Hello INFO not redacted");
+        redact_match!(
+            p,
+            "count def 123 hello hello hello hello 123 def def",
+            "count [REDACTED] [REDACTED] hello hello hello hello [REDACTED] [REDACTED] [REDACTED]"
         );
     }
 


### PR DESCRIPTION
Break early when insert index is defined (master).

Port fix from #143 and keep `Cargo.lock` up to date.