### PR TITLE
feat: Adding metrics to around ingest retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "logdna-agent"
-version = "3.3.0-beta.1"
+version = "3.4.0-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1483,6 +1483,7 @@ dependencies = [
  "pin-utils",
  "pnet",
  "predicates",
+ "prometheus-parse",
  "proptest",
  "rand",
  "rcgen",
@@ -1581,6 +1582,7 @@ dependencies = [
  "json",
  "lazy_static",
  "log",
+ "num",
  "prometheus",
  "tokio",
 ]
@@ -1668,12 +1670,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2083,6 +2142,16 @@ dependencies = [
  "procfs",
  "protobuf",
  "thiserror",
+]
+
+[[package]]
+name = "prometheus-parse"
+version = "0.2.1"
+source = "git+https://github.com/ccakes/prometheus-parse-rs?rev=a4574e9#a4574e9bade29b8af31e68b68a5392c61cbb74cd"
+dependencies = [
+ "chrono",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -79,6 +79,7 @@ wait-timeout = "0.2"
 hyper = { version = "0.14", features = ["http1"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+prometheus-parse = { git = "https://github.com/ccakes/prometheus-parse-rs", rev = "a4574e9" }
 
 [build-dependencies]
 auditable-build = "0.1"

--- a/bin/tests/retries.rs
+++ b/bin/tests/retries.rs
@@ -1,8 +1,12 @@
 use common::AgentSettings;
 pub use common::*;
+use hyper::StatusCode;
+use prometheus_parse::{Sample, Scrape, Value};
+use rand::Rng;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tempfile::tempdir;
@@ -141,6 +145,245 @@ async fn test_retry_is_not_made_before_retry_base_delay_ms() {
 
     server_result.unwrap();
     agent_handle.kill().unwrap();
+}
+
+async fn gen_log_data(file: &mut File) {
+    let mut rng = rand::thread_rng();
+    let total_lines = rng.gen_range(10..50);
+    for _ in 0..total_lines {
+        let line_len = rng.gen_range(5..80);
+        let line: String = rand::thread_rng()
+            .sample_iter(&rand::distributions::Alphanumeric)
+            .take(line_len)
+            .map(char::from)
+            .collect();
+
+        writeln!(file, "{}", line).unwrap();
+        file.flush().unwrap();
+    }
+    tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+}
+
+#[derive(Debug)]
+struct MetricRec {
+    timestamp_ms: i64,
+    raw_value: f64,
+}
+
+impl MetricRec {
+    fn new(timestamp_ms: i64, raw_value: f64) -> Self {
+        Self {
+            timestamp_ms,
+            raw_value,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TestMetrics {
+    min_timestamp_ms: AtomicI64,
+    max_timestamp_ms: AtomicI64,
+    retry_pending: Vec<MetricRec>,
+    retry_storage_used: Vec<MetricRec>,
+    retry_success: Vec<MetricRec>,
+    retry_failure: Vec<MetricRec>,
+}
+
+impl TestMetrics {
+    fn new() -> Self {
+        TestMetrics {
+            min_timestamp_ms: AtomicI64::new(i64::MAX),
+            max_timestamp_ms: AtomicI64::new(i64::MIN),
+            retry_pending: Vec::new(),
+            retry_storage_used: Vec::new(),
+            retry_success: Vec::new(),
+            retry_failure: Vec::new(),
+        }
+    }
+
+    fn record(&mut self, sample: &Sample) {
+        let ts = sample.timestamp.timestamp_millis();
+        self.min_timestamp_ms.fetch_min(ts, Ordering::Relaxed);
+        self.max_timestamp_ms.fetch_max(ts, Ordering::Relaxed);
+
+        match sample.metric.as_str() {
+            "logdna_agent_retry_pending" => {
+                if let Value::Gauge(v) = sample.value {
+                    self.retry_pending.push(MetricRec::new(ts, v));
+                }
+            }
+            "logdna_agent_retry_storage_used" => {
+                if let Value::Gauge(v) = sample.value {
+                    self.retry_storage_used.push(MetricRec::new(ts, v));
+                }
+            }
+            "logdna_agent_ingest_retries_success" => {
+                if let Value::Counter(c) = sample.value {
+                    self.retry_success.push(MetricRec::new(ts, c));
+                }
+            }
+            "logdna_agent_ingest_retries_failure" => {
+                if let Value::Counter(c) = sample.value {
+                    self.retry_failure.push(MetricRec::new(ts, c));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
+async fn test_retry_metrics_emitted() {
+    let _ = env_logger::Builder::from_default_env().try_init();
+    let timeout = 200;
+    let base_delay_ms = 300;
+    let step_delay_ms = 100;
+    let metrics_port = 9881;
+
+    let dir = tempdir().unwrap().into_path();
+    let file_path = dir.join("test.log");
+    let mut file = File::create(&file_path).expect("Couldn't create temp log file...");
+
+    // Generate a mock ingestion service that can be toggled between normal speed and slow running
+    // Slow responses should trigger a retry when the agent is set with small timeout values.
+    let simulate_ingest_problems = Arc::new(AtomicBool::new(false));
+    let (server, _, shutdown_ingest, address) = start_ingester({
+        let simulate_ingest_problems = simulate_ingest_problems.clone();
+        Box::new(move |body| {
+            if body
+                .lines
+                .iter()
+                .any(|l| l.file.as_deref().unwrap().contains("test.log"))
+                && simulate_ingest_problems.load(Ordering::Relaxed)
+            {
+                return Some(Box::pin(tokio::time::sleep(Duration::from_millis(
+                    timeout + 20,
+                ))));
+            }
+            None
+        })
+    });
+
+    // Agent Process
+    let mut settings = AgentSettings::with_mock_ingester(dir.to_str().unwrap(), &address);
+    let config_file_path = get_config_file(timeout, base_delay_ms, step_delay_ms);
+    settings.config_file = config_file_path.to_str();
+    settings.metrics_port = Some(metrics_port);
+
+    let mut agent_handle = common::spawn_agent(settings);
+    let agent_stderr = agent_handle.stderr.take().unwrap();
+    common::consume_output(agent_stderr);
+
+    // This creates a new thread that scrapes the metrics from the agent process and
+    // stores all the values for the retry metrics under test.
+    let scrape_metrics = Arc::new(AtomicBool::new(true));
+    let rec_metrics = Arc::new(Mutex::new(TestMetrics::new()));
+
+    let metrics_handle = tokio::spawn({
+        let scrape_metrics = scrape_metrics.clone();
+        let rec_metrics = rec_metrics.clone();
+
+        async move {
+            while scrape_metrics.load(Ordering::Relaxed) {
+                if let Ok((StatusCode::OK, Some(data))) =
+                    common::fetch_agent_metrics(metrics_port).await
+                {
+                    let lines = data.lines().map(|l| Ok(l.to_string()));
+                    for sample in Scrape::parse(lines).unwrap().samples {
+                        rec_metrics.lock().as_mut().unwrap().record(&sample);
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    });
+
+    let (server_result, _, _) = tokio::join!(server, metrics_handle, async move {
+        // Wait for the agent to bootstrap and then start generating some log data
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        gen_log_data(&mut file).await;
+
+        // Signal to the mock ingestor to start doing random rejections on log data.
+        simulate_ingest_problems.store(true, Ordering::Relaxed);
+        gen_log_data(&mut file).await;
+        gen_log_data(&mut file).await;
+
+        // Signal to the mock ingestor to stop doing random rejections
+        simulate_ingest_problems.store(false, Ordering::Relaxed);
+        tokio::time::sleep(tokio::time::Duration::from_millis(6000)).await;
+        gen_log_data(&mut file).await;
+
+        // Shut down the scraper and ingest server
+        scrape_metrics.store(false, Ordering::Relaxed);
+        shutdown_ingest();
+    });
+
+    server_result.unwrap();
+    agent_handle.kill().unwrap();
+
+    // Assertions
+    //
+    // There should be at least 1 metric recorded for each of the retry metrics.
+    let rec_metrics = rec_metrics.lock().unwrap();
+
+    assert!(!rec_metrics.retry_pending.is_empty());
+    assert!(!rec_metrics.retry_success.is_empty());
+    assert!(!rec_metrics.retry_failure.is_empty());
+    assert!(!rec_metrics.retry_storage_used.is_empty());
+
+    // The pending count should start and end at 0 since the agent starts normal and
+    // then recovers. This metric is a gauge and is allowed to move up and down.
+    let pending_first = rec_metrics.retry_pending.get(0).unwrap();
+    let pending_last = rec_metrics.retry_pending.iter().last().unwrap();
+    assert!(pending_first.raw_value < f64::EPSILON);
+    assert!(pending_last.raw_value < f64::EPSILON);
+
+    // The pending count should have some recorded value that greater than 0 if the
+    // agent did actually enter a retry loop.
+    rec_metrics.retry_pending.iter().any(|r| r.raw_value > 0.0);
+
+    // The retry success/failure counts first metric data point should only occur after
+    // the first recorded metric and continue since they are counters and counters only
+    // emit on the first increment.
+    let success_first = rec_metrics.retry_success.get(0).unwrap();
+    let failure_first = rec_metrics.retry_failure.get(0).unwrap();
+    assert!(rec_metrics.min_timestamp_ms.load(Ordering::Relaxed) < success_first.timestamp_ms);
+    assert!(rec_metrics.min_timestamp_ms.load(Ordering::Relaxed) < failure_first.timestamp_ms);
+
+    let success_last = rec_metrics.retry_success.iter().last().unwrap();
+    let failure_last = rec_metrics.retry_failure.iter().last().unwrap();
+    assert!(success_last.timestamp_ms <= rec_metrics.max_timestamp_ms.load(Ordering::Relaxed));
+    assert!(failure_last.timestamp_ms <= rec_metrics.max_timestamp_ms.load(Ordering::Relaxed));
+
+    // Each of the success counts should be greater than or equal to the prior count.
+    assert!(rec_metrics.retry_success.windows(2).all(|w| match w {
+        [a, b] => a.raw_value <= b.raw_value,
+        _ => false,
+    }));
+
+    // Each of the failure counts should be greater than or equal to the prior count.
+    assert!(rec_metrics.retry_failure.windows(2).all(|w| match w {
+        [a, b] => a.raw_value <= b.raw_value,
+        _ => false,
+    }));
+
+    // The amount of space used for retries should increase but then eventually decrease to to zero
+    // as the agent recovers. Note that zero values won't appear at first since nothing has reported
+    // a metric until a retry attempt.
+    assert!(rec_metrics
+        .retry_storage_used
+        .iter()
+        .any(|r| r.raw_value > 0.0));
+    assert!(
+        rec_metrics
+            .retry_storage_used
+            .iter()
+            .last()
+            .unwrap()
+            .raw_value
+            < f64::EPSILON
+    );
 }
 
 /// Creates a temp config file with required fields and the provided parameters

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -11,3 +11,4 @@ json = "0.12"
 log = "0.4"
 prometheus = { version = "0.12", features = ["process"] }
 tokio = { version= "1", features= ["time"] }
+num = "0.4"


### PR DESCRIPTION
This ticket adds metrics for the following retry data points:

* pending files in the retry queue that have not been resent yet
* counts of successful retry ingest API calls
* counts of failed retry ingest API calls
* disk space used by all the current retry files

This is in addition to counts around the HTTP API calls around ingest API attempts, successes and failures. Tested via the included integration test that makes assertions around the metric properties instead of specific metric values.

Ref: LOG-10294