### PR TITLE
feat: Retry disk space can be limited

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "fs",
  "globber",
  "http 0.1.0",
+ "humanize-rs",
  "java-properties",
  "k8s",
  "lazy_static",
@@ -1043,6 +1044,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humanize-rs"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016b02deb8b0c415d8d56a6f0ab265e50c22df61194e37f9be75ed3a722de8a6"
 
 [[package]]
 name = "humantime"

--- a/bin/tests/cmd_line_env.rs
+++ b/bin/tests/cmd_line_env.rs
@@ -51,6 +51,7 @@ fn test_command_line_arguments_help() {
         "--include",
         "--ingest-buffer-size",
         "--retry-dir",
+        "--retry-disk-limit",
         "--ingest-timeout",
         "--ip",
         "--journald-paths",
@@ -274,7 +275,8 @@ fn test_command_line_arguments_should_set_config() {
                 .args(&["--line-redact", "a@b.com"])
                 .args(&["--ingest-buffer-size", "123456"])
                 .args(&["--ingest-timeout", "9876"])
-                .args(&["--retry-dir", "/tmp/logdna/argv"]);
+                .args(&["--retry-dir", "/tmp/logdna/argv"])
+                .args(&["--retry-disk-limit", "9876543"]);
         },
         |d| {
             assert!(contains("tags: \"a,b\"").eval(d));
@@ -308,6 +310,7 @@ fn test_command_line_arguments_should_set_config() {
             assert!(contains("body_size: 123456").eval(d));
             assert!(contains("timeout: 9876").eval(d));
             assert!(contains("retry_dir: /tmp/logdna/argv").eval(d));
+            assert!(contains("retry_disk_limit: 9876543").eval(d));
         },
     );
 }
@@ -355,7 +358,8 @@ fn test_environment_variables_should_set_config() {
                 .env("LOGDNA_REDACT_REGEX", "c@d.com")
                 .env("LOGDNA_INGEST_TIMEOUT", "123456")
                 .env("LOGDNA_INGEST_BUFFER_SIZE", "987654")
-                .env("LOGDNA_RETRY_DIR", "/tmp/logdna/env");
+                .env("LOGDNA_RETRY_DIR", "/tmp/logdna/env")
+                .env("LOGDNA_RETRY_DISK_LIMIT", "7654321");
         },
         |d| {
             assert!(contains("tags: \"d,e,f\"").eval(d));
@@ -393,6 +397,7 @@ fn test_environment_variables_should_set_config() {
             assert!(contains("timeout: 123456").eval(d));
             assert!(contains("body_size: 987654").eval(d));
             assert!(contains("retry_dir: /tmp/logdna/env").eval(d));
+            assert!(contains("retry_disk_limit: 7654321").eval(d));
         },
     );
 }

--- a/bin/tests/cmd_line_env.rs
+++ b/bin/tests/cmd_line_env.rs
@@ -276,7 +276,7 @@ fn test_command_line_arguments_should_set_config() {
                 .args(&["--ingest-buffer-size", "123456"])
                 .args(&["--ingest-timeout", "9876"])
                 .args(&["--retry-dir", "/tmp/logdna/argv"])
-                .args(&["--retry-disk-limit", "9876543"]);
+                .args(&["--retry-disk-limit", "9 MB"]);
         },
         |d| {
             assert!(contains("tags: \"a,b\"").eval(d));
@@ -310,7 +310,7 @@ fn test_command_line_arguments_should_set_config() {
             assert!(contains("body_size: 123456").eval(d));
             assert!(contains("timeout: 9876").eval(d));
             assert!(contains("retry_dir: /tmp/logdna/argv").eval(d));
-            assert!(contains("retry_disk_limit: 9876543").eval(d));
+            assert!(contains("retry_disk_limit: 9000000").eval(d));
         },
     );
 }
