### PR TITLE
Musl static build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN env
 # Rebuild the agent
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_BUCKET" ]; then unset RUSTC_WRAPPER; fi; \
-    export ${BUILD_ENVS}; cargo build --manifest-path bin/Cargo.toml ${FEATURES} --release --target ${TARGET} && \
+    export ${BUILD_ENVS?}; cargo build --manifest-path bin/Cargo.toml ${FEATURES} --release --target ${TARGET} && \
     strip ./target/${TARGET}/release/logdna-agent && \
     cp ./target/${TARGET}/release/logdna-agent /logdna-agent && \
     sccache --show-stats

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     strip ./target/${TARGET}/release/logdna-agent && \
     cp ./target/${TARGET}/release/logdna-agent /logdna-agent && \
     sccache --show-stats
-#${FEATURES}
 
 # Use Red Hat Universal Base Image Minimal as the final base image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN env
 # Rebuild the agent
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_BUCKET" ]; then unset RUSTC_WRAPPER; fi; \
-    export ${BUILD_ENVS?}; cargo build --manifest-path bin/Cargo.toml ${FEATURES} --release --target ${TARGET} && \
+    export ${BUILD_ENVS?}; cargo build --manifest-path bin/Cargo.toml --no-default-features ${FEATURES} --release --target ${TARGET} && \
     strip ./target/${TARGET}/release/logdna-agent && \
     cp ./target/${TARGET}/release/logdna-agent /logdna-agent && \
     sccache --show-stats

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN env
 # Rebuild the agent
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_BUCKET" ]; then unset RUSTC_WRAPPER; fi; \
-    if [ ! -z "${TARGET}" ]; then export TARGET_ARG="--target ${TARGET}"; fi; \
-    export ${BUILD_ENVS?}; cargo build --manifest-path bin/Cargo.toml --no-default-features ${FEATURES} --release $TARGET_ARG && \
+    if [ -n "${TARGET}" ]; then export TARGET_ARG="--target ${TARGET}"; fi; \
+    export ${BUILD_ENVS?}; cargo build --manifest-path bin/Cargo.toml --no-default-features ${FEATURES} --release "$TARGET_ARG" && \
     strip ./target/${TARGET}/release/logdna-agent && \
     cp ./target/${TARGET}/release/logdna-agent /logdna-agent && \
     sccache --show-stats

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN env
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_BUCKET" ]; then unset RUSTC_WRAPPER; fi; \
     if [ -n "${TARGET}" ]; then export TARGET_ARG="--target ${TARGET}"; fi; \
-    export ${BUILD_ENVS?}; cargo build --manifest-path bin/Cargo.toml --no-default-features ${FEATURES} --release "$TARGET_ARG" && \
+    export ${BUILD_ENVS?}; cargo build --manifest-path bin/Cargo.toml --no-default-features ${FEATURES} --release $TARGET_ARG && \
     strip ./target/${TARGET}/release/logdna-agent && \
     cp ./target/${TARGET}/release/logdna-agent /logdna-agent && \
     sccache --show-stats

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN env
 # Rebuild the agent
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_BUCKET" ]; then unset RUSTC_WRAPPER; fi; \
-    export ${BUILD_ENVS?}; cargo build --manifest-path bin/Cargo.toml --no-default-features ${FEATURES} --release --target ${TARGET} && \
+    if [ ! -z "${TARGET}" ]; then export TARGET_ARG="--target ${TARGET}"; fi; \
+    export ${BUILD_ENVS?}; cargo build --manifest-path bin/Cargo.toml --no-default-features ${FEATURES} --release $TARGET_ARG && \
     strip ./target/${TARGET}/release/logdna-agent && \
     cp ./target/${TARGET}/release/logdna-agent /logdna-agent && \
     sccache --show-stats

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,13 +159,9 @@ pipeline {
                                 echo "[default]" > ${PWD}/.aws_creds_static
                                 echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds_static
                                 echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${PWD}/.aws_creds_static
-                                STATIC=1 sh 'make publish-s3-binary'
+                                STATIC=1 make publish-s3-binary
+                                rm ${PWD}/.aws_creds_static
                             '''
-                        }
-                    }
-                    post {
-                        always {
-                            sh "rm ${PWD}/.aws_creds_static"
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,15 +129,10 @@ pipeline {
                                 echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds_static
                                 echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${PWD}/.aws_creds_static
                                 STATIC=1 FEATURES= make build-release AWS_SHARED_CREDENTIALS_FILE=${PWD}/.aws_creds_static
+                                rm ${PWD}/.aws_creds_static
                             '''
                         }
                     }
