### PR TITLE
Update k8s base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     sccache --show-stats
 
 # Use Red Hat Universal Base Image Minimal as the final base image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG REPO
 ARG BUILD_TIMESTAMP


### PR DESCRIPTION
Redhat released ubi 8.4 a few months ago. Seems pretty low risk to bump this