### PR TITLE
Expose metrics in a Prometheus endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "0.1.0"
 dependencies = [
@@ -866,10 +872,12 @@ dependencies = [
  "chrono",
  "crossbeam",
  "futures",
+ "hyper",
  "log",
  "logdna-client",
  "metrics",
  "num_cpus",
+ "prometheus",
  "rand",
  "serde",
  "serde_json",
@@ -1331,6 +1339,7 @@ dependencies = [
  "fs",
  "futures",
  "http 0.1.0",
+ "hyper",
  "itertools",
  "jemallocator",
  "journald",
@@ -1441,6 +1450,8 @@ dependencies = [
  "json",
  "lazy_static",
  "log",
+ "prometheus",
+ "tokio",
 ]
 
 [[package]]
@@ -1846,6 +1857,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8809e0c18450a2db0f236d2a44ec0b4c1412d0eb936233579f0990faa5d5cd"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "procfs",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "proptest"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +1906,12 @@ dependencies = [
  "rusty-fork",
  "tempfile",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45604fc7a88158e7d514d8e22e14ac746081e7a70d7690074dd0029ee37458d6"
 
 [[package]]
 name = "quick-error"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -69,6 +69,7 @@ rand = "0.8"
 systemd = "0.7"
 nix = "0.20"
 wait-timeout = "0.2"
+hyper = { version = "0.14", features = ["http1"] }
 
 [build-dependencies]
 auditable-build = "0.1"

--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -419,7 +419,7 @@ async fn test_metrics_endpoint() {
             body_str = std::str::from_utf8(&buf).unwrap().to_string();
 
             // Request duration metrics are the last ones to appear
-            if body_str.contains("logdna_ingest_request_duration") {
+            if body_str.contains("logdna_agent_ingest_request_duration") {
                 break;
             }
         }
@@ -427,13 +427,13 @@ async fn test_metrics_endpoint() {
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    assert!(body_str.contains("# TYPE logdna_fs_bytes counter"));
-    assert!(body_str.contains("# TYPE logdna_fs_lines counter"));
-    assert!(body_str.contains("# TYPE logdna_ingest_request_size histogram"));
-    assert!(body_str.contains("# TYPE logdna_ingest_request_duration_millis histogram"));
-    assert!(body_str.contains("# TYPE logdna_fs_events counter"));
+    assert!(body_str.contains("# TYPE logdna_agent_fs_bytes counter"));
+    assert!(body_str.contains("# TYPE logdna_agent_fs_lines counter"));
+    assert!(body_str.contains("# TYPE logdna_agent_ingest_request_size histogram"));
+    assert!(body_str.contains("# TYPE logdna_agent_ingest_request_duration_millis histogram"));
+    assert!(body_str.contains("# TYPE logdna_agent_fs_events counter"));
     // One created file
-    assert!(body_str.contains("logdna_fs_events{event_type=\"create\"} 1"));
+    assert!(body_str.contains("logdna_agent_fs_events{event_type=\"create\"} 1"));
 
     common::assert_agent_running(&mut agent_handle);
     agent_handle.kill().expect("Could not kill process");

--- a/bin/tests/cmd_line_env.rs
+++ b/bin/tests/cmd_line_env.rs
@@ -83,6 +83,7 @@ fn test_command_line_arguments_should_set_config() {
                 .args(&["--use-k8s-enrichment", "never"])
                 .args(&["--log-k8s-events", "always"])
                 .args(&["--db-path", "/var/lib/some-agent/"])
+                .args(&["--metrics-port", "9898"])
                 .args(&["--line-exclusion", "abc"])
                 .args(&["--line-inclusion", "z_inc"])
                 .args(&["--line-redact", "a@b.com"]);
@@ -102,6 +103,7 @@ fn test_command_line_arguments_should_set_config() {
             assert!(contains("mac: 01-23-45-67-89-AB-CD-EF").eval(d));
             assert!(contains("lookback: start").eval(d));
             assert!(contains("db_path: /var/lib/some-agent/").eval(d));
+            assert!(contains("metrics_port: 9898").eval(d));
             assert!(contains("use_k8s_enrichment: never").eval(d));
             assert!(contains("log_k8s_events: always").eval(d));
             assert!(contains("a.*").eval(d));
@@ -125,6 +127,7 @@ fn test_invalid_command_line_arguments_should_exit() {
     cmd_line_invalid_test(&["--use-ssl", "ZZZ"]);
     cmd_line_invalid_test(&["--use-compression", "ZZZ"]);
     cmd_line_invalid_test(&["--gzip-level", "ZZZ"]);
+    cmd_line_invalid_test(&["--metrics-port", "ZZZ"]);
     cmd_line_invalid_test(&["--lookback", "ZZZ"]);
     cmd_line_invalid_test(&["--use-k8s-enrichment", "ZZZ"]);
     cmd_line_invalid_test(&["--log-k8s-events", "ZZZ"]);
@@ -153,6 +156,7 @@ fn test_environment_variables_should_set_config() {
                 .env("LOGDNA_JOURNALD_PATHS", "/j/d")
                 .env("LOGDNA_LOOKBACK", "none")
                 .env("LOGDNA_DB_PATH", "/var/lib/some-other-folder/")
+                .env("LOGDNA_METRICS_PORT", "9097")
                 .env("LOGDNA_USE_K8S_LOG_ENRICHMENT", "always")
                 .env("LOGDNA_LOG_K8S_EVENTS", "never")
                 .env("LOGDNA_LINE_EXCLUSION_REGEX", "exc_re")
@@ -174,6 +178,7 @@ fn test_environment_variables_should_set_config() {
             assert!(contains("mac: 22-23-45-67-89-AB-CD-EF").eval(d));
             assert!(contains("lookback: none").eval(d));
             assert!(contains("db_path: /var/lib/some-other-folder/").eval(d));
+            assert!(contains("metrics_port: 9097").eval(d));
             assert!(contains("j/d").eval(d));
             assert!(contains("use_k8s_enrichment: always").eval(d));
             assert!(contains("log_k8s_events: never").eval(d));

--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -119,6 +119,7 @@ pub struct AgentSettings<'a> {
     pub tags: Option<&'a str>,
     pub config_file: Option<&'a str>,
     pub state_db_dir: Option<&'a std::path::Path>,
+    pub metrics_port: Option<u32>,
     pub line_exclusion_regex: Option<&'a str>,
     pub line_inclusion_regex: Option<&'a str>,
     pub line_redact_regex: Option<&'a str>,
@@ -185,6 +186,10 @@ pub fn spawn_agent(settings: AgentSettings) -> Child {
 
     if let Some(state_db_dir) = settings.state_db_dir {
         agent.env("LOGDNA_DB_PATH", state_db_dir);
+    }
+
+    if let Some(port) = settings.metrics_port {
+        agent.env("LOGDNA_METRICS_PORT", format!("{}", port));
     }
 
     if let Some(rules) = settings.exclusion_regex {

--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -119,7 +119,7 @@ pub struct AgentSettings<'a> {
     pub tags: Option<&'a str>,
     pub config_file: Option<&'a str>,
     pub state_db_dir: Option<&'a std::path::Path>,
-    pub metrics_port: Option<u32>,
+    pub metrics_port: Option<u16>,
     pub line_exclusion_regex: Option<&'a str>,
     pub line_inclusion_regex: Option<&'a str>,
     pub line_redact_regex: Option<&'a str>,

--- a/common/config/src/argv.rs
+++ b/common/config/src/argv.rs
@@ -158,7 +158,7 @@ pub struct ArgumentOptions {
 
     /// The port number to expose a Prometheus endpoint target with the agent metrics.
     #[structopt(long, env = env::METRICS_PORT)]
-    metrics_port: Option<u32>,
+    metrics_port: Option<u16>,
 
     /// List of regex patterns to exclude log lines.
     /// When set, the Agent will NOT send log lines that match any of these patterns.

--- a/common/config/src/argv.rs
+++ b/common/config/src/argv.rs
@@ -31,6 +31,7 @@ pub mod env {
     pub const JOURNALD_PATHS: &str = "LOGDNA_JOURNALD_PATHS";
     pub const LOOKBACK: &str = "LOGDNA_LOOKBACK";
     pub const DB_PATH: &str = "LOGDNA_DB_PATH";
+    pub const METRICS_PORT: &str = "LOGDNA_METRICS_PORT";
     pub const USE_K8S_LOG_ENRICHMENT: &str = "LOGDNA_USE_K8S_LOG_ENRICHMENT";
     pub const LOG_K8S_EVENTS: &str = "LOGDNA_LOG_K8S_EVENTS";
     pub const LINE_EXCLUSION: &str = "LOGDNA_LINE_EXCLUSION_REGEX";
@@ -155,6 +156,10 @@ pub struct ArgumentOptions {
     #[structopt(long, env = env::DB_PATH)]
     db_path: Option<String>,
 
+    /// The port number to expose a Prometheus endpoint target with the agent metrics.
+    #[structopt(long, env = env::METRICS_PORT)]
+    metrics_port: Option<u32>,
+
     /// List of regex patterns to exclude log lines.
     /// When set, the Agent will NOT send log lines that match any of these patterns.
     #[structopt(long, env = env::LINE_EXCLUSION)]
@@ -239,6 +244,10 @@ impl ArgumentOptions {
 
         if let Some(ref p) = self.db_path {
             raw.log.db_path = Some(p.into())
+        }
+
+        if let Some(port) = self.metrics_port {
+            raw.log.metrics_port = Some(port)
         }
 
         set_rules(
@@ -552,6 +561,7 @@ mod test {
         assert_eq!(config.log.use_k8s_enrichment, None);
         assert_eq!(config.log.log_k8s_events, None);
         assert_eq!(config.log.db_path, None);
+        assert_eq!(config.log.metrics_port, None);
     }
 
     #[test]
@@ -567,6 +577,7 @@ mod test {
             ip: some_string!("1.2.3.4"),
             mac: some_string!("ac::dc"),
             db_path: some_string!("a/b/c"),
+            metrics_port: Some(9089),
             tags: vec_strings!("a", "b"),
             lookback: Some(Lookback::Start),
             use_k8s_enrichment: Some(K8sTrackingConf::Always),
@@ -593,6 +604,7 @@ mod test {
         assert_eq!(config.log.use_k8s_enrichment, some_string!("always"));
         assert_eq!(config.log.log_k8s_events, some_string!("never"));
         assert_eq!(config.log.db_path, Some(PathBuf::from("a/b/c")));
+        assert_eq!(config.log.metrics_port, Some(9089));
         assert_eq!(config.journald.paths, Some(vec_paths!["/a"]));
     }
 

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -51,6 +51,7 @@ pub struct HttpConfig {
 pub struct LogConfig {
     pub dirs: Vec<DirPathBuf>,
     pub db_path: Option<PathBuf>,
+    pub metrics_port: Option<u32>,
     pub rules: Rules,
     pub line_exclusion_regex: Vec<String>,
     pub line_inclusion_regex: Vec<String>,
@@ -206,6 +207,7 @@ impl TryFrom<RawConfig> for Config {
                 })
                 .collect(),
             db_path: raw.log.db_path,
+            metrics_port: raw.log.metrics_port,
             rules: Rules::new(),
             line_exclusion_regex: raw.log.line_exclusion_regex.unwrap_or_default(),
             line_inclusion_regex: raw.log.line_inclusion_regex.unwrap_or_default(),

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -51,7 +51,7 @@ pub struct HttpConfig {
 pub struct LogConfig {
     pub dirs: Vec<DirPathBuf>,
     pub db_path: Option<PathBuf>,
-    pub metrics_port: Option<u32>,
+    pub metrics_port: Option<u16>,
     pub rules: Rules,
     pub line_exclusion_regex: Vec<String>,
     pub line_inclusion_regex: Vec<String>,

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -55,7 +55,7 @@ pub struct LogConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub db_path: Option<PathBuf>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metrics_port: Option<u32>,
+    pub metrics_port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include: Option<Rules>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -55,6 +55,8 @@ pub struct LogConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub db_path: Option<PathBuf>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics_port: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub include: Option<Rules>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclude: Option<Rules>,
@@ -127,6 +129,7 @@ impl Default for LogConfig {
         LogConfig {
             dirs: vec!["/var/log/".into()],
             db_path: None,
+            metrics_port: None,
             include: Some(Rules {
                 glob: vec!["*.log".parse().unwrap()],
                 regex: Vec::new(),

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -291,7 +291,7 @@ impl Tailer {
                     let mut entries = fs.entries.borrow_mut();
                     if entries.remove(entry_ptr).is_some() {
                         info!(
-                            "Removed file information, currently tracking {} files",
+                            "Removed file information, currently tracking {} files and directories",
                             entries.len()
                         );
                     }

--- a/common/http/Cargo.toml
+++ b/common/http/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1"
 chrono = "0.4"
 thiserror = "1"
 futures = "0.3"
+hyper = { version = "0.14", features = ["http1", "server"] }
+prometheus = { version = "0.12", features = ["process"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/common/http/src/lib.rs
+++ b/common/http/src/lib.rs
@@ -3,6 +3,7 @@ extern crate log;
 
 pub mod client;
 pub mod limit;
+pub mod metrics_endpoint;
 pub mod retry;
 
 pub mod types {

--- a/common/http/src/metrics_endpoint.rs
+++ b/common/http/src/metrics_endpoint.rs
@@ -5,6 +5,7 @@ use hyper::{
     Body, Request, Response, Server,
 };
 use prometheus::{Encoder, TextEncoder};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -13,8 +14,8 @@ pub enum Error {
     Server(#[from] hyper::Error),
 }
 
-pub async fn serve(port: &u32) -> Result<(), Error> {
-    let address = format!("0.0.0.0:{}", port).parse().unwrap();
+pub async fn serve(port: &u16) -> Result<(), Error> {
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), *port);
     let serve_future = Server::bind(&address).serve(make_service_fn(|_| async {
         Ok::<_, hyper::Error>(service_fn(serve_req))
     }));

--- a/common/http/src/metrics_endpoint.rs
+++ b/common/http/src/metrics_endpoint.rs
@@ -1,0 +1,39 @@
+use futures::TryFutureExt;
+use hyper::{
+    header::CONTENT_TYPE,
+    service::{make_service_fn, service_fn},
+    Body, Request, Response, Server,
+};
+use prometheus::{Encoder, TextEncoder};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Server(#[from] hyper::Error),
+}
+
+pub async fn serve(port: &u32) -> Result<(), Error> {
+    let address = format!("0.0.0.0:{}", port).parse().unwrap();
+    let serve_future = Server::bind(&address).serve(make_service_fn(|_| async {
+        Ok::<_, hyper::Error>(service_fn(serve_req))
+    }));
+    info!("Metrics server listening on http://{}", address);
+    serve_future.map_err(Error::Server).await
+}
+
+async fn serve_req(_req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    let encoder = TextEncoder::new();
+
+    let metric_families = prometheus::gather();
+    let mut buffer = vec![];
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+
+    let response = Response::builder()
+        .status(200)
+        .header(CONTENT_TYPE, encoder.format_type())
+        .body(Body::from(buffer))
+        .unwrap();
+
+    Ok(response)
+}

--- a/common/journald/src/stream.rs
+++ b/common/journald/src/stream.rs
@@ -262,8 +262,7 @@ impl Reader {
             .or_else(|| record.get(KEY_SYSLOG_IDENTIFIER))
             .unwrap_or(&default_app);
 
-        Metrics::journald().increment_lines();
-        Metrics::journald().add_bytes(message.len() as u64);
+        Metrics::journald().add_bytes(message.len());
         Ok(Some(LineBuilder::new().line(message).file(app)))
     }
 }

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -10,3 +10,5 @@ chrono = "0.4"
 jemalloc-ctl = "0.3"
 json = "0.12"
 log = "0.4"
+prometheus = { version = "0.12", features = ["process"] }
+tokio = { version= "1", features= ["time"] }

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -14,38 +14,38 @@ use tokio::time::sleep;
 lazy_static! {
     static ref METRICS: Metrics = Metrics::new();
     static ref FS_EVENTS: IntCounterVec = register_int_counter_vec!(
-        "logdna_fs_events",
+        "logdna_agent_fs_events",
         "Filesystem events received",
         &["event_type"]
     )
     .unwrap();
     static ref FS_LINES: IntCounter =
-        register_int_counter!("logdna_fs_lines", "Number of lines parsed by the Filesystem module").unwrap();
+        register_int_counter!("logdna_agent_fs_lines", "Number of lines parsed by the Filesystem module").unwrap();
     static ref FS_FILES: IntGauge =
-        register_int_gauge!("logdna_fs_files", "Number of open files").unwrap();
+        register_int_gauge!("logdna_agent_fs_files", "Number of open files").unwrap();
     static ref FS_BYTES: IntCounter =
-        register_int_counter!("logdna_fs_bytes", "Number of bytes read by the Filesystem module").unwrap();
+        register_int_counter!("logdna_agent_fs_bytes", "Number of bytes read by the Filesystem module").unwrap();
     static ref FS_PARTIAL_READS: IntCounter =
-        register_int_counter!("logdna_fs_partial_reads", "Filesystem partial reads").unwrap();
+        register_int_counter!("logdna_agent_fs_partial_reads", "Filesystem partial reads").unwrap();
     static ref INGEST_RETRIES: IntCounter = register_int_counter!(
-        "logdna_ingest_retries",
+        "logdna_agent_ingest_retries",
         "Retry attempts made to the http ingestion service"
     )
     .unwrap();
     static ref INGEST_RATE_LIMIT_HITS: IntCounter = register_int_counter!(
-        "logdna_ingest_rate_limit_hits",
+        "logdna_agent_ingest_rate_limit_hits",
         "Number of times the http request was delayed due to the rate limiter"
     )
     .unwrap();
     static ref INGEST_REQUEST_SIZE: Histogram = register_histogram!(
-        "logdna_ingest_request_size",
+        "logdna_agent_ingest_request_size",
         "Size in bytes of the requests made to http ingestion service",
         // Buckets ranging from 500 bytes to 2Mb
         exponential_buckets(500.0, 2.0, 13).unwrap()
     )
     .unwrap();
     static ref INGEST_REQUEST_DURATION: HistogramVec = register_histogram_vec!(
-        "logdna_ingest_request_duration_millis",
+        "logdna_agent_ingest_request_duration_millis",
         "Latency of the requests made to http ingestion service",
         &["outcome"],
         // Buckets ranging from 0.1ms to 26s
@@ -53,15 +53,15 @@ lazy_static! {
     )
     .unwrap();
     static ref K8S_EVENTS: IntCounterVec = register_int_counter_vec!(
-        "logdna_k8s_events",
+        "logdna_agent_k8s_events",
         "Kubernetes events received",
         &["event_type"]
     )
     .unwrap();
     static ref K8S_LINES: IntCounter =
-        register_int_counter!("logdna_k8s_lines", "Kubernetes event lines read").unwrap();
+        register_int_counter!("logdna_agent_k8s_lines", "Kubernetes event lines read").unwrap();
     static ref JOURNAL_RECORDS: Histogram = register_histogram!(
-        "logdna_journald_records",
+        "logdna_agent_journald_records",
         "Size of the Journald log entries read"
     )
     .unwrap();

--- a/docs/INTERNAL_METRICS.md
+++ b/docs/INTERNAL_METRICS.md
@@ -1,0 +1,52 @@
+# LogDNA Agent Internal Metrics
+
+The LogDNA agent records metrics that can be relevant for monitoring and alerting, such as number log files currently
+tracked or number of bytes parsed, along with process status information.
+
+## Exposing the Agent Metrics as a Prometheus Endpoint 
+
+You can enable the agent's [Prometheus][prometheus] endpoint to expose the internal metrics to a Prometheus server,
+by setting the `LOGDNA_METRICS_PORT` environment variable to an available port number, for example:
+
+```yaml
+    - env:
+        - name: LOGDNA_METRICS_PORT
+          value: "9881"
+```
+
+Metrics related to the agent are exposed using the prefix `logdna_` and process status information, like memory and
+cpu usage, are exposed with the prefix `process_`.
+
+## Enabling Prometheus target discovery on Kubernetes
+
+Prometheus implements service discovery within Kubernetes, automatically scraping Kubernetes resources that
+define the annotations. You only need to specify the annotations in the agent DaemonSet metadata template for
+Prometheus to scrape the metrics from each pod.
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+spec:
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9881"
+        prometheus.io/scrape: "true"
+  # ... rest of daemonset settings ...
+```
+
+After applying the DaemonSet with the Prometheus annotations, the metrics will be available in your Prometheus server.
+
+## Metrics in log messages
+
+The agent also publishes its internal metrics every minute as a log line. This was useful in older versions for
+observability, but it's now deprecated in favor of Prometheus support.
+
+If you want to continue using these log line metrics, you should consider that there has been the following changes in
+version 3.3 and above of the agent:
+
+- Counters such as `"fs.events"`, `"ingest.requests"` and `"ingest.requests_size"`, etc are now monotonically
+increasing counters as opposed to counters that got reset every minute.
+- There are new metrics like `"ingest.requests_duration"` and `"fs.files_tracked"`.
+
+[prometheus]: https://prometheus.io/

--- a/docs/INTERNAL_METRICS.md
+++ b/docs/INTERNAL_METRICS.md
@@ -14,8 +14,8 @@ by setting the `LOGDNA_METRICS_PORT` environment variable to an available port n
           value: "9881"
 ```
 
-Metrics related to the agent are exposed using the prefix `logdna_` and process status information, like memory and
-cpu usage, are exposed with the prefix `process_`.
+Metrics related to the agent are exposed using the prefix `logdna_agent_` and process status information, like memory
+and cpu usage, are exposed with the prefix `process_`.
 
 ## Enabling Prometheus target discovery on Kubernetes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ The LogDNA agent is a resource-efficient log collection client that forwards log
   * [Configuring Kubernetes Events](#configuring-events)
   * [Configuring regex for redaction and exclusion or inclusion](#configuring-regex-for-redaction-and-exclusion-or-inclusion)
   * [Resource Limits](#resource-limits)
+  * [Exposing Agent Metrics](#exposing-agent-metrics)
 
 ## Managing Deployments
 
@@ -151,6 +152,7 @@ options are available:
 |`LOGDNA_USE_K8S_LOG_ENRICHMENT`|Determines whether the agent should query the K8s API to enrich log lines from other pods.|`always`|
 |`LOGDNA_LOG_K8S_EVENTS`|Whether the agent should log Kubernetes resource events. This setting only affects tracking and logging Kubernetes resource changes via watches. When disabled, the agent may still query k8s metadata to enrich log lines from other pods depending on the value of `LOGDNA_USE_K8S_LOG_ENRICHMENT` setting value.|`never`|
 |`LOGDNA_DB_PATH`|The directory the agent will store it's state database. Note that the agent must have write access to the directory and be a persistent volume.||
+|`LOGDNA_METRICS_PORT`|The port number to expose a Prometheus endpoint target with the [agent internal metrics](INTERNAL_METRICS.md).||
 
 All regular expressions use [Perl-style syntax][regex-syntax] with case sensitivity by default. If you don't
 want to differentiate between capital and lower-case letters, use non-capturing groups with a flag: `(?flags:exp)`,
@@ -247,6 +249,12 @@ event logging is enabled (disabled by default), additional CPU usage will occur 
 
 We do not recommend placing traffic shaping or CPU limits on the agent to ensure data can be sent to our
 log ingestion service.
+
+### Exposing Agent Metrics
+
+The LogDNA agent records internal metrics that can be relevant for monitoring and alerting, such as number log
+files currently tracked or number of bytes parsed, along with process status information. Check out the 
+[documentation for internal metrics](INTERNAL_METRICS.md) for more information.
 
 [regex-syntax]: https://docs.rs/regex/1.4.5/regex/#syntax
 [k8s-cpu-usage]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu


### PR DESCRIPTION
- Optionally expose a Prometheus endpoint.
- Add documentation for metrics.
- Create additional metrics, like a gauge for open files and a latency histogram.