### PR TITLE
Support listing the current options

### DIFF
--- a/common/config/src/argv.rs
+++ b/common/config/src/argv.rs
@@ -183,6 +183,11 @@ pub struct ArgumentOptions {
     /// sending it in the log line.
     #[structopt(long, env = env::REDACT)]
     line_redact: Vec<String>,
+
+    /// Show the current agent settings from the configuration sources (default config file
+    /// and environment variables).
+    #[structopt(short = "l", long = "list")]
+    pub list_settings: bool,
 }
 
 impl ArgumentOptions {


### PR DESCRIPTION
Print the current merged settings in yaml format and exit.

Useful for troubleshooting on production environments.