### PR TITLE
Build static binaries with 64k page size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ ifeq ($(STATIC), 1)
 	RUSTFLAGS:=-C link-self-contained=yes -Ctarget-feature=+crt-static -Clink-arg=-static -Clink-arg=-static-libstdc++ -Clink-arg=-static-libgcc -L /usr/local/$(ARCH)-linux-musl/lib/ -l static=stdc++ $(RUSTFLAGS)
 	BINDGEN_EXTRA_CLANG_ARGS:=-I /usr/local/$(ARCH)-linux-musl/include
 	TARGET=$(ARCH)-unknown-linux-musl
-	BUILD_ENVS=ROCKSDB_LIB_DIR=/usr/local/rocksdb/$(ARCH)-linux-musl/lib ROCKSDB_INCLUDE_DIR=/usr/local/rocksdb/$(ARCH)-linux-musl/include ROCKSDB_STATIC=1
+	BUILD_ENVS=ROCKSDB_LIB_DIR=/usr/local/rocksdb/$(ARCH)-linux-musl/lib ROCKSDB_INCLUDE_DIR=/usr/local/rocksdb/$(ARCH)-linux-musl/include ROCKSDB_STATIC=1 JEMALLOC_SYS_WITH_LG_PAGE=16
 else
 	RUSTFLAGS:=
 endif


### PR DESCRIPTION
RHEL 8 on ARM configures the kernel with a 65536 byte page size rather than the more usual 4k page size. By default Jemalloc picks up the page size on the build system and hard codes that into the binary.

Previously Jemalloc required it's compiled in page size to be the same as the system's in order to maintain alignment, however as of a year or so ago it now supports using a larger than native page size, at the cost of a small amount of performance.

This explicitly sets the jemalloc page size to 64k, I've tested the generated binary on both RHEL and Debian and it runs correctly on both.