### PR TITLE
fix: more tolerant logging for retry file deletes

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -401,11 +401,19 @@ async fn main() {
                                                 "cleaned up retry file {}",
                                                 path.to_string_lossy()
                                             ),
-                                            Err(e) => error!(
-                                                "couldn't clean up retry file {}, reason={}",
-                                                path.to_string_lossy(),
-                                                e
-                                            ),
+                                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                                debug!(
+                                                    "cleanup {}: not found err, skipping",
+                                                    path.to_string_lossy()
+                                                );
+                                            }
+                                            Err(e) => {
+                                                error!(
+                                                    "couldn't clean up retry file {}, reason={}",
+                                                    path.to_string_lossy(),
+                                                    e
+                                                )
+                                            }
                                         }
                                     }
                                     _ => {


### PR DESCRIPTION
In some circumstances around sending retry data, the code may attempt to remove a retry persistence file twice. Before this PR, we would log this as an error, now it will log a message as debug in case we need to troubleshoot further around the delete logic. The error message was needlessly harsh considering that the same end effect, the file was deleted, occurred whether or not a delete actually happened. 

Note: There is also the metric `logdna_agent_retry_storage_used` that can assist in alerting if files aren't actually be deleted.

Ref: LOG-11515