### PR TITLE
build: ignore chrono CVE; awaiting long term fixes upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ lint-clippy: ## Checks for code errors
 
 .PHONY:lint-audit
 lint-audit: ## Audits packages for issues
-	$(RUST_COMMAND) "--env RUST_BACKTRACE=full" "cargo audit"
+	$(RUST_COMMAND) "--env RUST_BACKTRACE=full" "cargo audit --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071"
 
 .PHONY:lint-docker
 lint-docker: ## Lint the Dockerfile for issues

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ lint-clippy: ## Checks for code errors
 
 .PHONY:lint-audit
 lint-audit: ## Audits packages for issues
-	$(RUST_COMMAND) "--env RUST_BACKTRACE=full" "cargo audit --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071"
+	$(RUST_COMMAND) "--env RUST_BACKTRACE=full" "cargo audit --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0124"
 
 .PHONY:lint-docker
 lint-docker: ## Lint the Dockerfile for issues


### PR DESCRIPTION
Fix Jenkins builds to ignore the chrono CVE for now while we wait for long term fixes from upstream packages as well as fixes to our code base.