### PR TITLE
test: hardening up the metrics integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ dependencies = [
  "config",
  "env_logger",
  "escargot",
+ "float-cmp",
  "fs",
  "futures",
  "http 0.1.0",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -82,6 +82,7 @@ hyper = { version = "0.14", features = ["http1"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 prometheus-parse = { git = "https://github.com/ccakes/prometheus-parse-rs", rev = "a4574e9" }
+float-cmp = "0.9.0"
 
 [build-dependencies]
 auditable-build = "0.1"

--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -14,7 +14,6 @@ use crate::common::{consume_output, AgentSettings};
 
 use assert_cmd::prelude::*;
 use futures::FutureExt;
-use hyper::{Client, StatusCode};
 use log::debug;
 use predicates::prelude::*;
 use proptest::prelude::*;
@@ -384,60 +383,6 @@ fn test_exclusion_rules() {
 
     common::assert_agent_running(&mut agent_handle);
 
-    agent_handle.kill().expect("Could not kill process");
-}
-
-#[tokio::test]
-#[cfg_attr(not(feature = "integration_tests"), ignore)]
-async fn test_metrics_endpoint() {
-    let dir = tempdir().expect("Could not create temp dir").into_path();
-    let included_file = dir.join("file1.log");
-    let port = 9881;
-
-    let mut agent_handle = common::spawn_agent(AgentSettings {
-        log_dirs: dir.to_str().unwrap(),
-        metrics_port: Some(port),
-        ..Default::default()
-    });
-
-    let mut stderr_reader = BufReader::new(agent_handle.stderr.take().unwrap());
-    common::wait_for_event("Enabling prometheus endpoint", &mut stderr_reader);
-
-    // Append to a file and wait for the notify event
-    common::append_to_file(&included_file, 100, 5).unwrap();
-    common::wait_for_file_event("tailer sendings lines", &included_file, &mut stderr_reader);
-    let mut body_str = String::new();
-
-    // Wait for all the metrics to be tracked
-    for _ in 0..20 {
-        let client = Client::new();
-        let url = format!("http://127.0.0.1:{}/metrics", port)
-            .parse()
-            .unwrap();
-        if let Ok(response) = client.get(url).await {
-            assert_eq!(response.status(), StatusCode::OK);
-
-            let buf = hyper::body::to_bytes(response).await.unwrap();
-            body_str = std::str::from_utf8(&buf).unwrap().to_string();
-
-            // Request duration metrics are the last ones to appear
-            if body_str.contains("logdna_agent_ingest_request_duration") {
-                break;
-            }
-        }
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-
-    assert!(body_str.contains("# TYPE logdna_agent_fs_bytes counter"));
-    assert!(body_str.contains("# TYPE logdna_agent_fs_lines counter"));
-    assert!(body_str.contains("# TYPE logdna_agent_ingest_request_size histogram"));
-    assert!(body_str.contains("# TYPE logdna_agent_ingest_request_duration_millis histogram"));
-    assert!(body_str.contains("# TYPE logdna_agent_fs_events counter"));
-    // One created file
-    assert!(body_str.contains("logdna_agent_fs_events{event_type=\"create\"} 1"));
-
-    common::assert_agent_running(&mut agent_handle);
     agent_handle.kill().expect("Could not kill process");
 }
 

--- a/bin/tests/metrics.rs
+++ b/bin/tests/metrics.rs
@@ -1,0 +1,264 @@
+mod common;
+
+use std::io::BufReader;
+use std::time::Duration;
+
+use float_cmp::approx_eq;
+use prometheus_parse::{Sample, Value};
+use tempfile::tempdir;
+
+use common::AgentSettings;
+pub use common::*;
+
+fn check_fs_bytes(samples: &Vec<Sample>) {
+    let fs_bytes = samples
+        .iter()
+        .filter_map(|s| match s.value {
+            Value::Counter(raw) if s.metric.as_str() == "logdna_agent_fs_bytes" => Some(raw),
+            _ => None,
+        })
+        .collect::<Vec<f64>>();
+
+    assert!(fs_bytes.len() > 0, "no fs_byte metrics were captured");
+
+    assert!(
+        *fs_bytes.iter().last().unwrap() > f64::EPSILON,
+        "last fs_byte datum should be greater than zero"
+    );
+
+    assert!(
+        fs_bytes.windows(2).all(|w| match w {
+            [a, b] => a <= b,
+            _ => false,
+        }),
+        "fs_bytes should increase in count while run"
+    );
+}
+
+fn check_fs_lines(samples: &Vec<Sample>) {
+    let fs_lines = samples
+        .iter()
+        .filter_map(|s| match s.value {
+            Value::Counter(raw) if s.metric.as_str() == "logdna_agent_fs_lines" => Some(raw),
+            _ => None,
+        })
+        .collect::<Vec<f64>>();
+
+    assert!(fs_lines.len() > 0, "no fs_line metrics were captured");
+    assert!(
+        *fs_lines.iter().last().unwrap() > f64::EPSILON,
+        "last fs_line datum should be greater than zero "
+    );
+    assert!(
+        fs_lines.windows(2).all(|w| match w {
+            [a, b] => a <= b,
+            _ => false,
+        }),
+        "fs_lines should increase in count while run"
+    );
+}
+
+fn check_fs_events(samples: &Vec<Sample>) {
+    // logdna_agent_fs_events
+    let fs_events = samples
+        .iter()
+        .filter_map(|s| match s.value {
+            Value::Counter(raw) if s.metric == "logdna_agent_fs_events" => {
+                Some((raw, s.labels.get("event_type")))
+            }
+            _ => None,
+        })
+        .collect::<Vec<(f64, Option<&str>)>>();
+
+    assert!(fs_events.len() > 0, "no fs_events metrics were captured");
+    assert!(
+        fs_events.iter().any(|result| match result {
+            &(value, Some(event_type)) => value == 1.0 && event_type == "create",
+            _ => false,
+        }),
+        "At least one file create event should be logged. Actual events: {:?}",
+        fs_events
+    );
+    assert!(
+        fs_events.iter().any(|result| match result {
+            &(value, Some(event_type)) => value > 1.0 && event_type == "write",
+            _ => false,
+        }),
+        "At least one file write event should be logged. Actual events: {:?}",
+        fs_events
+    );
+    assert!(
+        fs_events.iter().any(|result| match result {
+            &(value, Some(event_type)) => value == 1.0 && event_type == "delete",
+            _ => false,
+        }),
+        "At least one file delete event should be logged. Actual events: {:?}",
+        fs_events
+    );
+}
+
+fn check_fs_files(samples: &Vec<Sample>) {
+    // logdna_agent_fs_files
+    let fs_files = samples
+        .iter()
+        .filter_map(|s| match s.value {
+            Value::Gauge(raw) if s.metric.as_str() == "logdna_agent_fs_files" => Some(raw),
+            _ => None,
+        })
+        .collect::<Vec<f64>>();
+
+    assert!(fs_files.len() > 0, "no fs_files metrics were captured");
+
+    let first_fs_file = *fs_files.get(0).unwrap();
+    let last_fs_file = *fs_files.iter().last().unwrap();
+    assert_eq!(first_fs_file, last_fs_file);
+    assert!(
+        fs_files.iter().any(|v| *v > first_fs_file),
+        "at least one fs_files gauge should be above starting value"
+    );
+}
+
+fn check_ingest_req_size(samples: &Vec<Sample>) {
+    let expected_bucket_boundaries = vec![
+        500.0,
+        1000.0,
+        2000.0,
+        4000.0,
+        8000.0,
+        16000.0,
+        32000.0,
+        64000.0,
+        128000.0,
+        256000.0,
+        512000.0,
+        1024000.0,
+        2048000.0,
+        f64::INFINITY,
+    ];
+
+    assert!(
+        samples
+            .iter()
+            .filter_map(|s| match &s.value {
+                Value::Histogram(counts)
+                    if s.metric.as_str() == "logdna_agent_ingest_request_size_bucket" =>
+                {
+                    Some(counts.iter().map(|hc| hc.less_than).collect::<Vec<f64>>())
+                }
+                _ => None,
+            })
+            .all(|buckets| buckets == expected_bucket_boundaries),
+        "logdna_agent_ingest_request_size bucket boundries do not match"
+    );
+
+    assert!(samples
+        .iter()
+        .filter_map(|s| match &s.value {
+            Value::Histogram(counts)
+                if s.metric.as_str() == "logdna_agent_ingest_request_size_bucket" =>
+            {
+                Some(counts.iter().map(|hc| hc.count).collect::<Vec<f64>>())
+            }
+            _ => None,
+        })
+        .any(|count| count.iter().any(|value| *value > 0.0)));
+}
+
+fn data_pair_for(name: &str) -> impl Fn(&Sample) -> Option<(i64, f64)> + '_ {
+    move |s: &Sample| match (&s.value, &s.labels.get("outcome")) {
+        (Value::Untyped(raw), Some("success")) if s.metric.as_str() == name => {
+            Some((s.timestamp.timestamp_millis(), *raw))
+        }
+        _ => None,
+    }
+}
+
+fn check_ingest_req_duration(samples: &Vec<Sample>) {
+    let counts = samples
+        .iter()
+        .filter_map(data_pair_for(
+            "logdna_agent_ingest_request_duration_millis_count",
+        ))
+        .zip(samples.iter().filter_map(data_pair_for(
+            "logdna_agent_ingest_request_duration_seconds_count",
+        )))
+        .collect::<Vec<((i64, f64), (i64, f64))>>();
+
+    assert!(
+        counts
+            .iter()
+            .all(|((ms_ts, ms_count), (sec_ts, sec_count))| {
+                *ms_ts == *sec_ts && approx_eq!(f64, *ms_count, *sec_count)
+            }),
+        "counts for req/ms and req/sec should match"
+    );
+
+    let sums = samples
+        .iter()
+        .filter_map(data_pair_for(
+            "logdna_agent_ingest_request_duration_millis_sum",
+        ))
+        .zip(samples.iter().filter_map(data_pair_for(
+            "logdna_agent_ingest_request_duration_seconds_sum",
+        )))
+        .collect::<Vec<((i64, f64), (i64, f64))>>();
+
+    assert!(
+        sums.iter().all(|((ms_ts, ms_sum), (sec_ts, sec_sum))| {
+            // There is some loss of precision in these metrics since the metric is a floating
+            // point number and there is multiple conversions taking place before this point.
+            // Loss of 1/10 of a millisecond seems acceptable to avoid a flakey test.
+            *ms_ts == *sec_ts && approx_eq!(f64, *ms_sum, *sec_sum * 1000.0, epsilon = 0.1)
+        }),
+        "sums for req/ms and req/sec should be equal after conversion to ms; sums = {:?}",
+        sums
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
+async fn test_metrics_endpoint() {
+    let dir = tempdir().expect("Could not create temp dir").into_path();
+    let included_file = dir.join("file1.log");
+    let metrics_port = 9881;
+
+    let (server, _, shutdown_ingest, address) =
+        start_ingester(Box::new(|_| None), Box::new(|_| None));
+
+    let mut settings = AgentSettings::with_mock_ingester(dir.to_str().unwrap(), &address);
+    settings.metrics_port = Some(metrics_port);
+
+    let mut agent_handle = common::spawn_agent(settings);
+    let mut stderr_reader = BufReader::new(agent_handle.stderr.take().unwrap());
+    common::wait_for_event("Enabling prometheus endpoint", &mut stderr_reader);
+
+    let recorder = MetricsRecorder::start(metrics_port, Some(Duration::from_millis(100)));
+    let (_, metrics_result) = tokio::join!(server, async move {
+        // Wait for the agent to bootstrap and then start generating some log data
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        // Generate some log data with pauses to simulate some logging traffic
+        for _ in 1..10 {
+            common::append_to_file(&included_file, 100, 5).unwrap();
+            tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        }
+
+        tokio::fs::remove_file(&included_file).await.unwrap();
+        common::wait_for_event("Delete Event", &mut stderr_reader);
+
+        // Give the agent time to register the delete event before terminating
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        shutdown_ingest();
+        recorder.stop().await
+    });
+
+    common::assert_agent_running(&mut agent_handle);
+    agent_handle.kill().expect("Could not kill process");
+
+    check_fs_bytes(&metrics_result);
+    check_fs_lines(&metrics_result);
+    check_fs_events(&metrics_result);
+    check_fs_files(&metrics_result);
+    check_ingest_req_size(&metrics_result);
+    check_ingest_req_duration(&metrics_result);
+}

--- a/bin/tests/retries.rs
+++ b/bin/tests/retries.rs
@@ -1,13 +1,12 @@
 use common::AgentSettings;
 pub use common::*;
-use hyper::StatusCode;
-use prometheus_parse::{Sample, Scrape, Value};
+use prometheus_parse::Value;
 use rand::Rng;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
 
@@ -305,74 +304,6 @@ async fn gen_log_data(file: &mut File) {
     tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
 }
 
-#[derive(Debug)]
-struct MetricRec {
-    timestamp_ms: i64,
-    raw_value: f64,
-}
-
-impl MetricRec {
-    fn new(timestamp_ms: i64, raw_value: f64) -> Self {
-        Self {
-            timestamp_ms,
-            raw_value,
-        }
-    }
-}
-
-#[derive(Debug)]
-struct TestMetrics {
-    min_timestamp_ms: AtomicI64,
-    max_timestamp_ms: AtomicI64,
-    retry_pending: Vec<MetricRec>,
-    retry_storage_used: Vec<MetricRec>,
-    retry_success: Vec<MetricRec>,
-    retry_failure: Vec<MetricRec>,
-}
-
-impl TestMetrics {
-    fn new() -> Self {
-        TestMetrics {
-            min_timestamp_ms: AtomicI64::new(i64::MAX),
-            max_timestamp_ms: AtomicI64::new(i64::MIN),
-            retry_pending: Vec::new(),
-            retry_storage_used: Vec::new(),
-            retry_success: Vec::new(),
-            retry_failure: Vec::new(),
-        }
-    }
-
-    fn record(&mut self, sample: &Sample) {
-        let ts = sample.timestamp.timestamp_millis();
-        self.min_timestamp_ms.fetch_min(ts, Ordering::Relaxed);
-        self.max_timestamp_ms.fetch_max(ts, Ordering::Relaxed);
-
-        match sample.metric.as_str() {
-            "logdna_agent_retry_pending" => {
-                if let Value::Gauge(v) = sample.value {
-                    self.retry_pending.push(MetricRec::new(ts, v));
-                }
-            }
-            "logdna_agent_retry_storage_used" => {
-                if let Value::Gauge(v) = sample.value {
-                    self.retry_storage_used.push(MetricRec::new(ts, v));
-                }
-            }
-            "logdna_agent_ingest_retries_success" => {
-                if let Value::Counter(c) = sample.value {
-                    self.retry_success.push(MetricRec::new(ts, c));
-                }
-            }
-            "logdna_agent_ingest_retries_failure" => {
-                if let Value::Counter(c) = sample.value {
-                    self.retry_failure.push(MetricRec::new(ts, c));
-                }
-            }
-            _ => {}
-        }
-    }
-}
-
 #[tokio::test]
 #[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_retry_metrics_emitted() {
@@ -420,29 +351,9 @@ async fn test_retry_metrics_emitted() {
 
     // This creates a new thread that scrapes the metrics from the agent process and
     // stores all the values for the retry metrics under test.
-    let scrape_metrics = Arc::new(AtomicBool::new(true));
-    let rec_metrics = Arc::new(Mutex::new(TestMetrics::new()));
+    let recorder = MetricsRecorder::start(metrics_port, Some(Duration::from_millis(100)));
 
-    let metrics_handle = tokio::spawn({
-        let scrape_metrics = scrape_metrics.clone();
-        let rec_metrics = rec_metrics.clone();
-
-        async move {
-            while scrape_metrics.load(Ordering::Relaxed) {
-                if let Ok((StatusCode::OK, Some(data))) =
-                    common::fetch_agent_metrics(metrics_port).await
-                {
-                    let lines = data.lines().map(|l| Ok(l.to_string()));
-                    for sample in Scrape::parse(lines).unwrap().samples {
-                        rec_metrics.lock().as_mut().unwrap().record(&sample);
-                    }
-                }
-                tokio::time::sleep(Duration::from_millis(100)).await;
-            }
-        }
-    });
-
-    let (server_result, _, _) = tokio::join!(server, metrics_handle, async move {
+    let (ingest_result, metrics_result) = tokio::join!(server, async move {
         // Wait for the agent to bootstrap and then start generating some log data
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
         gen_log_data(&mut log_file).await;
@@ -458,76 +369,116 @@ async fn test_retry_metrics_emitted() {
         tokio::time::sleep(tokio::time::Duration::from_millis(6000)).await;
         gen_log_data(&mut log_file).await;
 
-        // Shut down the scraper and ingest server
-        scrape_metrics.store(false, Ordering::Relaxed);
         shutdown_ingest();
+        recorder.stop().await
     });
 
-    server_result.unwrap();
+    // Shut down processes
+    ingest_result.unwrap();
     agent_handle.kill().unwrap();
+
+    // Extract a set of metrics that are revelent for this test
+    let retry_pending = metrics_result
+        .iter()
+        .filter_map(|s| match s.value {
+            Value::Gauge(raw) if s.metric.as_str() == "logdna_agent_retry_pending" => {
+                Some((s.timestamp.timestamp_millis(), raw))
+            }
+            _ => None,
+        })
+        .collect::<Vec<(i64, f64)>>();
+
+    let retry_success = metrics_result
+        .iter()
+        .filter_map(|s| match s.value {
+            Value::Counter(raw) if s.metric.as_str() == "logdna_agent_ingest_retries_success" => {
+                Some((s.timestamp.timestamp_millis(), raw))
+            }
+            _ => None,
+        })
+        .collect::<Vec<(i64, f64)>>();
+
+    let retry_failure = metrics_result
+        .iter()
+        .filter_map(|s| match s.value {
+            Value::Counter(raw) if s.metric.as_str() == "logdna_agent_ingest_retries_failure" => {
+                Some((s.timestamp.timestamp_millis(), raw))
+            }
+            _ => None,
+        })
+        .collect::<Vec<(i64, f64)>>();
+
+    let retry_storage_used = metrics_result
+        .iter()
+        .filter_map(|s| match s.value {
+            Value::Gauge(raw) if s.metric.as_str() == "logdna_agent_retry_storage_used" => {
+                Some((s.timestamp.timestamp_millis(), raw))
+            }
+            _ => None,
+        })
+        .collect::<Vec<(i64, f64)>>();
+
+    let min_timestamp_ms = metrics_result
+        .iter()
+        .map(|s| s.timestamp.timestamp_millis())
+        .min()
+        .unwrap();
+
+    let max_timestamp_ms = metrics_result
+        .iter()
+        .map(|s| s.timestamp.timestamp_millis())
+        .max()
+        .unwrap();
 
     // Assertions
     //
     // There should be at least 1 metric recorded for each of the retry metrics.
-    let rec_metrics = rec_metrics.lock().unwrap();
-
-    assert!(!rec_metrics.retry_pending.is_empty());
-    assert!(!rec_metrics.retry_success.is_empty());
-    assert!(!rec_metrics.retry_failure.is_empty());
-    assert!(!rec_metrics.retry_storage_used.is_empty());
+    assert!(!retry_pending.is_empty());
+    assert!(!retry_success.is_empty());
+    assert!(!retry_failure.is_empty());
+    assert!(!retry_storage_used.is_empty());
 
     // The pending count should start and end at 0 since the agent starts normal and
     // then recovers. This metric is a gauge and is allowed to move up and down.
-    let pending_first = rec_metrics.retry_pending.get(0).unwrap();
-    let pending_last = rec_metrics.retry_pending.iter().last().unwrap();
-    assert!(pending_first.raw_value < f64::EPSILON);
-    assert!(pending_last.raw_value < f64::EPSILON);
+    let pending_first = retry_pending.get(0).unwrap();
+    let pending_last = retry_pending.iter().last().unwrap();
+    assert!(pending_first.1 < f64::EPSILON);
+    assert!(pending_last.1 < f64::EPSILON);
 
     // The pending count should have some recorded value that greater than 0 if the
     // agent did actually enter a retry loop.
-    rec_metrics.retry_pending.iter().any(|r| r.raw_value > 0.0);
+    retry_pending.iter().any(|r| r.1 > 0.0);
 
     // The retry success/failure counts first metric data point should only occur after
     // the first recorded metric and continue since they are counters and counters only
     // emit on the first increment.
-    let success_first = rec_metrics.retry_success.get(0).unwrap();
-    let failure_first = rec_metrics.retry_failure.get(0).unwrap();
-    assert!(rec_metrics.min_timestamp_ms.load(Ordering::Relaxed) < success_first.timestamp_ms);
-    assert!(rec_metrics.min_timestamp_ms.load(Ordering::Relaxed) < failure_first.timestamp_ms);
+    let success_first = retry_success.get(0).unwrap();
+    let failure_first = retry_failure.get(0).unwrap();
+    assert!(min_timestamp_ms < success_first.0);
+    assert!(min_timestamp_ms < failure_first.0);
 
-    let success_last = rec_metrics.retry_success.iter().last().unwrap();
-    let failure_last = rec_metrics.retry_failure.iter().last().unwrap();
-    assert!(success_last.timestamp_ms <= rec_metrics.max_timestamp_ms.load(Ordering::Relaxed));
-    assert!(failure_last.timestamp_ms <= rec_metrics.max_timestamp_ms.load(Ordering::Relaxed));
+    let success_last = retry_success.iter().last().unwrap();
+    let failure_last = retry_failure.iter().last().unwrap();
+    assert!(success_last.0 <= max_timestamp_ms);
+    assert!(failure_last.0 <= max_timestamp_ms);
 
     // Each of the success counts should be greater than or equal to the prior count.
-    assert!(rec_metrics.retry_success.windows(2).all(|w| match w {
-        [a, b] => a.raw_value <= b.raw_value,
+    assert!(retry_success.windows(2).all(|w| match w {
+        [a, b] => a.1 <= b.1,
         _ => false,
     }));
 
     // Each of the failure counts should be greater than or equal to the prior count.
-    assert!(rec_metrics.retry_failure.windows(2).all(|w| match w {
-        [a, b] => a.raw_value <= b.raw_value,
+    assert!(retry_failure.windows(2).all(|w| match w {
+        [a, b] => a.1 <= b.1,
         _ => false,
     }));
 
     // The amount of space used for retries should increase but then eventually decrease to to zero
     // as the agent recovers. Note that zero values won't appear at first since nothing has reported
     // a metric until a retry attempt.
-    assert!(rec_metrics
-        .retry_storage_used
-        .iter()
-        .any(|r| r.raw_value > 0.0));
-    assert!(
-        rec_metrics
-            .retry_storage_used
-            .iter()
-            .last()
-            .unwrap()
-            .raw_value
-            < f64::EPSILON
-    );
+    assert!(retry_storage_used.iter().any(|r| r.1 > 0.0));
+    assert!(retry_storage_used.iter().last().unwrap().1 < f64::EPSILON);
 }
 
 /// Creates a temp config file with required fields and the provided parameters

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -205,6 +205,7 @@ impl Middleware for K8sMetadata {
         });
     }
 
+    #[allow(clippy::question_mark)]
     fn process<'a>(&self, line: &'a mut dyn LineBufferMut) -> Status<&'a mut dyn LineBufferMut> {
         if let Some(file_name) = line.get_file() {
             if let Some(key) = parse_container_path(file_name) {

--- a/common/middleware/src/line_rules.rs
+++ b/common/middleware/src/line_rules.rs
@@ -125,6 +125,7 @@ impl LineRules {
             redacted.extend_from_slice(&value[index..]);
         }
 
+        #[allow(clippy::question_mark)]
         if line.set_line_buffer(redacted).is_err() {
             return Status::Skip;
         }


### PR DESCRIPTION
Building off the retry metrics work, this PR updates the existing metrics test case to not just check that metrics data points are defined. but also makes assertions about the captured values to ensure they are working as we intended. The test case also expands the number of metrics looked at, bringing the coverage to 12/15 metrics. 

I did find one metric that was never emitted in the code base and thus removed its definition.  

Ref: LOG-11063