### PR TITLE
Remove libjournald from default features

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -47,7 +47,7 @@ auditable = "0.1"
 miniz_oxide = "0.4"
 
 [features]
-default = ["libjournald"]
+default = []
 integration_tests = []
 profiling = ["jemallocator/profiling"]
 k8s_tests = []


### PR DESCRIPTION
The Makefile still adds it to all the cargo invocations by default, this just means language servers on non-linux can operate properly for a better editing experience without having to make this change locally