### PR TITLE
build: Picking main line linting fixes over

### DIFF
--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -127,7 +127,7 @@ impl<T: PartialEq + Clone> Merge for Vec<T> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 pub struct Config {
     pub http: HttpConfig,
     pub log: LogConfig,
@@ -218,16 +218,10 @@ pub struct LogConfig {
     pub log_k8s_events: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 pub struct JournaldConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub paths: Option<Vec<PathBuf>>,
-}
-
-impl Default for JournaldConfig {
-    fn default() -> Self {
-        JournaldConfig { paths: None }
-    }
 }
 
 impl Merge for JournaldConfig {
@@ -236,35 +230,16 @@ impl Merge for JournaldConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 pub struct Rules {
     pub glob: Vec<String>,
     pub regex: Vec<String>,
-}
-
-impl Default for Rules {
-    fn default() -> Self {
-        Rules {
-            glob: Vec::new(),
-            regex: Vec::new(),
-        }
-    }
 }
 
 impl Merge for Rules {
     fn merge(&mut self, other: &Self, default: &Self) {
         self.glob.merge(&other.glob, &default.glob);
         self.regex.merge(&other.regex, &default.regex);
-    }
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            http: HttpConfig::default(),
-            log: LogConfig::default(),
-            journald: JournaldConfig::default(),
-        }
     }
 }
 

--- a/common/fs/src/rule.rs
+++ b/common/fs/src/rule.rs
@@ -11,6 +11,7 @@ pub trait Rule {
     fn matches(&self, value: &Path) -> bool;
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum RuleDef {
     RegexRule(Regex),

--- a/common/http/src/limit.rs
+++ b/common/http/src/limit.rs
@@ -99,6 +99,7 @@ impl<T> AsRef<T> for Slot<T> {
 #[derive(Debug)]
 struct InnerSlot<T> {
     inner: T,
+    #[allow(dead_code)]
     slot: usize,
     slots: Arc<AtomicUsize>,
 }

--- a/common/journald/src/journalctl/mod.rs
+++ b/common/journald/src/journalctl/mod.rs
@@ -32,16 +32,9 @@ const KEY_SYSLOG_IDENTIFIER: &str = "SYSLOG_IDENTIFIER";
 const KEY_CONTAINER_NAME: &str = "CONTAINER_NAME";
 const DEFAULT_APP: &str = "UNKNOWN_SYSTEMD_APP";
 
+#[derive(Default)]
 pub struct JournaldExportDecoder {
     state: AnyPartialState,
-}
-
-impl Default for JournaldExportDecoder {
-    fn default() -> Self {
-        JournaldExportDecoder {
-            state: Default::default(),
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/common/state/src/lib.rs
+++ b/common/state/src/lib.rs
@@ -252,6 +252,7 @@ impl FileOffsetShutdownHandle {
 #[derive(Clone)]
 pub struct FileOffsetState {
     db: Arc<DB>,
+    #[allow(dead_code)]
     cf_opts: Options,
     rx: std::cell::RefCell<Option<async_channel::Receiver<FileOffsetEvent>>>,
     shutdown: std::cell::RefCell<Option<async_channel::Sender<FileOffsetEvent>>>,


### PR DESCRIPTION
After updating the Jenkins build container images, we have some new linting rule failures that have been addressed in master as part of PR #279. This PR applies those changes to the 3.4 branch so we can build it again.