### PR TITLE
Use recommended env var for ingester key

### DIFF
--- a/k8s/agent-resources-openshift-supertenant.yaml
+++ b/k8s/agent-resources-openshift-supertenant.yaml
@@ -102,7 +102,7 @@ spec:
               drop:
                 - all
           env:
-            - name: LOGDNA_AGENT_KEY
+            - name: LOGDNA_INGESTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: logdna-agent-key

--- a/k8s/agent-resources-openshift.yaml
+++ b/k8s/agent-resources-openshift.yaml
@@ -102,7 +102,7 @@ spec:
               drop:
                 - all
           env:
-            - name: LOGDNA_AGENT_KEY
+            - name: LOGDNA_INGESTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: logdna-agent-key

--- a/k8s/agent-resources-supertenant.yaml
+++ b/k8s/agent-resources-supertenant.yaml
@@ -111,7 +111,7 @@ spec:
               drop:
                 - all
           env:
-            - name: LOGDNA_AGENT_KEY
+            - name: LOGDNA_INGESTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: logdna-agent-key

--- a/k8s/agent-resources.yaml
+++ b/k8s/agent-resources.yaml
@@ -111,7 +111,7 @@ spec:
               drop:
                 - all
           env:
-            - name: LOGDNA_AGENT_KEY
+            - name: LOGDNA_INGESTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: logdna-agent-key

--- a/k8s/mock-ingester.yaml
+++ b/k8s/mock-ingester.yaml
@@ -114,7 +114,7 @@ spec:
           image: logdna/logdna-agent:3.3.0-dev
           imagePullPolicy: Always
           env:
-            - name: LOGDNA_AGENT_KEY
+            - name: LOGDNA_INGESTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: logdna-agent-key


### PR DESCRIPTION
Use `LOGDNA_INGESTION_KEY` in our own yamls. For future reference, `LOGDNA_AGENT_KEY` will continue to be supported (forever).

The change should not affect users' instrumentation as the `secretKeyRef` remains the same.