### PR TITLE
docs(linux): dedupe installation instructions and update conf desc

### DIFF
--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -6,9 +6,9 @@ The LogDNA Agent for Linux collects log data from your Linux environment. The ag
   * [Installation: fresh installs](#Installation)
   * [Upgrading: migrating from legacy Linux agent](#upgrade-migration)
   * [Usage](#usage)
-   * [Enable the agent](#enable-the-agent)
-   * [Configure the agent](#configure-the-agent)
-   * [Run the agent](#run-the-agent)
+    * [Enable the agent](#enable-the-agent)
+    * [Configure the agent](#configure-the-agent)
+    * [Run the agent](#run-the-agent)
 
 ## Installation
 

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -1,34 +1,27 @@
 # LogDNA Agent on Linux distributions
 
-The agent is available as a Linux package for Debian-based distributions
-using apt and Red Hat-based distributions using yum. If you use a
-different package manager that does not support .deb or .rpm files, you
-can still use the agent by following the steps
-[here](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#building-agent-binary-on-linux)
-to manually compile its binary.
+The LogDNA Agent for Linux collects log data from your Linux environment. The agent is available as a Linux package for Debian-based distributions using `apt` and Red Hat-based distributions using `yum`. If you use a different package manager that does not support `.deb` or `.rpm` files, you can still use the agent by [manually compiling the binary](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#building-agent-binary-on-linux).
+
+## Table of Contents
+  * [Installation: fresh installs](#Installation)
+  * [Upgrading: migrating from legacy Linux agent](#upgrade-migration)
+  * [Usage](#usage)
+   * [Enable the agent](#enable-the-agent)
+   * [Configure the agent](#configure-the-agent)
+   * [Run the agent](#run-the-agent)
 
 ## Installation
-└ **Note** [for users upgrading from older versions of the [LogDNA Agent](https://github.com/logdna/logdna-agent-v2) or migrating from the [Legacy LogDNA Agent](https://github.com/logdna/logdna-agent)]:
-> Even if you have previously installed the `logdna-agent` Linux package, it is _still_ recommended to follow the appropriate instructions below to ensure that all users are retrieving the latest version of the package from the correct logdna source repository.
 
+1. To download the agent and resources package, open a host terminal and run the appropriate commands based on the Linux distribution.
 
-### _On Debian-based distributions_
+* Debian-based distributions
 ```bash
-# add logdna source repo → retrieve latest .deb file & manage package via apt
 echo "deb https://assets.logdna.com stable main" | sudo tee /etc/apt/sources.list.d/logdna.list
 wget -qO - https://assets.logdna.com/logdna.gpg | sudo apt-key add -
 sudo apt-get update
-
-# install the package via apt (skip this step if already installed)
-sudo apt-get install logdna-agent
-
-# update the package via apt
-sudo apt-get upgrade logdna-agent
 ```
-
-### _On Red Hat-based distributions_
+* RPM/Red Hat-based distributions
 ```bash
-# import latest .rpm file from logdna source repo → move into yum dir & manage package via yum
 sudo rpm --import https://assets.logdna.com/logdna.gpg
 echo "[logdna]
 name=LogDNA packages
@@ -36,22 +29,60 @@ baseurl=https://assets.logdna.com/el6/
 enabled=1
 gpgcheck=1
 gpgkey=https://assets.logdna.com/logdna.gpg" | sudo tee /etc/yum.repos.d/logdna.repo
+```
 
-# install the package via yum (skip this step if already installed)
+2. To upgrade the agent, use the commands below, based on the distro:
+
+* Debian-base distributions:
+```bash
+sudo apt-get install logdna-agent
+```
+* RPM/Red Hat-based distributions:
+```bash
 sudo yum -y install logdna-agent
+```
 
-# update the package via yum
+## Upgrade/migration
+└ **Note** [for users migrating from the [legacy LogDNA Agent](https://github.com/logdna/logdna-agent)]:
+> If you have previously installed the `logdna-agent` Linux package and have an existing `/etc/logdna.conf` file, it is _still_ recommended to follow the instructions below to ensure that all users are retrieving the latest version of the package from the correct source repository.
+
+1.  To download the agent and resources package, open a host terminal and run the appropriate commands based on the Linux distribution.
+
+* Debian-base distributions:
+```bash
+echo "deb https://assets.logdna.com stable main" | sudo tee /etc/apt/sources.list.d/logdna.list
+wget -qO - https://assets.logdna.com/logdna.gpg | sudo apt-key add -
+sudo apt-get update
+```
+
+* RPM/Red Hat-based distributions:
+```bash
+sudo rpm --import https://assets.logdna.com/logdna.gpg
+echo "[logdna]
+name=LogDNA packages
+baseurl=https://assets.logdna.com/el6/
+enabled=1
+gpgcheck=1
+gpgkey=https://assets.logdna.com/logdna.gpg" | sudo tee /etc/yum.repos.d/logdna.repo
+```
+
+2. To upgrade the agent, use the commands below, based on the distro:
+
+* Debian-base distributions:
+```bash
+sudo apt-get upgrade logdna-agent
+```
+* RPM/Red Hat-based distributions:
+```bash
 sudo yum update logdna-agent
 ```
 
 ## Usage
-
 The agent uses [**systemd**](https://systemd.io/) to run as a Linux daemon. The installed package provides a **systemd** unit file for the `logdna-agent` service, which is defined to execute a daemon process with the compiled agent binary. The process that is started in the service is managed by **systemd** and can be interfaced with using `systemctl`.
 
----
 ### _Enable the agent_
 
-1.  Reload the **systemd** unit files to ensure that the most recent version of the agent is used:
+1.  Reload the **systemd** unit files to obtain the most recent version of the agent:
 ```bash
     sudo systemctl daemon-reload
 ```
@@ -60,56 +91,43 @@ The agent uses [**systemd**](https://systemd.io/) to run as a Linux daemon. The 
 ```bash
     sudo systemctl enable logdna-agent
 ```
----
+
+
 ### _Configure the agent_
 
 └ Note \[for users upgrading /migrating from the [legacy LogDNA
-Agent](https://github.com/logdna/logdna-agent)\]: Many users will likely
-already have a configuration file `/etc/logdna.conf` from prior
-installations. While the config variable names have been changed /
-updated between the [Legacy LogDNA
-Agent](https://github.com/logdna/logdna-agent) and the current [LogDNA
-Agent](https://github.com/logdna/logdna-agent-v2), backward
-compatibility has been maintained so that older `/etc/logdna.conf` files
-are still valid. If this is applicable to you and there are no changes
-that need to be made, you can skip this section and start the service
-using your existing configuration.
+Agent](https://github.com/logdna/logdna-agent)\]: Many users will likely already have a configuration file `/etc/logdna.conf` from prior installations. The LogDNA Agent 3.3 does not utilize the legacy `/etc/logdna.conf` file, but instead uses a **systemd** unit file `/etc/logdna.env`.
+
 
 1.  Create the agent's configuration file (`logdna.env`) in the `/etc` directory, using the following command:
 
     ```bash
-    sudo touch /etc/logdna.env # it can initialized as an empty file, you will be adding to it in the steps below
+    sudo touch /etc/logdna.env
     ```
-    This file stores key-value pairs as environment variables that
-    are injected into the agent at runtime and manage a variety of
-    configuration options. You can see all the available variable
-    options via `logdna-agent --help` or refer to the table in the
-    [README.md file](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#options).
-    If you're migrating from the legacy agent, take note of the
-    variables which have been changed, updated, and deprecated when
-    compared to the [legacy LogDNA
-    Agent](https://github.com/logdna/logdna-agent).
+    The logdna.env file can be initialized as an empty file; you will add to it in the steps below. This file stores key-value pairs as environment variables that are injected into the agent at runtime and manage a variety of configuration options.
 
 2.  Edit the `/etc/logdna.env` file and set the `LOGDNA_INGESTION_KEY` variable:
     ```bash
     LOGDNA_INGESTION_KEY=<YOUR INGESTION KEY HERE>
     ```
 
-    The ingestion key is the only required variable, but you can set
+3. (_Optional_) The ingestion key is the only required variable, but you can set
     any additional variables in order to meet your desired
     configuration. For example, to attach a "production" tag to
     every log line, set the `LOGDNA_TAGS` variable in the
     `/etc/logdna.env` file:
 
     ```bash
-    LOGDNA_INGESTION_KEY=<YOUR INGESTION KEY HERE>
     LOGDNA_TAGS=production
     ```
----
+You can see all the available variable options by running the command `logdna-agent --help` or refer to them in our [README](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#options). If you're migrating from the legacy agent, take note of the variables that have are changed, updated, and deprecated when compared to the [legacy LogDNA
+Agent](https://github.com/logdna/logdna-agent).
+
+
 ### _Run the agent_
 
 1.  After you have added your ingestion key and configured your desired
-    settings, save the `/etc/logdna.env file` and then start the
+    settings, save the `/etc/logdna.env` file and then start the
     `logdna-agent` service using the `systemctl` command:
 
     ```bash

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -4,7 +4,7 @@ The LogDNA Agent for Linux collects log data from your Linux environment. The ag
 
 ## Table of Contents
   * [Installation: fresh installs](#Installation)
-  * [Upgrading: migrating from legacy Linux agent](#upgrade-migration)
+  * [Upgrading: migrating from legacy Linux agent](#upgrademigration)
   * [Usage](#usage)
     * [Enable the agent](#enable-the-agent)
     * [Configure the agent](#configure-the-agent)
@@ -20,7 +20,7 @@ echo "deb https://assets.logdna.com stable main" | sudo tee /etc/apt/sources.lis
 wget -qO - https://assets.logdna.com/logdna.gpg | sudo apt-key add -
 sudo apt-get update
 ```
-* **RPM/Red Hat-based distributions**
+* **RPM-based distributions**
 ```bash
 sudo rpm --import https://assets.logdna.com/logdna.gpg
 echo "[logdna]
@@ -31,20 +31,24 @@ gpgcheck=1
 gpgkey=https://assets.logdna.com/logdna.gpg" | sudo tee /etc/yum.repos.d/logdna.repo
 ```
 
-2. To upgrade the agent, use the commands below, based on the distro:
+2. To install the agent, use the commands below, based on the Linux distribution:
 
 * **Debian-based distributions:**
 ```bash
 sudo apt-get install logdna-agent
 ```
-* **RPM/Red Hat-based distributions:**
+* **RPM-based distributions:**
 ```bash
-sudo yum -y install logdna-agent
+sudo yum install logdna-agent
 ```
 
 ## Upgrade/migration
-└ **Note** [for users migrating from the [legacy LogDNA Agent](https://github.com/logdna/logdna-agent)]:
-> If you have previously installed the `logdna-agent` Linux package and have an existing `/etc/logdna.conf` file, it is _still_ recommended to follow the instructions below to ensure that all users are retrieving the latest version of the package from the correct source repository.
+
+---
+**NOTE**
+for users migrating from the [legacy LogDNA Agent](https://github.com/logdna/logdna-agent): If you have previously installed the `logdna-agent` Linux package and have an existing `/etc/logdna.conf` file, it is _still_ recommended to follow the instructions below to ensure that all users are retrieving the latest version of the package from the correct source repository.
+
+---
 
 1.  To download the agent and resources package, open a host terminal and run the appropriate commands based on the Linux distribution.
 
@@ -55,7 +59,7 @@ wget -qO - https://assets.logdna.com/logdna.gpg | sudo apt-key add -
 sudo apt-get update
 ```
 
-* **RPM/Red Hat-based distributions:**
+* **RPM-based distributions:**
 ```bash
 sudo rpm --import https://assets.logdna.com/logdna.gpg
 echo "[logdna]
@@ -72,7 +76,7 @@ gpgkey=https://assets.logdna.com/logdna.gpg" | sudo tee /etc/yum.repos.d/logdna.
 ```bash
 sudo apt-get upgrade logdna-agent
 ```
-* **RPM/Red Hat-based distributions:**
+* **RPM-based distributions:**
 ```bash
 sudo yum update logdna-agent
 ```
@@ -96,7 +100,7 @@ The agent uses [**systemd**](https://systemd.io/) to run as a Linux daemon. The 
 ### _Configure the agent_
 
 └ Note \[for users upgrading /migrating from the [legacy LogDNA
-Agent](https://github.com/logdna/logdna-agent)\]: Many users will likely already have a configuration file `/etc/logdna.conf` from prior installations. The LogDNA Agent 3.3 does not utilize the legacy `/etc/logdna.conf` file, but instead uses a **systemd** unit file `/etc/logdna.env`.
+Agent](https://github.com/logdna/logdna-agent)\]: Many users will likely already have a configuration file `/etc/logdna.conf` from prior installations. The LogDNA Agent 3.3 does support the legacy `/etc/logdna.conf` file by default, and additionally uses a **systemd** unit file `/etc/logdna.env`.
 
 
 1.  Create the agent's configuration file (`logdna.env`) in the `/etc` directory, using the following command:

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -99,9 +99,11 @@ The agent uses [**systemd**](https://systemd.io/) to run as a Linux daemon. The 
 
 ### _Configure the agent_
 
-└ Note \[for users upgrading /migrating from the [legacy LogDNA
-Agent](https://github.com/logdna/logdna-agent)\]: Many users will likely already have a configuration file `/etc/logdna.conf` from prior installations. The LogDNA Agent 3.3 does support the legacy `/etc/logdna.conf` file by default, and additionally uses a **systemd** unit file `/etc/logdna.env`.
+---
+**NOTE** for users upgrading /migrating from the [legacy LogDNA
+Agent](https://github.com/logdna/logdna-agent)\: Many users will likely already have a configuration file `/etc/logdna.conf` from prior installations. The LogDNA Agent 3.3 does support the legacy `/etc/logdna.conf` file by default, and additionally uses a **systemd** unit file `/etc/logdna.env`.
 
+---
 
 1.  Create the agent's configuration file (`logdna.env`) in the `/etc` directory, using the following command:
 
@@ -124,7 +126,7 @@ Agent](https://github.com/logdna/logdna-agent)\]: Many users will likely already
     ```bash
     LOGDNA_TAGS=production
     ```
-You can see all the available variable options by running the command `logdna-agent --help` or refer to them in our [README](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#options). If you're migrating from the legacy agent, take note of the variables that have are changed, updated, and deprecated when compared to the [legacy LogDNA
+   You can see all the available variable options by running the command `logdna-agent --help` or refer to them in our [README](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#options). If you're migrating from the legacy agent, take note of the variables that have are changed, updated, and deprecated when compared to the [legacy LogDNA
 Agent](https://github.com/logdna/logdna-agent).
 
 

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -10,7 +10,7 @@ to manually compile its binary.
 ## Installation
 └ **Note** [for users upgrading from older versions of the [LogDNA Agent](https://github.com/logdna/logdna-agent-v2) or migrating from the [Legacy LogDNA Agent](https://github.com/logdna/logdna-agent)]:
 > Even if you have previously installed the `logdna-agent` Linux package, it is _still_ recommended to follow the appropriate instructions below to ensure that all users are retrieving the latest version of the package from the correct logdna source repository.
-#
+
 
 ### _On Debian-based distributions_
 ```bash
@@ -43,23 +43,20 @@ sudo yum -y install logdna-agent
 # update the package via yum
 sudo yum update logdna-agent
 ```
-#
+
 ## Usage
 
-The agent uses [systemd](https://systemd.io/) to run as a Linux daemon.
-The installed package provides a systemd unit file for the logdna-agent
-service, which is defined to execute a daemon process with the compiled
-agent binary. The process that is started in the service is managed by
-systemd and can be interfaced with using systemctl.
+The agent uses [**systemd**](https://systemd.io/) to run as a Linux daemon. The installed package provides a **systemd** unit file for the `logdna-agent` service, which is defined to execute a daemon process with the compiled agent binary. The process that is started in the service is managed by **systemd** and can be interfaced with using `systemctl`.
+
 ---
 ### _Enable the agent_
 
-1.  Reload the systemd unit files to ensure that the most recent version of the agent is used:
+1.  Reload the **systemd** unit files to ensure that the most recent version of the agent is used:
 ```bash
     sudo systemctl daemon-reload
 ```
 
-2.  Enable the logdna-agent service using the systemctl command:
+2.  Enable the `logdna-agent` service using the `systemctl` command:
 ```bash
     sudo systemctl enable logdna-agent
 ```
@@ -68,17 +65,17 @@ systemd and can be interfaced with using systemctl.
 
 └ Note \[for users upgrading /migrating from the [legacy LogDNA
 Agent](https://github.com/logdna/logdna-agent)\]: Many users will likely
-already have a configuration file /etc/logdna.conf from prior
+already have a configuration file `/etc/logdna.conf` from prior
 installations. While the config variable names have been changed /
 updated between the [Legacy LogDNA
 Agent](https://github.com/logdna/logdna-agent) and the current [LogDNA
 Agent](https://github.com/logdna/logdna-agent-v2), backward
-compatibility has been maintained so that older /etc/logdna.conf files
+compatibility has been maintained so that older `/etc/logdna.conf` files
 are still valid. If this is applicable to you and there are no changes
 that need to be made, you can skip this section and start the service
 using your existing configuration.
 
-1.  Create the agent's configuration file (logdna.env) in the /etc directory, using the following command:
+1.  Create the agent's configuration file (`logdna.env`) in the ``/etc` directory, using the following command:
 
     ```bash
     sudo touch /etc/logdna.env # it can initialized as an empty file, you will be adding to it in the steps below
@@ -86,14 +83,14 @@ using your existing configuration.
     This file stores key-value pairs as environment variables that
     are injected into the agent at runtime and manage a variety of
     configuration options. You can see all the available variable
-    options via logdna-agent --help or refer to them
-    [here](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#options).
+    options via `logdna-agent --help` or refer to the table in the
+    [README.md file](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#options).
     If you're migrating from the legacy agent, take note of the
     variables which have been changed, updated, and deprecated when
-    compared to the [Legacy LogDNA
+    compared to the [legacy LogDNA
     Agent](https://github.com/logdna/logdna-agent).
 
-2.  Edit the/etc/logdna.env file and set the LOGDNA_INGESTION_KEY variable:
+2.  Edit the `/etc/logdna.env` file and set the `LOGDNA_INGESTION_KEY` variable:
     ```bash
     LOGDNA_INGESTION_KEY=<YOUR INGESTION KEY HERE>
     ```
@@ -101,8 +98,8 @@ using your existing configuration.
     The ingestion key is the only required variable, but you can set
     any additional variables in order to meet your desired
     configuration. For example, to attach a "production" tag to
-    every log line, set the LOGDNA_TAGS variable in the
-    /etc/logdna.conf file:\
+    every log line, set the `LOGDNA_TAGS` variable in the
+    `/etc/logdna.env` file:
 
     ```bash
     LOGDNA_INGESTION_KEY=<YOUR INGESTION KEY HERE>
@@ -112,15 +109,15 @@ using your existing configuration.
 ### _Run the agent_
 
 1.  After you have added your ingestion key and configured your desired
-    settings, save the etc/logdna.env file and then start the
-    logdna-agent service using the systemctl command:
+    settings, save the `/etc/logdna.env file` and then start the
+    `logdna-agent` service using the `systemctl` command:
 
     ```bash
     sudo systemctl start logdna-agent
     ```
 
 2.  Verify that the agent is running and log data flowing, using the
-    systemctl command to check the status of the agent:
+    `systemctl` command to check the status of the agent:
     ```bash
     systemctl status logdna-agent
     ```

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -14,13 +14,13 @@ The LogDNA Agent for Linux collects log data from your Linux environment. The ag
 
 1. To download the agent and resources package, open a host terminal and run the appropriate commands based on the Linux distribution.
 
-* Debian-based distributions
+* **Debian-based distributions**
 ```bash
 echo "deb https://assets.logdna.com stable main" | sudo tee /etc/apt/sources.list.d/logdna.list
 wget -qO - https://assets.logdna.com/logdna.gpg | sudo apt-key add -
 sudo apt-get update
 ```
-* RPM/Red Hat-based distributions
+* **RPM/Red Hat-based distributions**
 ```bash
 sudo rpm --import https://assets.logdna.com/logdna.gpg
 echo "[logdna]
@@ -33,11 +33,11 @@ gpgkey=https://assets.logdna.com/logdna.gpg" | sudo tee /etc/yum.repos.d/logdna.
 
 2. To upgrade the agent, use the commands below, based on the distro:
 
-* Debian-base distributions:
+* **Debian-based distributions:**
 ```bash
 sudo apt-get install logdna-agent
 ```
-* RPM/Red Hat-based distributions:
+* **RPM/Red Hat-based distributions:**
 ```bash
 sudo yum -y install logdna-agent
 ```
@@ -48,14 +48,14 @@ sudo yum -y install logdna-agent
 
 1.  To download the agent and resources package, open a host terminal and run the appropriate commands based on the Linux distribution.
 
-* Debian-base distributions:
+* **Debian-based distributions:**
 ```bash
 echo "deb https://assets.logdna.com stable main" | sudo tee /etc/apt/sources.list.d/logdna.list
 wget -qO - https://assets.logdna.com/logdna.gpg | sudo apt-key add -
 sudo apt-get update
 ```
 
-* RPM/Red Hat-based distributions:
+* **RPM/Red Hat-based distributions:**
 ```bash
 sudo rpm --import https://assets.logdna.com/logdna.gpg
 echo "[logdna]
@@ -68,11 +68,11 @@ gpgkey=https://assets.logdna.com/logdna.gpg" | sudo tee /etc/yum.repos.d/logdna.
 
 2. To upgrade the agent, use the commands below, based on the distro:
 
-* Debian-base distributions:
+* **Debian-based distributions:**
 ```bash
 sudo apt-get upgrade logdna-agent
 ```
-* RPM/Red Hat-based distributions:
+* **RPM/Red Hat-based distributions:**
 ```bash
 sudo yum update logdna-agent
 ```

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -75,7 +75,7 @@ are still valid. If this is applicable to you and there are no changes
 that need to be made, you can skip this section and start the service
 using your existing configuration.
 
-1.  Create the agent's configuration file (`logdna.env`) in the ``/etc` directory, using the following command:
+1.  Create the agent's configuration file (`logdna.env`) in the `/etc` directory, using the following command:
 
     ```bash
     sudo touch /etc/logdna.env # it can initialized as an empty file, you will be adding to it in the steps below

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -1,6 +1,11 @@
 # LogDNA Agent on Linux distributions
 
-The agent is available as a Linux package for Debian-based distributions using `apt` and Red Hat-based distributions using `yum`. If you use a different package manager that does not support `.deb` or `.rpm` files, you can still use the agent by following the steps [here](README.md#building-agent-binary-on-linux) to manually compile its binary.
+The agent is available as a Linux package for Debian-based distributions
+using apt and Red Hat-based distributions using yum. If you use a
+different package manager that does not support .deb or .rpm files, you
+can still use the agent by following the steps
+[here](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#building-agent-binary-on-linux)
+to manually compile its binary.
 
 ## Installation
 └ **Note** [for users upgrading from older versions of the [LogDNA Agent](https://github.com/logdna/logdna-agent-v2) or migrating from the [Legacy LogDNA Agent](https://github.com/logdna/logdna-agent)]:
@@ -40,55 +45,82 @@ sudo yum update logdna-agent
 ```
 #
 ## Usage
-The agent uses [systemd](https://systemd.io/) to run as a Linux daemon. The installed package provides a `systemd` unit file for the `logdna-agent` service, which is defined to execute a daemon process with the compiled agent binary. The process that is started in the service is managed by `systemd` and can be interfaced with using `systemctl`.
 
+The agent uses [systemd](https://systemd.io/) to run as a Linux daemon.
+The installed package provides a systemd unit file for the logdna-agent
+service, which is defined to execute a daemon process with the compiled
+agent binary. The process that is started in the service is managed by
+systemd and can be interfaced with using systemctl.
 ---
-### _Enabling the agent_
-- Reload the `systemd` unit files to ensure that the most recent version of the agent is used:
+### _Enable the agent_
 
-  ```bash
-  sudo systemctl daemon-reload
-  ```
+1.  Reload the systemd unit files to ensure that the most recent version of the agent is used:
+```bash
+    sudo systemctl daemon-reload
+```
 
-- Enable the `logdna-agent` service using the `systemctl` command:
-
-  ```bash
-  sudo systemctl enable logdna-agent
-  ``` 
+2.  Enable the logdna-agent service using the systemctl command:
+```bash
+    sudo systemctl enable logdna-agent
+```
 ---
-### _Configuring the agent_
-└ **Note** [for users upgrading from older versions of the [LogDNA Agent](https://github.com/logdna/logdna-agent-v2) or migrating from the [Legacy LogDNA Agent](https://github.com/logdna/logdna-agent)]: 
-  > Many users will likely already have a configuration file `/etc/logdna.conf` from prior installations. While the config variable names have been changed / updated between the [Legacy LogDNA Agent](https://github.com/logdna/logdna-agent) and the current [LogDNA Agent](https://github.com/logdna/logdna-agent-v2), backwards compatibility has been maintained so older `.conf` files are still valid. If this is applicable to you and there are no changes that need to be made, you can skip this section and start the service using your existing configuration.
-#
+### _Configure the agent_
 
-- By default, `/etc/logdna.conf` is the expected path for the agent's configuration file. Make sure to create this file if it doesn't exist since it's required to start the agent.
+└ Note \[for users upgrading /migrating from the [legacy LogDNA
+Agent](https://github.com/logdna/logdna-agent)\]: Many users will likely
+already have a configuration file /etc/logdna.conf from prior
+installations. While the config variable names have been changed /
+updated between the [Legacy LogDNA
+Agent](https://github.com/logdna/logdna-agent) and the current [LogDNA
+Agent](https://github.com/logdna/logdna-agent-v2), backward
+compatibility has been maintained so that older /etc/logdna.conf files
+are still valid. If this is applicable to you and there are no changes
+that need to be made, you can skip this section and start the service
+using your existing configuration.
+
+1.  Create the agent's configuration file (logdna.env) in the /etc directory, using the following command:
 
     ```bash
-    sudo touch /etc/logdna.conf # it can initialized as an empty file, you will be adding to it in the steps below
+    sudo touch /etc/logdna.env # it can initialized as an empty file, you will be adding to it in the steps below
     ```
-    This file stores key-value pairs as environment variables that can be injected into the agent at runtime and manage a variety of configuration options. You can see all the available variable options via `logdna-agent --help` or refer to them [here](README.md#options). If you're migrating from the legacy agent, take note of the variables which have been changed, updated, and deprecated when compared to the [Legacy LogDNA Agent](https://github.com/logdna/logdna-agent).
+    This file stores key-value pairs as environment variables that
+    are injected into the agent at runtime and manage a variety of
+    configuration options. You can see all the available variable
+    options via logdna-agent --help or refer to them
+    [here](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#options).
+    If you're migrating from the legacy agent, take note of the
+    variables which have been changed, updated, and deprecated when
+    compared to the [Legacy LogDNA
+    Agent](https://github.com/logdna/logdna-agent).
 
-- Before starting the `logdna-agent` service, you must add an ingestion key setting the `LOGDNA_INGESTION_KEY` variable in `/etc/logdna.conf`:
-  
-  ```edit /etc/logdna.conf
-  LOGDNA_INGESTION_KEY=<YOUR INGESTION KEY HERE>
-  ```
-  The ingestion key is the only required variable, but you can set any additional variables in order to meet your desired configuration. For example, to attach a "production" tag to every log line, you could set the `LOGDNA_TAGS` variable in `/etc/logdna.conf`:
+2.  Edit the/etc/logdna.env file and set the LOGDNA_INGESTION_KEY variable:
+    ```bash
+    LOGDNA_INGESTION_KEY=<YOUR INGESTION KEY HERE>
+    ```
 
-  ```edit etc/logdna.conf
-  LOGDNA_INGESTION_KEY=<YOUR INGESTION KEY HERE>
-  LOGDNA_TAGS=production
-  ```
+    The ingestion key is the only required variable, but you can set
+    any additional variables in order to meet your desired
+    configuration. For example, to attach a "production" tag to
+    every log line, set the LOGDNA_TAGS variable in the
+    /etc/logdna.conf file:\
+
+    ```bash
+    LOGDNA_INGESTION_KEY=<YOUR INGESTION KEY HERE>
+    LOGDNA_TAGS=production
+    ```
 ---
-### _Running the agent_
-- After you have configured your desired settings, save the `etc/logdna.conf` file and then start the `logdna-agent` service using the `systemctl` command:
-  
-  ```bash
-  sudo systemctl start logdna-agent
-  ```
-  
-- You can check the status of the agent using the `systemctl` command:
+### _Run the agent_
 
-  ```bash
-  systemctl status logdna-agent
-  ```
+1.  After you have added your ingestion key and configured your desired
+    settings, save the etc/logdna.env file and then start the
+    logdna-agent service using the systemctl command:
+
+    ```bash
+    sudo systemctl start logdna-agent
+    ```
+
+2.  Verify that the agent is running and log data flowing, using the
+    systemctl command to check the status of the agent:
+    ```bash
+    systemctl status logdna-agent
+    ```


### PR DESCRIPTION
* Added some more detail about the compatibility of the agent with the listed Linux distros
* Deduped the install/upgrade instructions since it's safe for people in either camp to fully follow along with the appropriate instructions for their OS distribution type
*  Added some header notes in the relevant sections to cover our bases in terms of supporting these 3 end-users / scenarios
    * User doing a new / fresh install of the *Linux* agent - notes aren't applicable to them, they can & should run every command in the instructions
    * User upgrading from a older version of `logdna-agent-v2` - they can skip the `install logdna-agent` command if they've ever installed the Linux package for the current agent OR the legacy agent and just update their package. Running through these steps will also ensure that they're pulling the latest version from the correct source repository.
    * User migrating from the legacy client `logdna-agent` - similar to above, they can skip the `install logdna-agent` step if they've ever installed the Linux package and just update the agent. The most recent release of `logdna-agent-v2` automates the teardown and removal process of the legacy client as well.
* Fleshed out the description/explanation of the `logdna-agent` service managed by `systemd` & updated the usage instructions to reflect the standard configuration process for the agent
    * The default filepath for the agent's configuration file is `/etc/logdna.conf` and its expected to be plain text file which stores environment variables as key-value pairs to be passed into the agent at runtime