### PR TITLE
Test include-only rules

### DIFF
--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -109,6 +109,7 @@ pub fn truncate_file(file_path: &Path) -> Result<(), std::io::Error> {
 #[derive(Clone, Default)]
 pub struct AgentSettings<'a> {
     pub log_dirs: &'a str,
+    pub exclusion: Option<&'a str>,
     pub exclusion_regex: Option<&'a str>,
     pub journald_dirs: Option<&'a str>,
     pub ssl_cert_file: Option<&'a std::path::Path>,
@@ -190,6 +191,10 @@ pub fn spawn_agent(settings: AgentSettings) -> Child {
 
     if let Some(port) = settings.metrics_port {
         agent.env("LOGDNA_METRICS_PORT", format!("{}", port));
+    }
+
+    if let Some(rules) = settings.exclusion {
+        agent.env("LOGDNA_EXCLUSION_RULES", rules);
     }
 
     if let Some(rules) = settings.exclusion_regex {


### PR DESCRIPTION
Adds coverage for "include-only" type of rules, using negative exclusion rules.

Related to #158.