### PR TITLE
Docs delete section

### DIFF
--- a/docs/INTERNAL_METRICS.md
+++ b/docs/INTERNAL_METRICS.md
@@ -20,7 +20,7 @@ Linux:
 
 ```
 
-To expose the metrics that are agent-related, use the prefix `logdna_agent_`. To expose metrics about process status information (e.g.memory and CPU usage), use the prefix  `process_`.
+To access the metrics that are agent-related, use the prefix `logdna_agent_`. To access metrics about process status information (e.g.memory and CPU usage), use the prefix  `process_`.
 
 ## Enabling Prometheus target discovery on Kubernetes
 
@@ -45,9 +45,9 @@ After applying the DaemonSet with the Prometheus annotations, the metrics will b
 ## Metrics in log messages
 
 The agent also publishes its internal metrics every minute as a log line. This was useful in older versions for
-observability, but it's now deprecated in favor of Prometheus support.
+observability.
 
-If you want to continue using these log line metrics, you should consider that there has been the following changes in
+Prometheus metrics provide further detail and granularity than log messages. If you want to continue using these log line metrics, you should consider that there has been the following changes in
 version 3.3 and above of the agent:
 
 - Counters such as `"fs.events"`, `"ingest.requests"` and `"ingest.requests_size"`, etc are now monotonically

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -14,9 +14,9 @@ The LogDNA Agent for Linux collects log data from your Linux environment. The ag
 ## Considerations
 * The agent provides a "stateful" or persistent set of files that is available for reference whenever the agent is restarted; this allows for a configurable `lookback` option. For details, refer to our documentation about [configuring lookback](README.md/#configuring-lookback) and the [configuration options](README.md/#options) for environment variables.
 
-## Installation
+## Installation (first-time installations)
 
-1. To download the agent and resources package, open a host terminal and run the appropriate commands based on the Linux distribution.
+1. To add the logdna repository to your package manager, open a host terminal and run the appropriate commands based on the Linux distribution.
 
 * **Debian-based distributions**
 ```bash
@@ -54,7 +54,7 @@ for users migrating from the [legacy LogDNA Agent](https://github.com/logdna/log
 
 ---
 
-1.  To download the agent and resources package, open a host terminal and run the appropriate commands based on the Linux distribution.
+1.  To add the logdna repository to your package manager, open a host terminal and run the appropriate commands based on the Linux distribution.
 
 * **Debian-based distributions:**
 ```bash
@@ -88,18 +88,6 @@ sudo yum update logdna-agent
 ## Usage
 The agent uses [**systemd**](https://systemd.io/) to run as a Linux daemon. The installed package provides a **systemd** unit file for the `logdna-agent` service, which is defined to execute a daemon process with the compiled agent binary. The process that is started in the service is managed by **systemd** and can be interfaced with using `systemctl`.
 
-### _Enable the agent_
-
-1.  Reload the **systemd** unit files to obtain the most recent version of the agent:
-```bash
-    sudo systemctl daemon-reload
-```
-
-2.  Enable the `logdna-agent` service using the `systemctl` command:
-```bash
-    sudo systemctl enable logdna-agent
-```
-
 
 ### _Configure the agent_
 
@@ -130,9 +118,7 @@ Agent](https://github.com/logdna/logdna-agent)\: You might already have a config
     ```bash
     LOGDNA_TAGS=production
     ```
-   You can see all the available variable options by running the command `logdna-agent --help` or refer to them in our [README](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#options). If you're migrating from the legacy agent, take note of the variables that have are changed, updated, and deprecated when compared to the [legacy LogDNA
-Agent](https://github.com/logdna/logdna-agent).
-
+   You can see all the available variable options by running the command `logdna-agent --help` or refer to them in our [README](https://github.com/logdna/logdna-agent-v2/blob/eb06d4f3f7c1033b494f1f0439957f96533f9225/docs/README.md#options). If you're migrating from the legacy agent, take note of the variables that have are changed, updated, and deprecated when compared to the [legacy LogDNA Agent](https://github.com/logdna/logdna-agent).
 
 ### _Run the agent_
 
@@ -144,8 +130,16 @@ Agent](https://github.com/logdna/logdna-agent).
     sudo systemctl start logdna-agent
     ```
 
+    **Note:**  If the agent was already running when you made configuration changes, you must restart the agent for the new configuration to take effect, using the `sudo systemctl restart logdna-agent` command.
+
+
 2.  Verify that the agent is running and log data flowing, using the
     `systemctl` command to check the status of the agent:
     ```bash
     systemctl status logdna-agent
+    ```
+
+3. To enable the agent on boot run the command:
+    ```bash
+    sudo systemctl enable logdna-agent
     ```


### PR DESCRIPTION
Edits per Chris' suggestions for removing the "Enable the agent"  section, and adding the `enable` step to be the last part of "Starting the agent" section.