### PR TITLE
fix: Bump rocksdb and jemallocator crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,38 +1160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jemalloc-ctl"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7"
-dependencies = [
- "jemalloc-sys",
- "libc",
- "paste",
-]
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,7 +1435,6 @@ dependencies = [
  "http 0.1.0",
  "hyper",
  "itertools",
- "jemallocator",
  "journald",
  "k8s",
  "k8s-openapi",
@@ -1494,6 +1461,7 @@ dependencies = [
  "state",
  "systemd",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -1578,12 +1546,12 @@ dependencies = [
 name = "metrics"
 version = "0.1.0"
 dependencies = [
- "jemalloc-ctl",
  "json",
  "lazy_static",
  "log",
  "num",
  "prometheus",
+ "tikv-jemalloc-ctl",
  "tokio",
 ]
 
@@ -1814,22 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.18"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
-dependencies = [
- "proc-macro-hack",
-]
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "pcre2"
@@ -2361,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d83c02c429044d58474eaf5ae31e062d0de894e21125b47437ec0edc1397e6"
+checksum = "7a62eca5cacf2c8261128631bed9f045598d40bfbe4b29f5163f0f802f8f44a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -2828,6 +2783,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb833c46ecbf8b6daeccb347cefcabf9c1beb5c9b0f853e1cec45632d9963e69"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.2+5.2.1-patched.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5844e429d797c62945a566f8da4e24c7fe3fbd5d6617fd8bf7a0b7dc1ee0f22e"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -37,7 +37,7 @@ log = "0.4"
 env_logger = "0.8"
 anyhow = "1"
 serde_yaml = "0.8"
-jemallocator = { version = "0.3", default-features = false, features = ["stats"] }
+tikv-jemallocator  = { version = "0.4.1", default-features = false, features = ["stats"] }
 futures = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "signal"] }
 tokio-stream = "0.1"
@@ -49,7 +49,7 @@ miniz_oxide = "0.4"
 [features]
 default = []
 integration_tests = []
-profiling = ["jemallocator/profiling"]
+profiling = ["tikv-jemallocator/profiling"]
 k8s_tests = []
 libjournald = ["journald/libjournald"]
 journald_tests = ["journald/journald_tests"]

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -38,7 +38,7 @@ mod dep_audit;
 mod stream_adapter;
 
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 // Statically include the CARGO_PKG_NAME and CARGO_PKG_VERSIONs in the binary
 // and export under the PKG_NAME and PKG_VERSION symbols.

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.0"
-jemalloc-ctl = "0.3"
+tikv-jemalloc-ctl = "0.4.1"
 json = "0.12"
 log = "0.4"
 prometheus = { version = "0.12", features = ["process"] }

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -1,5 +1,3 @@
-use tikv_jemalloc_ctl::stats::{active, active_mib, allocated, allocated_mib, resident, resident_mib};
-use tikv_jemalloc_ctl::{epoch, epoch_mib};
 use json::object;
 use lazy_static::lazy_static;
 use log::{info, warn};
@@ -10,6 +8,10 @@ use prometheus::{
     IntCounterVec, IntGauge,
 };
 use std::time::{Duration, Instant};
+use tikv_jemalloc_ctl::stats::{
+    active, active_mib, allocated, allocated_mib, resident, resident_mib,
+};
+use tikv_jemalloc_ctl::{epoch, epoch_mib};
 use tokio::time::sleep;
 
 lazy_static! {

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -1,5 +1,5 @@
-use jemalloc_ctl::stats::{active, active_mib, allocated, allocated_mib, resident, resident_mib};
-use jemalloc_ctl::{epoch, epoch_mib};
+use tikv_jemalloc_ctl::stats::{active, active_mib, allocated, allocated_mib, resident, resident_mib};
+use tikv_jemalloc_ctl::{epoch, epoch_mib};
 use json::object;
 use lazy_static::lazy_static;
 use log::{info, warn};

--- a/common/state/Cargo.toml
+++ b/common/state/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 derivative = "2.2"
 futures = "0.3"
-rocksdb = "0.15"
+rocksdb = "0.17"
 async-channel = "1.6"
 thiserror = "1.0"
 log = "0.4"


### PR DESCRIPTION
Bumps the rocksdb crate to the latest release in order to pick up changes around the jemalloc library (see https://github.com/rust-rocksdb/rust-rocksdb/pull/554). The PR also updates the agent to use tikv-jemallocator.

Ref: LOG-11566