@@ -359,7 +359,7 @@ fn test_environment_variables_should_set_config() {
                 .env("LOGDNA_INGEST_TIMEOUT", "123456")
                 .env("LOGDNA_INGEST_BUFFER_SIZE", "987654")
                 .env("LOGDNA_RETRY_DIR", "/tmp/logdna/env")
-                .env("LOGDNA_RETRY_DISK_LIMIT", "7654321");
+                .env("LOGDNA_RETRY_DISK_LIMIT", "7 KB");
         },
         |d| {
             assert!(contains("tags: \"d,e,f\"").eval(d));
@@ -397,7 +397,7 @@ fn test_environment_variables_should_set_config() {
             assert!(contains("timeout: 123456").eval(d));
             assert!(contains("body_size: 987654").eval(d));
             assert!(contains("retry_dir: /tmp/logdna/env").eval(d));
-            assert!(contains("retry_disk_limit: 7654321").eval(d));
+            assert!(contains("retry_disk_limit: 7000").eval(d));
         },
     );
 }

--- a/common/config/Cargo.toml
+++ b/common/config/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4"
 sysinfo = "0.15"
 structopt = "0.3"
 java-properties = "1"
+humanize-rs = "0.1"
 
 [dev-dependencies]
 scopeguard = "1.0"

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -75,6 +75,7 @@ pub struct HttpConfig {
     pub body_size: usize,
     pub require_ssl: bool,
     pub retry_dir: PathBuf,
+    pub retry_disk_limit: Option<u64>,
 
     // Development only settings
     pub retry_base_delay: Duration,
@@ -236,6 +237,7 @@ impl TryFrom<RawConfig> for Config {
                 .http
                 .retry_dir
                 .unwrap_or_else(|| PathBuf::from("/tmp/logdna")),
+            retry_disk_limit: raw.http.retry_disk_limit,
             retry_base_delay: Duration::from_millis(
                 raw.http.retry_base_delay_ms.unwrap_or(15_000) as u64
             ),

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate log;
+extern crate humanize_rs;
 
 use std::convert::{TryFrom, TryInto};
 use std::fs::File;

--- a/common/config/src/properties.rs
+++ b/common/config/src/properties.rs
@@ -3,6 +3,7 @@ use crate::error::ConfigError;
 use crate::raw::{Config, Rules};
 use crate::{argv, get_hostname};
 use http::types::params::{Params, Tags};
+use humanize_rs::bytes::Bytes;
 use java_properties::PropertiesIter;
 use std::collections::HashMap;
 use std::fs::File;
@@ -174,10 +175,10 @@ fn from_property_map(map: HashMap<String, String>) -> Result<Config, ConfigError
     }
 
     if let Some(value) = map.get(&RETRY_DISK_LIMIT) {
-        let limit = u64::from_str(value).map_err(|e| {
+        let limit = Bytes::<u64>::from_str(value).map_err(|e| {
             ConfigError::PropertyInvalid(format!("retry disk limit property is invalid: {}", e))
         })?;
-        result.http.retry_disk_limit = Some(limit);
+        result.http.retry_disk_limit = Some(limit.size());
     }
 
     if let Some(log_dirs) = map.get(&LOG_DIRS) {

--- a/common/config/src/properties.rs
+++ b/common/config/src/properties.rs
@@ -48,6 +48,7 @@ from_env_name!(REDACT);
 from_env_name!(INGEST_TIMEOUT);
 from_env_name!(INGEST_BUFFER_SIZE);
 from_env_name!(RETRY_DIR);
+from_env_name!(RETRY_DISK_LIMIT);
 
 enum Key {
     FromEnv(&'static str),
@@ -170,6 +171,13 @@ fn from_property_map(map: HashMap<String, String>) -> Result<Config, ConfigError
 
     if let Some(value) = map.get(&RETRY_DIR) {
         result.http.retry_dir = Some(PathBuf::from(value));
+    }
+
+    if let Some(value) = map.get(&RETRY_DISK_LIMIT) {
+        let limit = u64::from_str(value).map_err(|e| {
+            ConfigError::PropertyInvalid(format!("retry disk limit property is invalid: {}", e))
+        })?;
+        result.http.retry_disk_limit = Some(limit);
     }
 
     if let Some(log_dirs) = map.get(&LOG_DIRS) {

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -188,6 +188,8 @@ pub struct HttpConfig {
     pub body_size: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_dir: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_disk_limit: Option<u64>,
 
     // Mostly for development, these settings are hidden from the user
     // There's no guarantee that these settings will exist in the future
@@ -294,6 +296,7 @@ impl Default for HttpConfig {
                 .ok(),
             body_size: Some(2 * 1024 * 1024),
             retry_dir: Some(PathBuf::from("/tmp/logdna")),
+            retry_disk_limit: None,
             retry_base_delay_ms: None,
             retry_step_delay_ms: None,
         }
@@ -315,6 +318,8 @@ impl Merge for HttpConfig {
         self.params.merge(&other.params, &default.params);
         self.body_size.merge(&other.body_size, &default.body_size);
         self.retry_dir.merge(&other.retry_dir, &default.retry_dir);
+        self.retry_disk_limit
+            .merge(&other.retry_disk_limit, &default.retry_disk_limit);
         self.retry_base_delay_ms
             .merge(&other.retry_base_delay_ms, &default.retry_base_delay_ms);
         self.retry_step_delay_ms
@@ -880,6 +885,7 @@ ingest_buffer_size = 3145728
                 .ok(),
             body_size: Some(1337),
             retry_dir: Some(PathBuf::from("/tmp/logdna/left")),
+            retry_disk_limit: Some(12345),
             retry_base_delay_ms: Some(10_000),
             retry_step_delay_ms: Some(10_000),
         };
@@ -898,6 +904,7 @@ ingest_buffer_size = 3145728
                 .ok(),
             body_size: Some(7331),
             retry_dir: Some(PathBuf::from("/tmp/logdna/right")),
+            retry_disk_limit: Some(98765),
             retry_base_delay_ms: Some(2_000),
             retry_step_delay_ms: Some(2_000),
         };
@@ -920,6 +927,7 @@ ingest_buffer_size = 3145728
             left_conf.retry_dir,
             Some(PathBuf::from("/tmp/logdna/right"))
         );
+        assert_eq!(left_conf.retry_disk_limit, Some(98765));
         assert_eq!(left_conf.retry_base_delay_ms, Some(2_000));
         assert_eq!(left_conf.retry_step_delay_ms, Some(2_000));
     }

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -190,7 +190,7 @@ impl<T: PartialEq + Clone> Merge for Vec<T> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 pub struct Config {
     pub http: HttpConfig,
     pub log: LogConfig,
@@ -289,16 +289,10 @@ pub struct LogConfig {
     pub log_k8s_events: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 pub struct JournaldConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub paths: Option<Vec<PathBuf>>,
-}
-
-impl Default for JournaldConfig {
-    fn default() -> Self {
-        JournaldConfig { paths: None }
-    }
 }
 
 impl Merge for JournaldConfig {
@@ -307,35 +301,16 @@ impl Merge for JournaldConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 pub struct Rules {
     pub glob: Vec<String>,
     pub regex: Vec<String>,
-}
-
-impl Default for Rules {
-    fn default() -> Self {
-        Rules {
-            glob: Vec::new(),
-            regex: Vec::new(),
-        }
-    }
 }
 
 impl Merge for Rules {
     fn merge(&mut self, other: &Self, default: &Self) {
         self.glob.merge(&other.glob, &default.glob);
         self.regex.merge(&other.regex, &default.regex);
-    }
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            http: HttpConfig::default(),
-            log: LogConfig::default(),
-            journald: JournaldConfig::default(),
-        }
     }
 }
 

--- a/common/fs/src/rule.rs
+++ b/common/fs/src/rule.rs
@@ -11,6 +11,7 @@ pub trait Rule {
     fn matches(&self, value: &Path) -> bool;
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum RuleDef {
     RegexRule(Regex),

--- a/common/http/src/limit.rs
+++ b/common/http/src/limit.rs
@@ -99,6 +99,7 @@ impl<T> AsRef<T> for Slot<T> {
 #[derive(Debug)]
 struct InnerSlot<T> {
     inner: T,
+    #[allow(dead_code)]
     slot: usize,
     slots: Arc<AtomicUsize>,
 }

--- a/common/http/src/retry.rs
+++ b/common/http/src/retry.rs
@@ -155,8 +155,8 @@ impl Retry {
             }
         }
 
-        self.disk_used.fetch_sub(file_size, SeqCst);
-        Metrics::retry().report_storage_used(self.disk_used.load(SeqCst));
+        let prev_du = self.disk_used.fetch_sub(file_size, SeqCst);
+        Metrics::retry().report_storage_used(prev_du - file_size); // avoid atomic op by subtracting again
 
         let DiskRead { offsets, body } = serde_json::from_str(&data)?;
         Ok((offsets, body))

--- a/common/http/src/retry.rs
+++ b/common/http/src/retry.rs
@@ -335,7 +335,7 @@ impl RetrySender {
         let mut new_file_name = self.directory.clone();
         new_file_name.push(format!("{}_{}.retry", fn_ts, fn_uuid));
 
-        return Ok(rename(file_name, new_file_name).await?);
+        Ok(rename(file_name, new_file_name).await?)
     }
 }
 

--- a/common/journald/src/journalctl/mod.rs
+++ b/common/journald/src/journalctl/mod.rs
@@ -32,16 +32,9 @@ const KEY_SYSLOG_IDENTIFIER: &str = "SYSLOG_IDENTIFIER";
 const KEY_CONTAINER_NAME: &str = "CONTAINER_NAME";
 const DEFAULT_APP: &str = "UNKNOWN_SYSTEMD_APP";
 
+#[derive(Default)]
 pub struct JournaldExportDecoder {
     state: AnyPartialState,
-}
-
-impl Default for JournaldExportDecoder {
-    fn default() -> Self {
-        JournaldExportDecoder {
-            state: Default::default(),
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/common/state/src/lib.rs
+++ b/common/state/src/lib.rs
@@ -252,6 +252,7 @@ impl FileOffsetShutdownHandle {
 #[derive(Clone)]
 pub struct FileOffsetState {
     db: Arc<DB>,
+    #[allow(dead_code)]
     cf_opts: Options,
     rx: std::cell::RefCell<Option<async_channel::Receiver<FileOffsetEvent>>>,
     shutdown: std::cell::RefCell<Option<async_channel::Sender<FileOffsetEvent>>>,

--- a/docs/README.md
+++ b/docs/README.md
@@ -161,6 +161,7 @@ options are available:
 |`LOGDNA_INGEST_TIMEOUT`|The timeout of the API calls to the ingest API in milliseconds|`10000`|
 |`LOGDNA_INGEST_BUFFER_SIZE`|The size, in bytes, of the ingest data buffer used to batch log data with.|`2097152`|
 |`LOGDNA_RETRY_DIR`|The directory used by the agent to store data temporarily while retrying calls to the ingestion API.|`/tmp/logdna`|
+|`LOGDNA_RETRY_DISK_LIMIT`|The maximum amount of disk space the agent will use to store retry data. The value can be the total number of bytes or a human representation of space using suffixes "KB", "MB", "GB" or "TB", e.g. `10 MB` If left unset, the agent will not limit disk usage. If set to `0`, no retry data will be stored on disk.||
 
 All regular expressions use [Perl-style syntax][regex-syntax] with case sensitivity by default. If you don't
 want to differentiate between capital and lower-case letters, use non-capturing groups with a flag: `(?flags:exp)`,


### PR DESCRIPTION
New configuration parameter now allows for limiting the amount of disk space the agent will use to store retry files. The usage is tracked across the sending and consuming retry structs and the disk usage metric now references that counter. Also updates the existing retry integration tests to separate out the retry directory used so each test now has a clean state on execution.

Ref: LOG-10296