### PR TITLE
Add timeout to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ def publishDockerhubICRImages = false
 pipeline {
     agent any
     options {
+        timeout time: 1, unit: 'HOURS'
         timestamps()
         ansiColor 'xterm'
     }


### PR DESCRIPTION
* we've seen jobs hanging on Jenkins, so add a 1 hour timeout to prevent it
  from continuing.
* looking at the recent jobs that passed, they took between 35 and 50 minutes,
  so 1 hour should be enough, but we can bump this up if we see too many jobs
  timeout
