### PR TITLE
Get arm64 musl build working

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,6 +163,7 @@ pipeline {
                                 echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds_static
                                 echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${PWD}/.aws_creds_static
                                 STATIC=1 make publish-s3-binary
+                                ARCH=aarch64 STATIC=1 make publish-s3-binary
                                 rm ${PWD}/.aws_creds_static
                             '''
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,23 +131,6 @@ pipeline {
                                 echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds_static
                                 echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${PWD}/.aws_creds_static
                                 STATIC=1 FEATURES= make build-release AWS_SHARED_CREDENTIALS_FILE=${PWD}/.aws_creds_static
-                                rm ${PWD}/.aws_creds_static
-                            '''
-                        }
-                    }
-                }
-                stage('Build aarch64 static release binary') {
-                    steps {
-                        withCredentials([[
-                            $class: 'AmazonWebServicesCredentialsBinding',
-                            credentialsId: 'aws',
-                            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                        ]]) {
-                            sh '''
-                                echo "[default]" > ${PWD}/.aws_creds_static
-                                echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds_static
-                                echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${PWD}/.aws_creds_static
                                 ARCH=aarch64 STATIC=1 FEATURES= make build-release AWS_SHARED_CREDENTIALS_FILE=${PWD}/.aws_creds_static
                                 rm ${PWD}/.aws_creds_static
                             '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,24 @@ pipeline {
                         }
                     }
                 }
-
+                stage('Build aarch64 static release binary') {
+                    steps {
+                        withCredentials([[
+                            $class: 'AmazonWebServicesCredentialsBinding',
+                            credentialsId: 'aws',
+                            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                        ]]) {
+                            sh '''
+                                echo "[default]" > ${PWD}/.aws_creds_static
+                                echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds_static
+                                echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${PWD}/.aws_creds_static
+                                ARCH=aarch64 STATIC=1 FEATURES= make build-release AWS_SHARED_CREDENTIALS_FILE=${PWD}/.aws_creds_static
+                                rm ${PWD}/.aws_creds_static
+                            '''
+                        }
+                    }
+                }
             }
         }
         stage('Check Publish Images') {

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -37,7 +37,7 @@ log = "0.4"
 env_logger = "0.8"
 anyhow = "1"
 serde_yaml = "0.8"
-jemallocator = "0.3"
+jemallocator = { version = "0.3", default-features = false, features = ["stats"] }
 futures = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "signal"] }
 tokio-stream = "0.1"

--- a/common/config/Cargo.toml
+++ b/common/config/Cargo.toml
@@ -13,7 +13,6 @@ http = { package = "http", path = "../http" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 globber = "0.1"
-pcre2 = "0.2"
 lazy_static = "1.0"
 async-compression = "0.3"
 log = "0.4"

--- a/common/config/src/error.rs
+++ b/common/config/src/error.rs
@@ -11,7 +11,7 @@ pub enum ConfigError {
     PropertyInvalid(String),
     Template(http::types::error::TemplateError),
     Glob(globber::Error),
-    Regex(pcre2::Error),
+    Regex(fs::rule::RuleError),
     NotADirectory(fs::cache::DirPathBufError),
     Lookback(fs::tail::ParseLookbackError),
 }
@@ -65,8 +65,8 @@ impl From<globber::Error> for ConfigError {
     }
 }
 
-impl From<pcre2::Error> for ConfigError {
-    fn from(e: pcre2::Error) -> Self {
+impl From<fs::rule::RuleError> for ConfigError {
+    fn from(e: fs::rule::RuleError) -> Self {
         ConfigError::Regex(e)
     }
 }

--- a/common/fs/Cargo.toml
+++ b/common/fs/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0"
 #utils
 bytes = "1"
 chrono = "0.4"
-pcre2 = "0.2"
+pcre2 = { git = "https://github.com/logdna/rust-pcre2.git", branch="0.2", version = "0.2" }
 globber = "0.1"
 slotmap = "1"
 smallvec = "1"

--- a/common/fs/src/rule.rs
+++ b/common/fs/src/rule.rs
@@ -26,6 +26,14 @@ pub enum Status {
     Ok,
 }
 
+#[derive(std::fmt::Debug, thiserror::Error)]
+pub enum RuleError {
+    #[error("{0}")]
+    Regex(RegexError),
+    #[error("{0}")]
+    Pattern(PatternError),
+}
+
 impl Status {
     /// Converts a status into a bool, returning true if the status is ok and false otherwise
     pub fn is_ok(&self) -> bool {
@@ -106,9 +114,9 @@ pub struct RegexRule {
 
 impl RegexRule {
     /// Creates a new RegexRule from a pattern
-    pub fn new<'a, T: Into<&'a str>>(pattern: T) -> Result<Self, RegexError> {
+    pub fn new<'a, T: Into<&'a str>>(pattern: T) -> Result<Self, RuleError> {
         Ok(Self {
-            inner: Regex::new(pattern.into())?,
+            inner: Regex::new(pattern.into()).map_err(RuleError::Regex)?,
         })
     }
 }
@@ -122,7 +130,7 @@ impl Rule for RegexRule {
 }
 
 impl FromStr for RegexRule {
-    type Err = RegexError;
+    type Err = RuleError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         RegexRule::new(s)
@@ -137,9 +145,9 @@ pub struct GlobRule {
 
 impl GlobRule {
     /// Creates a new GlobRule from a pattern
-    pub fn new<'a, T: Into<&'a str>>(pattern: T) -> Result<Self, PatternError> {
+    pub fn new<'a, T: Into<&'a str>>(pattern: T) -> Result<Self, RuleError> {
         Ok(Self {
-            inner: Pattern::new(pattern.into())?,
+            inner: Pattern::new(pattern.into()).map_err(RuleError::Pattern)?,
         })
     }
 }
@@ -151,7 +159,7 @@ impl Rule for GlobRule {
 }
 
 impl FromStr for GlobRule {
-    type Err = PatternError;
+    type Err = RuleError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         GlobRule::new(s)

--- a/common/k8s/Cargo.toml
+++ b/common/k8s/Cargo.toml
@@ -22,8 +22,8 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 futures = "0.3"
 thiserror = "1.0"
 parking_lot = "0.11"
-kube = "0.52"
-kube-runtime = "0.52"
+kube = { version = "0.52", default-features = false, features = ["rustls-tls"] }
+kube-runtime = { version = "0.52", default-features = false, features = ["rustls-tls"] }
 k8s-openapi = { version = "0.11", default_features = false, features = ["v1_12"] }
 serde = { version = "1", features = ["derive"]}
 serde_json = "1"


### PR DESCRIPTION
This gets Aarch64 builds working.

Unfortunately I had to drop PCRE2 from config and switch kube-runtime over to rustls to get around compiler errors, so this is a bigger change than I'd hoped. Functionality changes should be minimal to zero though.