### PR TITLE
Tweak buffer sizes and timeouts and raise some logging thresholds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
+checksum = "81cf2cc85830eae84823884db23c5306442a6c3d5bfd3beb2f2a2c829faa1816"
 dependencies = [
  "glob",
  "libc",
@@ -933,9 +933,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.11"
+version = "0.14.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
+checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "logdna-agent"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1946,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd94b6e266c4d2865f4e514af50a409625291daf7dc914609e0f3415719382d"
+checksum = "2351cbef4bf91837f5ff7face6091cb277ba960d1638d2c5ae2327859912fbba"
 dependencies = [
  "chrono",
  "pem",
@@ -2148,9 +2148,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1056a0db1978e9dbf0f6e4fca677f6f9143dc1c19de346f22cac23e422196834"
+checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
 dependencies = [
  "serde_derive",
 ]
@@ -2167,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13af2fbb8b60a8950d6c72a56d2095c28870367cc8e10c55e9745bac4995a2c4"
+checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2461,9 +2461,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
+checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
 dependencies = [
  "autocfg",
  "bytes",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "logdna-agent"
-version = "3.2.4"
+version = "3.2.5"
 authors = ["CJP10 <connor.peticca@logdna.com>"]
 edition = "2018"
 build = "build.rs"

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -98,15 +98,15 @@ impl Default for HttpConfig {
             host: Some("logs.logdna.com".to_string()),
             endpoint: Some("/logs/agent".to_string()),
             use_ssl: Some(true),
-            timeout: Some(10_000),
+            timeout: Some(25_000),
             use_compression: Some(true),
-            gzip_level: Some(2),
+            gzip_level: Some(9),
             ingestion_key: None,
             params: Params::builder()
                 .hostname(get_hostname().unwrap_or_default())
                 .build()
                 .ok(),
-            body_size: Some(2 * 1024 * 1024),
+            body_size: Some(2 * 1024 * 1024 + 5 * 1024),
             retry_base_delay_ms: None,
             retry_step_delay_ms: None,
         }

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -106,7 +106,7 @@ impl Default for HttpConfig {
                 .hostname(get_hostname().unwrap_or_default())
                 .build()
                 .ok(),
-            body_size: Some(2 * 1024 * 1024 + 5 * 1024),
+            body_size: Some(2 * 1024 * 1024),
             retry_base_delay_ms: None,
             retry_step_delay_ms: None,
         }

--- a/common/fs/src/cache/tailed_file.rs
+++ b/common/fs/src/cache/tailed_file.rs
@@ -517,7 +517,7 @@ impl Stream for LazyLines {
                     *total_read += count.get();
                     // Got a line
                     debug_assert_eq!(*read, 0);
-                    debug!("tailer sendings lines for {:?}", &paths);
+                    trace!("tailer sendings lines for {:?}", &paths);
                     let count = TryInto::<u64>::try_into(count.get()).unwrap();
                     Metrics::fs().add_bytes(count);
                     *offset += count;
@@ -642,7 +642,7 @@ impl TailedFile<LineBuilder> {
                             let paths = paths.clone();
                             line_res.ok().map({
                                 move |line| {
-                                    debug!("tailer sendings lines for {:?}", paths);
+                                    trace!("tailer sendings lines for {:?}", paths);
                                     futures::stream::iter(paths.into_iter().map({
                                         move |path| {
                                             Metrics::fs().increment_lines();

--- a/common/fs/src/cache/tailed_file.rs
+++ b/common/fs/src/cache/tailed_file.rs
@@ -517,7 +517,7 @@ impl Stream for LazyLines {
                     *total_read += count.get();
                     // Got a line
                     debug_assert_eq!(*read, 0);
-                    trace!("tailer sendings lines for {:?}", &paths);
+                    debug!("tailer sendings lines for {:?}", &paths);
                     let count = TryInto::<u64>::try_into(count.get()).unwrap();
                     Metrics::fs().add_bytes(count);
                     *offset += count;
@@ -642,7 +642,7 @@ impl TailedFile<LineBuilder> {
                             let paths = paths.clone();
                             line_res.ok().map({
                                 move |line| {
-                                    trace!("tailer sendings lines for {:?}", paths);
+                                    debug!("tailer sendings lines for {:?}", paths);
                                     futures::stream::iter(paths.into_iter().map({
                                         move |path| {
                                             Metrics::fs().increment_lines();

--- a/common/http/src/client.rs
+++ b/common/http/src/client.rs
@@ -90,7 +90,7 @@ impl Client {
                 Ok((offsets, Some(body))) => {
                     if let (Some(sw), Some(offsets)) = (self.state_write.as_ref(), &offsets) {
                         for (file_name, offset) in offsets {
-                            debug!("Updating offset for {:?} to {}", file_name, *offset);
+                            trace!("Updating offset for {:?} to {}", file_name, *offset);
                             if let Err(e) = sw.update(file_name, *offset).await {
                                 error!("Unable to write offsets. error: {}", e);
                             };
@@ -121,7 +121,7 @@ impl Client {
             Ok(_) => {
                 if let Some(wh) = self.state_write.as_ref() {
                     if let (Some(key), Some(offset)) = (key.as_ref(), offset) {
-                        debug!("Updating offset for {:?} to {}", key, offset);
+                        trace!("Updating offset for {:?} to {}", key, offset);
                         wh.update(key, offset).await.unwrap();
                     }
                 }

--- a/k8s/agent-namespace.yaml
+++ b/k8s/agent-namespace.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5

--- a/k8s/agent-resources-openshift-supertenant.yaml
+++ b/k8s/agent-resources-openshift-supertenant.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -21,7 +21,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -38,7 +38,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -54,7 +54,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -72,7 +72,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -87,12 +87,12 @@ spec:
         app: logdna-agent
         app.kubernetes.io/name: logdna-agent
         app.kubernetes.io/instance: logdna-agent
-        app.kubernetes.io/version: 3.2.4
+        app.kubernetes.io/version: 3.2.5
     spec:
       serviceAccountName: logdna-agent
       containers:
         - name: logdna-agent
-          image: logdna/logdna-agent:3.2.4
+          image: logdna/logdna-agent:3.2.5
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/k8s/agent-resources-openshift.yaml
+++ b/k8s/agent-resources-openshift.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -21,7 +21,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -38,7 +38,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -54,7 +54,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -72,7 +72,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -87,12 +87,12 @@ spec:
         app: logdna-agent
         app.kubernetes.io/name: logdna-agent
         app.kubernetes.io/instance: logdna-agent
-        app.kubernetes.io/version: 3.2.4
+        app.kubernetes.io/version: 3.2.5
     spec:
       serviceAccountName: logdna-agent
       containers:
         - name: logdna-agent
-          image: logdna/logdna-agent:3.2.4
+          image: logdna/logdna-agent:3.2.5
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/k8s/agent-resources-supertenant.yaml
+++ b/k8s/agent-resources-supertenant.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -17,7 +17,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -31,7 +31,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -48,7 +48,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -64,7 +64,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -82,7 +82,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -97,12 +97,12 @@ spec:
         app: logdna-agent
         app.kubernetes.io/name: logdna-agent
         app.kubernetes.io/instance: logdna-agent
-        app.kubernetes.io/version: 3.2.4
+        app.kubernetes.io/version: 3.2.5
     spec:
       serviceAccountName: logdna-agent
       containers:
         - name: logdna-agent
-          image: logdna/logdna-agent:3.2.4
+          image: logdna/logdna-agent:3.2.5
           imagePullPolicy: Always
           securityContext:
             capabilities:

--- a/k8s/agent-resources.yaml
+++ b/k8s/agent-resources.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -17,7 +17,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -31,7 +31,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -48,7 +48,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -64,7 +64,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -82,7 +82,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -97,12 +97,12 @@ spec:
         app: logdna-agent
         app.kubernetes.io/name: logdna-agent
         app.kubernetes.io/instance: logdna-agent
-        app.kubernetes.io/version: 3.2.4
+        app.kubernetes.io/version: 3.2.5
     spec:
       serviceAccountName: logdna-agent
       containers:
         - name: logdna-agent
-          image: logdna/logdna-agent:3.2.4
+          image: logdna/logdna-agent:3.2.5
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/k8s/mock-ingester.yaml
+++ b/k8s/mock-ingester.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -16,7 +16,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -26,7 +26,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -40,7 +40,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -57,7 +57,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -73,7 +73,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -91,7 +91,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logdna-agent
     app.kubernetes.io/instance: logdna-agent
-    app.kubernetes.io/version: 3.2.4
+    app.kubernetes.io/version: 3.2.5
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -106,12 +106,12 @@ spec:
         app: logdna-agent
         app.kubernetes.io/name: logdna-agent
         app.kubernetes.io/instance: logdna-agent
-        app.kubernetes.io/version: 3.2.4
+        app.kubernetes.io/version: 3.2.5
     spec:
       serviceAccountName: logdna-agent
       containers:
         - name: logdna-agent
-          image: logdna/logdna-agent:3.2.4
+          image: logdna/logdna-agent:3.2.5
           imagePullPolicy: Always
           env:
             - name: LOGDNA_AGENT_KEY


### PR DESCRIPTION
Bump Timeout to 25 seconds, default gzip ratio to "best" (9), and buffer size to 2.5MB which seemed to be about the right size.

The numbers above were obtained from testing against logs.logdna.com while the environment was under peak load.