-                    post {
-                        always {
-                            sh "rm ${PWD}/.aws_creds_static"
-                        }
-                    }
-
                 }
 
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,11 +119,11 @@ pipeline {
                 stage('Build static release binary') {
                     steps {
                         withCredentials([[
-                                                 $class: 'AmazonWebServicesCredentialsBinding',
-                                                 credentialsId: 'aws',
-                                                 accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                                                 secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                                         ]]) {
+                            $class: 'AmazonWebServicesCredentialsBinding',
+                            credentialsId: 'aws',
+                            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                        ]]) {
                             sh '''
                                 echo "[default]" > ${PWD}/.aws_creds_static
                                 echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds_static
@@ -131,7 +131,7 @@ pipeline {
                                 STATIC=1 FEATURES= make build-release AWS_SHARED_CREDENTIALS_FILE=${PWD}/.aws_creds_static
                             '''
                         }
-                   }
+                    }
                     post {
                         always {
                             sh "rm ${PWD}/.aws_creds_static"
@@ -150,11 +150,11 @@ pipeline {
                 stage('Publish static binary') {
                     steps {
                         withCredentials([[
-                                            $class: 'AmazonWebServicesCredentialsBinding',
-                                            credentialsId: 'aws',
-                                            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                                            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                                         ]]) {
+                            $class: 'AmazonWebServicesCredentialsBinding',
+                            credentialsId: 'aws',
+                            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                        ]]) {
                             sh '''
                                 echo "[default]" > ${PWD}/.aws_creds_static
                                 echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds_static

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,26 +88,58 @@ pipeline {
                 }
             }
         }
-        stage('Build Release Image') {
-            steps {
-                withCredentials([[
-                    $class: 'AmazonWebServicesCredentialsBinding',
-                    credentialsId: 'aws',
-                    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                    secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                ]]){
-                    sh """
-                        echo "[default]" > ${PWD}/.aws_creds
-                        echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds
-                        echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${PWD}/.aws_creds
-                        make build-image AWS_SHARED_CREDENTIALS_FILE=${PWD}/.aws_creds
-                    """
-                }
+        stage('Build Release Binaries') {
+            environment {
+                CREDS_FILE = credentials('pipeline-e2e-creds')
+                LOGDNA_HOST = "logs.use.stage.logdna.net"
             }
-            post {
-                always {
-                    sh "rm ${PWD}/.aws_creds"
+            parallel {
+                stage('Build Release Image') {
+                    steps {
+                        withCredentials([[
+                            $class: 'AmazonWebServicesCredentialsBinding',
+                            credentialsId: 'aws',
+                            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                        ]]){
+                            sh """
+                                echo "[default]" > ${PWD}/.aws_creds
+                                echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds
+                                echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${PWD}/.aws_creds
+                                make build-image AWS_SHARED_CREDENTIALS_FILE=${PWD}/.aws_creds
+                            """
+                        }
+                    }
+                    post {
+                        always {
+                            sh "rm ${PWD}/.aws_creds"
+                        }
+                    }
                 }
+                stage('Build static release binary') {
+                    steps {
+                        withCredentials([[
+                                                 $class: 'AmazonWebServicesCredentialsBinding',
+                                                 credentialsId: 'aws',
+                                                 accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                                 secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                         ]]) {
+                            sh '''
+                                echo "[default]" > ${PWD}/.aws_creds_static
+                                echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds_static
+                                echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${PWD}/.aws_creds_static
+                                STATIC=1 FEATURES= make build-release AWS_SHARED_CREDENTIALS_FILE=${PWD}/.aws_creds_static
+                            '''
+                        }
+                   }
+                    post {
+                        always {
+                            sh "rm ${PWD}/.aws_creds_static"
+                        }
+                    }
+
+                }
+
             }
         }
         stage('Check Publish Images') {
@@ -115,6 +147,28 @@ pipeline {
                 branch pattern: "\\d\\.\\d.*", comparator: "REGEXP"
             }
             stages {
+                stage('Publish static binary') {
+                    steps {
+                        withCredentials([[
+                                            $class: 'AmazonWebServicesCredentialsBinding',
+                                            credentialsId: 'aws',
+                                            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                         ]]) {
+                            sh '''
+                                echo "[default]" > ${PWD}/.aws_creds_static
+                                echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds_static
+                                echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${PWD}/.aws_creds_static
+                                STATIC=1 sh 'make publish-s3-binary'
+                            '''
+                        }
+                    }
+                    post {
+                        always {
+                            sh "rm ${PWD}/.aws_creds_static"
+                        }
+                    }
+                }
                 stage('Check Publish GCR Image or Timeout') {
                     steps {
                         script {

--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ build-image: ## Build a docker image as specified in the Dockerfile
 
 .PHONY: publish-s3-binary
 publish-s3-binary:
-	aws s3 cp target/$(TARGET)/release/logdna-agent s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/logdna-agent
+	aws s3 cp --acl public-read target/$(TARGET)/release/logdna-agent s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/logdna-agent
 
 define publish_images
 	$(eval TARGET_VERSIONS := $(TARGET_TAG) $(shell if [ "$(BETA_VERSION)" = "0" ]; then echo "$(BUILD_VERSION)-$(BUILD_DATE).$(shell docker images -q $(REPO):$(BUILD_TAG)) $(MAJOR_VERSION) $(MAJOR_VERSION).$(MINOR_VERSION)"; fi))

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ lint-audit: ## Audits packages for issues
 
 .PHONY:lint-docker
 lint-docker: ## Lint the Dockerfile for issues
-	$(HADOLINT_COMMAND) "" "hadolint Dockerfile --ignore DL3006"
+	$(HADOLINT_COMMAND) "" "hadolint Dockerfile --ignore DL3006 --ignore SC2086"
 
 .PHONY:lint-shell
 lint-shell: ## Lint the Dockerfile for issues

--- a/Makefile
+++ b/Makefile
@@ -313,6 +313,10 @@ build-image: ## Build a docker image as specified in the Dockerfile
 		--build-arg SCCACHE_BUCKET=$(SCCACHE_BUCKET) \
 		--build-arg SCCACHE_REGION=$(SCCACHE_REGION)
 
+.PHONY: publish-s3-binary
+publish-s3-binary:
+	aws s3 cp target/$(TARGET)/release/logdna-agent s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/logdna-agent
+
 define publish_images
 	$(eval TARGET_VERSIONS := $(TARGET_TAG) $(shell if [ "$(BETA_VERSION)" = "0" ]; then echo "$(BUILD_VERSION)-$(BUILD_DATE).$(shell docker images -q $(REPO):$(BUILD_TAG)) $(MAJOR_VERSION) $(MAJOR_VERSION).$(MINOR_VERSION)"; fi))
 	@set -e; \

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,6 @@ ifeq ($(STATIC), 1)
 else
 	RUSTFLAGS:=
 	TARGET=x86_64-unknown-linux-gnu
-	BUILD_ENVS="ROCKSDB_LIB_DIR= ROCKSDB_INCLUDE_DIR="
 endif
 
 CHANGE_BIN_VERSION = awk '{sub(/^version = ".+"$$/, "version = \"$(1)\"")}1' bin/Cargo.toml >> bin/Cargo.toml.tmp && mv bin/Cargo.toml.tmp bin/Cargo.toml

--- a/common/journald/Cargo.toml
+++ b/common/journald/Cargo.toml
@@ -30,5 +30,6 @@ partial_io = { package = "partial-io", version = "0.5", features = ["tokio1"]}
 tokio-test = "0.4"
 
 [features]
+default = []
 libjournald = ["systemd", "mio"]
 journald_tests = ["libjournald", "serial_test"]

--- a/docker/lib.sh
+++ b/docker/lib.sh
@@ -13,12 +13,14 @@ get_volume_mounts() {
 	if [ -z "$cargo_home" ]; then
 		cargo_home="/usr/local/cargo"
 	fi
-
+	if [ "$HOST_MACHINE" = "Mac" ] && [ "$CACHE_TARGET" != "false" ]; then
+		docker volume create agent-v2-cache > /dev/null
+		echo " -v agent-v2-cache:$1/target"
+	fi
 	if [ "$HOST_MACHINE" = "Mac" ]; then
 		# host mounts are hideously slow on Mac, create docker volumes instead
 		docker volume create cargo_cache > /dev/null
-		docker volume create agent-v2-cache > /dev/null
-		echo "-v cargo_cache:$cargo_home/registry -v agent-v2-cache:$1/target"
+		echo "-v cargo_cache:$cargo_home/registry"
 	elif [ "$HOST_MACHINE" = "Linux" ]; then
 		mkdir -p "$CARGO_CACHE/git" "$CARGO_CACHE/registry"
 		echo "-v $CARGO_CACHE/git:$cargo_home/git:Z -v $CARGO_CACHE/registry:$cargo_home/registry:Z"


### PR DESCRIPTION
This adds the ability to build a completely static agent binary using musl.

The binary is still built in docker using the existing build-image command. to configure it set the STATIC env var to 1 when calling make build-image