### PR TITLE
Update the makefile to use the new split base images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@ REPO := logdna-agent-v2
 
 SHELLFLAGS:=-ic
 
+# The target architecture the agent is to be compiled for
+ARCH?=x86_64
 # The image repo and tag can be modified e.g.
 # `make build RUST_IMAGE=docker.io/rust:latest
 RUST_IMAGE_REPO ?= docker.io/logdna/build-images
-RUST_IMAGE_TAG ?= rust-buster-stable
-RUST_IMAGE ?= $(RUST_IMAGE_REPO):$(RUST_IMAGE_TAG)
-RUST_IMAGE := $(RUST_IMAGE)
+RUST_IMAGE_BASE ?= buster
+RUST_IMAGE_TAG ?= rust-$(RUST_IMAGE_BASE)-1-stable
+RUST_IMAGE ?= $(RUST_IMAGE_REPO):$(RUST_IMAGE_TAG)-$(ARCH)
 
 HADOLINT_IMAGE_REPO ?= hadolint/hadolint
 HADOLINT_IMAGE_TAG ?= v1.18.0-debian
@@ -70,7 +72,6 @@ else
 	PULL_OPTS :=
 endif
 
-ARCH?=x86_64
 ARCH_TRIPLE?=$(ARCH)-linux-gnu
 TARGET?=$(ARCH)-unknown-linux-gnu
 STATIC ?= 0


### PR DESCRIPTION
This updates the makefile to use the newer build image tag format