### PR TITLE
de-chrono everything except kube module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,15 +336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-humanize"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8164ae3089baf04ff71f32aeb70213283dcd236dce8bc976d00b17a458f5f71c"
-dependencies = [
- "chrono",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,7 +750,6 @@ dependencies = [
  "async-channel",
  "async-trait",
  "bytes",
- "chrono",
  "env_logger",
  "futures",
  "futures-core",
@@ -780,6 +770,7 @@ dependencies = [
  "state",
  "tempfile",
  "thiserror",
+ "time 0.3.4",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -957,7 +948,6 @@ version = "0.1.0"
 dependencies = [
  "async-compat",
  "bytes",
- "chrono",
  "crossbeam",
  "futures",
  "futures-timer",
@@ -974,6 +964,7 @@ dependencies = [
  "state",
  "tempfile",
  "thiserror",
+ "time 0.3.4",
  "tokio",
  "tokio-test",
  "types",
@@ -1205,7 +1196,6 @@ name = "journald"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "chrono",
  "combine",
  "futures",
  "http 0.1.0",
@@ -1215,6 +1205,7 @@ dependencies = [
  "partial-io",
  "serial_test",
  "systemd",
+ "time 0.3.4",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -1263,11 +1254,11 @@ version = "0.1.0"
 dependencies = [
  "backoff",
  "chrono",
- "chrono-humanize",
  "crossbeam",
  "futures",
  "http 0.1.0",
  "http 0.2.5",
+ "humantime",
  "k8s-openapi",
  "kube",
  "kube-runtime",
@@ -1458,7 +1449,6 @@ dependencies = [
  "auditable",
  "auditable-build",
  "bytes",
- "chrono",
  "config",
  "env_logger",
  "escargot",
@@ -1494,6 +1484,7 @@ dependencies = [
  "state",
  "systemd",
  "tempfile",
+ "time 0.3.4",
  "tokio",
  "tokio-stream",
  "tokio-test",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -31,7 +31,7 @@ journald = { package = "journald", path = "../common/journald" }
 state = { package = "state", path = "../common/state" }
 
 bytes = "1"
-chrono = "0.4"
+time = "0.3"
 async-trait = "0.1"
 log = "0.4"
 env_logger = "0.8"

--- a/common/fs/Cargo.toml
+++ b/common/fs/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0"
 
 #utils
 bytes = "1"
-chrono = "0.4"
+time = "0.3"
 pcre2 = { git = "https://github.com/logdna/rust-pcre2.git", branch="0.2", version = "0.2" }
 globber = "0.1"
 slotmap = "1"

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -25,6 +25,7 @@ use inotify::WatchDescriptor;
 use slotmap::{DefaultKey, SlotMap};
 use smallvec::SmallVec;
 use thiserror::Error;
+use time::OffsetDateTime;
 use tokio::sync::Mutex;
 
 pub mod dir_path;
@@ -71,7 +72,7 @@ pub enum Error {
     File(io::Error),
 }
 
-type EventTimestamp = chrono::DateTime<chrono::Utc>;
+type EventTimestamp = time::OffsetDateTime;
 
 /// Turns an inotify event into an event stream
 fn as_event_stream(
@@ -112,7 +113,7 @@ fn as_event_stream(
 fn get_initial_events(
     fs: &Arc<Mutex<FileSystem>>,
 ) -> impl Stream<Item = (Result<Event, Error>, EventTimestamp)> {
-    let init_time = chrono::offset::Utc::now();
+    let init_time = OffsetDateTime::now_utc();
     let initial_events = {
         let mut fs = fs.try_lock().expect("could not lock filesystem cache");
 

--- a/common/fs/src/cache/watch.rs
+++ b/common/fs/src/cache/watch.rs
@@ -8,9 +8,10 @@ use std::sync::Arc;
 use futures::future::Either;
 use futures::{Stream, StreamExt};
 use smallvec::SmallVec;
-use tokio::time::Instant;
 
+use time::OffsetDateTime;
 use tokio::sync::Mutex;
+use tokio::time::Instant;
 
 const INOTIFY_EVENT_GRACE_PERIOD_MS: u64 = 10;
 
@@ -90,12 +91,7 @@ pub struct WatchEventStream {
 impl WatchEventStream {
     pub fn into_stream(
         self,
-    ) -> impl Stream<
-        Item = (
-            Result<WatchEvent, std::io::Error>,
-            chrono::DateTime<chrono::Utc>,
-        ),
-    > {
+    ) -> impl Stream<Item = (Result<WatchEvent, std::io::Error>, time::OffsetDateTime)> {
         let unmatched_move_to: Arc<Mutex<Vec<(Instant, WatchEvent)>>> =
             Arc::new(Mutex::new(Vec::new()));
         let unmatched_move_from: Arc<Mutex<Vec<(Instant, WatchEvent)>>> =
@@ -403,7 +399,7 @@ impl WatchEventStream {
                     event => Some(event.map(|e| e.unwrap())),
                 }
             })
-            .map(|event| (event, chrono::offset::Utc::now()))
+            .map(|event| (event, OffsetDateTime::now_utc()))
     }
 }
 

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -25,7 +25,7 @@ type SyncHashMap<K, V> = Arc<Mutex<HashMap<K, V>>>;
 /// Tails files on a filesystem by inheriting events from a Watcher
 pub struct Tailer {
     fs_cache: Arc<Mutex<FileSystem>>,
-    event_times: SyncHashMap<EntryKey, (usize, chrono::DateTime<chrono::Utc>)>,
+    event_times: SyncHashMap<EntryKey, (usize, time::OffsetDateTime)>,
 }
 
 fn get_file_for_path(fs: &FileSystem, next_path: &std::path::Path) -> Option<EntryKey> {
@@ -218,7 +218,7 @@ pub fn process(
 
                             if let Some((key, _)) = key_and_previous_event_time {
                                 let mut event_times = event_times.lock().await;
-                                let new_event_time = chrono::offset::Utc::now();
+                                let new_event_time = time::OffsetDateTime::now_utc();
                                 event_times.insert(key, (event_idx, new_event_time));
                             }
 

--- a/common/http/Cargo.toml
+++ b/common/http/Cargo.toml
@@ -22,8 +22,8 @@ hyper = { version = "0.14", features = ["http1", "server"] }
 uuid = { version = "0.8", features = ["v4"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-chrono = "0.4"
 thiserror = "1"
+time = "0.3"
 futures = "0.3"
 futures-timer = "3"
 prometheus = { version = "0.12", features = ["process"] }

--- a/common/http/src/retry.rs
+++ b/common/http/src/retry.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 
 use async_compat::CompatExt;
 
-use chrono::prelude::Utc;
 use crossbeam::queue::SegQueue;
+use time::OffsetDateTime;
 
 use futures::stream::{self, Stream};
 use futures_timer::Delay;
@@ -124,7 +124,9 @@ impl Retry {
 
                 retry_disk_used += file_size;
 
-                if Utc::now().timestamp() - timestamp < self.retry_base_delay_secs {
+                if OffsetDateTime::now_utc().unix_timestamp() - timestamp
+                    < self.retry_base_delay_secs
+                {
                     continue;
                 }
                 Metrics::retry().inc_pending();
@@ -203,7 +205,7 @@ impl RetrySender {
     ) -> Result<(), Error> {
         Metrics::http().increment_retries();
 
-        let fn_ts = Utc::now().timestamp();
+        let fn_ts = OffsetDateTime::now_utc().unix_timestamp();
         let fn_uuid = Uuid::new_v4().to_string();
 
         // Write to a partial file to avoid concurrently reading from a file that's not been written

--- a/common/journald/Cargo.toml
+++ b/common/journald/Cargo.toml
@@ -11,7 +11,7 @@ metrics = { package = "metrics", path = "../metrics" }
 tokio = { package = "tokio", version = "1", features = ["macros", "process", "rt-multi-thread", "time"] }
 futures = "0.3"
 log = "0.4"
-chrono = "0.4"
+time = "0.3"
 
 # journalctl
 combine = { package = "combine", version = "4" }

--- a/common/k8s/Cargo.toml
+++ b/common/k8s/Cargo.toml
@@ -13,7 +13,7 @@ metrics = { package = "metrics", path = "../metrics" }
 backoff = { version = "0.3.0", features = ["tokio"] }
 
 chrono = { version = "0.4", features = ["serde"] }
-chrono-humanize = "0.1"
+humantime = "2"
 crossbeam = "0.8"
 regex = "1"
 lazy_static = "1"

--- a/common/k8s/src/event_source.rs
+++ b/common/k8s/src/event_source.rs
@@ -8,7 +8,6 @@ use backoff::ExponentialBackoff;
 use crossbeam::atomic::AtomicCell;
 
 use chrono::Duration;
-use chrono_humanize::HumanTime;
 
 use futures::{stream::try_unfold, Stream, StreamExt, TryStreamExt};
 
@@ -99,7 +98,7 @@ impl From<Event> for EventLog {
 
         let duration = age.map(|age| {
             if age > Duration::weeks(0) {
-                HumanTime::from(age).to_string()
+                age.to_std().map(|d|humantime::format_duration(d).to_string()).unwrap(/*Safe to unwrap as we checked it's positive*/)
             } else {
                 "just now".to_string()
             }


### PR DESCRIPTION
This removes Chrono from as many places as we can to minimise the surface area affected by the setenv/localtime_r-in-multi-threaded-environment issue. The kube-rs project aren't planning on removing it immediately and there is a lot of debate over how best to handle it in general, so this is the best we can do I think.