### PR TITLE
Support retries when fetching initial pod metadata

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -115,7 +115,14 @@ async fn main() {
                 executor.register(v);
                 info!("Registered k8s metadata middleware");
             }
-            Err(e) => warn!("{}", e),
+            Err(e) => {
+                let message = format!(
+                    "The agent could not access k8s api after several attempts: {}",
+                    e
+                );
+                error!("{}", message);
+                panic!("{}", message);
+            }
         };
     }
 


### PR DESCRIPTION
Sometimes the kube api might not be accessible as network
is not fully initialized (CNI). Retry with backoff and exit
in error when all attempts fail.