### PR TITLE
fix: create state dir if possible

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -433,8 +433,8 @@ async fn get_signal() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
     use config::DbPath;
+    use std::fs::File;
     use tempfile::tempdir;
 
     #[test]
@@ -446,13 +446,20 @@ mod tests {
             .join("a")
             .join("ghostly")
             .join("path");
-        assert!(!missing_state_dir.exists(), "test prereq failed: {:?} reported as already existing", missing_state_dir);
-        
+        assert!(
+            !missing_state_dir.exists(),
+            "test prereq failed: {:?} reported as already existing",
+            missing_state_dir
+        );
+
         let test_db_path = DbPath::from(Some(missing_state_dir.clone()));
         let result = load_agent_state(&test_db_path).unwrap();
 
         assert!(result.is_some(), "failed to create valid AgentState struct");
-        assert!(missing_state_dir.exists(), "state directory was not created");
+        assert!(
+            missing_state_dir.exists(),
+            "state directory was not created"
+        );
     }
 
     #[test]
@@ -462,15 +469,27 @@ mod tests {
         use std::os::unix::fs::DirBuilderExt;
 
         let noperm_dir = tempdir().unwrap().into_path().join("denied");
-        assert!(!noperm_dir.exists(), "test prereq failed: {:?} reported as already existing", noperm_dir);
+        assert!(
+            !noperm_dir.exists(),
+            "test prereq failed: {:?} reported as already existing",
+            noperm_dir
+        );
         DirBuilder::new()
             .mode(0o000) // is only supported with the unix extension
             .create(&noperm_dir)
             .unwrap();
 
-        assert!(noperm_dir.exists(), "test preqreq failed: failed to create {:?}", noperm_dir);
-        assert!(noperm_dir.metadata().unwrap().permissions().readonly(), "test prereq failed: {:?} is not read only", noperm_dir);
-        
+        assert!(
+            noperm_dir.exists(),
+            "test preqreq failed: failed to create {:?}",
+            noperm_dir
+        );
+        assert!(
+            noperm_dir.metadata().unwrap().permissions().readonly(),
+            "test prereq failed: {:?} is not read only",
+            noperm_dir
+        );
+
         let test_db_path = DbPath::from(Some(noperm_dir.clone()));
         let result = load_agent_state(&test_db_path).unwrap_err();
 

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -27,7 +27,7 @@ use middleware::line_rules::LineRules;
 use middleware::Executor;
 
 use pin_utils::pin_mut;
-use state::AgentState;
+use state::{AgentState, StateError};
 use std::cell::RefCell;
 use std::rc::Rc;
 use tokio::signal::*;
@@ -70,28 +70,25 @@ async fn main() {
     let mut _agent_state = None;
     let mut offset_state = None;
     let mut initial_offsets = None;
-    if let DbPath::Path(path) = config.log.db_path {
-        if path.is_dir() {
-            match AgentState::new(path) {
-                Ok(agent_state) => {
-                    let _offset_state = agent_state.get_offset_state();
-                    let offsets = _offset_state.offsets();
-                    _agent_state = Some(agent_state);
-                    offset_state = Some(_offset_state);
-                    match offsets {
-                        Ok(os) => {
-                            initial_offsets =
-                                Some(os.into_iter().map(|fo| (fo.key, fo.offset)).collect());
-                        }
-                        Err(e) => warn!("couldn't retrieve offsets from agent state, {:?}", e),
+
+    match load_agent_state(&config.log.db_path) {
+        Ok(load_state_result) => {
+            if let Some(agent_state) = load_state_result {
+                let _offset_state = agent_state.get_offset_state();
+                let offsets = _offset_state.offsets();
+                _agent_state = Some(agent_state);
+                offset_state = Some(_offset_state);
+                match offsets {
+                    Ok(os) => {
+                        initial_offsets =
+                            Some(os.into_iter().map(|fo| (fo.key, fo.offset)).collect());
                     }
-                }
-                Err(e) => {
-                    error!("Failed to open agent state db {}", e);
+                    Err(e) => warn!("couldn't retrieve offsets from agent state, {:?}", e),
                 }
             }
-        } else {
-            error!("{} is not a directory", path.to_string_lossy());
+        }
+        Err(e) => {
+            error!("Failed to open agent state db {}", e);
         }
     }
 
@@ -326,6 +323,24 @@ async fn main() {
     }
 }
 
+fn load_agent_state(db_path: &DbPath) -> Result<Option<AgentState>, StateError> {
+    if let DbPath::Path(path) = &db_path {
+        if !path.exists() {
+            std::fs::create_dir_all(path).map_err(StateError::IoError)?;
+        }
+
+        if path.is_dir() {
+            let state = AgentState::new(path)?;
+            Ok(Some(state))
+        } else {
+            error!("{} is not a directory", path.to_string_lossy());
+            Err(StateError::InvalidPath(path.to_path_buf()))
+        }
+    } else {
+        Ok(None)
+    }
+}
+
 #[cfg(unix)]
 async fn get_signal() -> &'static str {
     let mut interrupt_signal = unix::signal(unix::SignalKind::interrupt()).unwrap();
@@ -343,4 +358,78 @@ async fn get_signal() -> &'static str {
 async fn get_signal() -> &'static str {
     ctrl_c().await.unwrap();
     "CTRL+C"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use config::DbPath;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_agent_state_dir_missing() {
+        // build a path with multiple levels of missing directories to ensure they're all created
+        let missing_state_dir = tempdir()
+            .unwrap()
+            .into_path()
+            .join("a")
+            .join("ghostly")
+            .join("path");
+        assert!(!missing_state_dir.exists(), "test prereq failed: {:?} reported as already existing", missing_state_dir);
+        
+        let test_db_path = DbPath::from(Some(missing_state_dir.clone()));
+        let result = load_agent_state(&test_db_path).unwrap();
+
+        assert!(result.is_some(), "failed to create valid AgentState struct");
+        assert!(missing_state_dir.exists(), "state directory was not created");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn load_agent_state_dir_create_error() {
+        use std::fs::DirBuilder;
+        use std::os::unix::fs::DirBuilderExt;
+
+        let noperm_dir = tempdir().unwrap().into_path().join("denied");
+        assert!(!noperm_dir.exists(), "test prereq failed: {:?} reported as already existing", noperm_dir);
+        DirBuilder::new()
+            .mode(0o000) // is only supported with the unix extension
+            .create(&noperm_dir)
+            .unwrap();
+
+        assert!(noperm_dir.exists(), "test preqreq failed: failed to create {:?}", noperm_dir);
+        assert!(noperm_dir.metadata().unwrap().permissions().readonly(), "test prereq failed: {:?} is not read only", noperm_dir);
+        
+        let test_db_path = DbPath::from(Some(noperm_dir.clone()));
+        let result = load_agent_state(&test_db_path).unwrap_err();
+
+        assert!(matches!(result, StateError::PermissionDenied(p) if p == noperm_dir));
+    }
+
+    #[test]
+    fn load_agent_state_not_dir() {
+        let blocking_file = tempdir().unwrap().into_path().join("block");
+        File::create(&blocking_file).unwrap();
+
+        let test_db_path = DbPath::from(Some(blocking_file.clone()));
+        let result = load_agent_state(&test_db_path).unwrap_err();
+
+        assert!(matches!(result, StateError::InvalidPath(p) if p == blocking_file));
+    }
+
+    #[test]
+    fn load_agent_state_dir_exists() {
+        let state_dir = tempdir().unwrap().into_path();
+        let test_db_path = DbPath::from(Some(state_dir));
+        let result = load_agent_state(&test_db_path).unwrap();
+
+        assert!(result.is_some(), "failed to create valid AgentState struct");
+    }
+
+    #[test]
+    fn load_agent_state_not_set() {
+        let result = load_agent_state(&DbPath::Empty).unwrap();
+        assert!(result.is_none());
+    }
 }

--- a/bin/tests/http.rs
+++ b/bin/tests/http.rs
@@ -53,7 +53,6 @@ async fn test_http_buffer_size() {
         // Ensure that the agent sent each log message individually because each log line
         // filled the configured buffer capacity.
         let calls_made = call_counter.lock().unwrap();
-        println!("total call count = {}", calls_made);
         assert_eq!(*calls_made, 5);
 
         shutdown_handle();

--- a/common/state/src/lib.rs
+++ b/common/state/src/lib.rs
@@ -34,60 +34,73 @@ pub struct AgentState {
     offset_cf_opt: Options,
 }
 
+// This was the old new fn implementation. It could probably be broken up
+// into a few smaller, private functions.
+fn _construct_agent_state(path: &Path) -> Result<AgentState, StateError> {
+    if path.metadata()?.permissions().readonly() {
+        return Err(StateError::PermissionDenied(path.into()));
+    }
+
+    let path = path.join("agent_state.db");
+
+    let mut db_opts = Options::default();
+    db_opts.create_missing_column_families(true);
+    db_opts.create_if_missing(true);
+
+    let offset_cf_opt = Options::default();
+    let offset_cf = ColumnFamilyDescriptor::new(OFFSET_NAME, offset_cf_opt.clone());
+    let cfs = vec![offset_cf];
+
+    info!("Opening state db at {:?}", path);
+
+    let db = match DB::open_cf_descriptors(&db_opts, &path, cfs) {
+        Ok(db) => db,
+        // Attempt to repair a badly closed DB
+        Err(e) => {
+            warn!("error opening state db, attempted to repair: {}", e);
+            DB::repair(&db_opts, &path).map_or_else(
+                |_| {
+                    DB::destroy(&db_opts, &path)?;
+                    DB::open_cf_descriptors(
+                        &db_opts,
+                        &path,
+                        vec![ColumnFamilyDescriptor::new(
+                            OFFSET_NAME,
+                            offset_cf_opt.clone(),
+                        )],
+                    )
+                },
+                |_| {
+                    DB::open_cf_descriptors(
+                        &db_opts,
+                        &path,
+                        vec![ColumnFamilyDescriptor::new(
+                            OFFSET_NAME,
+                            offset_cf_opt.clone(),
+                        )],
+                    )
+                },
+            )?
+        }
+    };
+    Ok(AgentState {
+        db: Arc::new(db),
+        offset_cf_opt,
+    })
+}
+
 impl AgentState {
     pub fn new(path: impl AsRef<Path>) -> Result<Self, StateError> {
         let path = path.as_ref();
 
-        if path.metadata()?.permissions().readonly() {
-            return Err(StateError::PermissionDenied(path.into()));
+        if !path.exists() {
+            std::fs::create_dir_all(path).map_err(StateError::IoError)?;
+        } else if !path.is_dir() {
+            error!("{} is not a directory", path.to_string_lossy());
+            return Err(StateError::InvalidPath(path.to_path_buf()));
         }
 
-        let path = path.join("agent_state.db");
-
-        let mut db_opts = Options::default();
-        db_opts.create_missing_column_families(true);
-        db_opts.create_if_missing(true);
-
-        let offset_cf_opt = Options::default();
-        let offset_cf = ColumnFamilyDescriptor::new(OFFSET_NAME, offset_cf_opt.clone());
-        let cfs = vec![offset_cf];
-
-        info!("Opening state db at {:?}", path);
-
-        let db = match DB::open_cf_descriptors(&db_opts, &path, cfs) {
-            Ok(db) => db,
-            // Attempt to repair a badly closed DB
-            Err(e) => {
-                warn!("error opening state db, attempted to repair: {}", e);
-                DB::repair(&db_opts, &path).map_or_else(
-                    |_| {
-                        DB::destroy(&db_opts, &path)?;
-                        DB::open_cf_descriptors(
-                            &db_opts,
-                            &path,
-                            vec![ColumnFamilyDescriptor::new(
-                                OFFSET_NAME,
-                                offset_cf_opt.clone(),
-                            )],
-                        )
-                    },
-                    |_| {
-                        DB::open_cf_descriptors(
-                            &db_opts,
-                            &path,
-                            vec![ColumnFamilyDescriptor::new(
-                                OFFSET_NAME,
-                                offset_cf_opt.clone(),
-                            )],
-                        )
-                    },
-                )?
-            }
-        };
-        Ok(Self {
-            db: Arc::new(db),
-            offset_cf_opt,
-        })
+        _construct_agent_state(path)
     }
 }
 
@@ -311,6 +324,7 @@ pub trait GetOffset {
 mod test {
 
     use super::*;
+    use std::fs::File;
     use tempfile::tempdir;
 
     #[test]
@@ -376,5 +390,76 @@ mod test {
         }
         _test(&data_dir, 0);
         _test(&data_dir, 2);
+    }
+
+    #[test]
+    fn load_agent_state_dir_missing() {
+        // build a path with multiple levels of missing directories to ensure they're all created
+        let missing_state_dir = tempdir()
+            .unwrap()
+            .into_path()
+            .join("a")
+            .join("ghostly")
+            .join("path");
+        assert!(
+            !missing_state_dir.exists(),
+            "test prereq failed: {:?} reported as already existing",
+            missing_state_dir
+        );
+
+        let result = AgentState::new(&missing_state_dir);
+        assert!(result.is_ok());
+        assert!(
+            missing_state_dir.exists(),
+            "state directory was not created"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn new_agent_state_dir_create_error() {
+        use std::fs::DirBuilder;
+        use std::os::unix::fs::DirBuilderExt;
+
+        let noperm_dir = tempdir().unwrap().into_path().join("denied");
+        assert!(
+            !noperm_dir.exists(),
+            "test prereq failed: {:?} reported as already existing",
+            noperm_dir
+        );
+        DirBuilder::new()
+            .mode(0o000) // is only supported with the unix extension
+            .create(&noperm_dir)
+            .unwrap();
+
+        assert!(
+            noperm_dir.exists(),
+            "test preqreq failed: failed to create {:?}",
+            noperm_dir
+        );
+        assert!(
+            noperm_dir.metadata().unwrap().permissions().readonly(),
+            "test prereq failed: {:?} is not read only",
+            noperm_dir
+        );
+
+        let result = AgentState::new(&noperm_dir).unwrap_err();
+        assert!(matches!(result, StateError::PermissionDenied(p) if p == noperm_dir));
+    }
+
+    #[test]
+    fn new_agent_state_not_dir() {
+        let blocking_file = tempdir().unwrap().into_path().join("block");
+        File::create(&blocking_file).unwrap();
+
+        let result = AgentState::new(&blocking_file).unwrap_err();
+        assert!(matches!(result, StateError::InvalidPath(p) if p == blocking_file));
+    }
+
+    #[test]
+    fn new_agent_state_dir_exists() {
+        let state_dir = tempdir().unwrap().into_path();
+        let result = AgentState::new(&state_dir);
+        assert!(result.is_ok(), "failed to create valid AgentState struct");
     }
 }

--- a/common/state/src/lib.rs
+++ b/common/state/src/lib.rs
@@ -21,6 +21,8 @@ pub enum StateError {
     IoError(#[from] std::io::Error),
     #[error("{0:?}")]
     PermissionDenied(PathBuf),
+    #[error("{0:?}")]
+    InvalidPath(PathBuf),
 }
 
 #[derive(Derivative)]


### PR DESCRIPTION
Attempt to create the configured state directory (db_path)  if it doesn't exist, handling invalid permissions by logging and skipping the creation. 

Ref: LOG-10638