### PR TITLE
Feat: Adds Metrics to Benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ dependencies = [
  "futures",
  "hyper",
  "indicatif",
+ "logdna-metrics-recorder",
  "logdna-mock-ingester",
  "memmap2",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,12 +200,16 @@ dependencies = [
  "async-channel",
  "escargot",
  "file-rotate",
+ "futures",
+ "hyper",
  "indicatif",
  "logdna-mock-ingester",
  "memmap2",
  "nix",
  "owning_ref",
  "procfs",
+ "prometheus 0.13.0",
+ "prometheus-parse",
  "rand",
  "structopt",
  "tokio",
@@ -1013,7 +1017,7 @@ dependencies = [
  "logdna-client",
  "metrics",
  "num_cpus",
- "prometheus",
+ "prometheus 0.12.0",
  "proptest",
  "rand",
  "serde",
@@ -1650,7 +1654,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num",
- "prometheus",
+ "prometheus 0.12.0",
  "tikv-jemalloc-ctl",
  "tokio",
 ]
@@ -2211,6 +2215,21 @@ dependencies = [
  "memchr",
  "parking_lot",
  "procfs",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
  "protobuf",
  "thiserror",
 ]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -17,6 +17,7 @@ futures = "0.3.19"
 hyper = "0.14.16"
 indicatif = "0.16"
 logdna_mock_ingester = { package = "logdna-mock-ingester", path = "../common/test/mock-ingester" }
+logdna-metrics-recorder = { package = "logdna-metrics-recorder", path = "../utils/metrics-recorder" }
 memmap2 = "0.3"
 nix = "0.23"
 owning_ref = "0.4"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -13,12 +13,16 @@ path = "bin/throughput.rs"
 async-channel = "1.6"
 escargot = { version = "0.5", features = ["print"] }
 file-rotate = "0.4"
+futures = "0.3.19"
+hyper = "0.14.16"
 indicatif = "0.16"
 logdna_mock_ingester = { package = "logdna-mock-ingester", path = "../common/test/mock-ingester" }
 memmap2 = "0.3"
 nix = "0.23"
 owning_ref = "0.4"
 procfs = "0.9"
+prometheus = "0.13.0"
+prometheus-parse = { git = "https://github.com/ccakes/prometheus-parse-rs", rev = "a4574e9" }
 rand = "0.8"
 structopt = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/bench/bin/throughput.rs
+++ b/bench/bin/throughput.rs
@@ -571,7 +571,7 @@ async fn main() -> Result<(), std::io::Error> {
         fs_line_metrics.0, fs_line_metrics.1
     );
     println!(
-        "\nINGESTION METRICS\n . Totol Time (sec): {:?}\n . Average Duration (sec): {:?}\n . Average Request Size (bytes): {:?}",
+        "\nINGESTION METRICS\n . Total Time (sec): {:?}\n . Average Duration (sec): {:?}\n . Average Request Size (bytes): {:?}",
         ingest_time_metrics.0, ingest_time_metrics.1, ingest_size_metrics
     );
     println!(

--- a/bench/bin/throughput.rs
+++ b/bench/bin/throughput.rs
@@ -500,7 +500,7 @@ async fn main() -> Result<(), std::io::Error> {
         ingest_time_metrics.0, ingest_size_metrics.0, ingest_size_metrics.1, ingest_time_metrics.1, ingest_size_metrics.2
     );
     println!(
-        "\nMEMEORY METRICS:\n . Max Process Virtual Memory (bytes): {:?}\n",
+        "\nMEMORY METRICS:\n . Max Process Virtual Memory (bytes): {:?}\n",
         max_memory
     );
 

--- a/bench/bin/throughput.rs
+++ b/bench/bin/throughput.rs
@@ -185,8 +185,8 @@ fn calculate_ingest_time_metrics(samples: &[Sample]) -> (i64, f64) {
         ingest_duration_sample[0];
 
     let ingest_total_time = (last_sum_tv - first_sum_tv) / 1000;
-    let ingest_count_rate = *last_count_val / ingest_total_time as f64;
-    (ingest_total_time, ingest_count_rate)
+    let ingest_average_request_time = *last_sum_val / *last_count_val;
+    (ingest_total_time, ingest_average_request_time)
 }
 
 fn calulate_ingest_size_metrics(samples: &[Sample]) -> (f64, f64, f64) {
@@ -492,12 +492,12 @@ async fn main() -> Result<(), std::io::Error> {
     let ingest_size_metrics = calulate_ingest_size_metrics(&metrics_result);
     let max_memory = calculate_memory_max(&metrics_result);
     println!(
-        "\nFILE SYSTEM METRICS\n . Total Time (sec): {:?}\n . Total Lines: {:?}\n . Line Rate (lines/sec): {:?}\n . Total Size (bytes): {:?}\n . Size Rate (bytes/sec): {:?}",
+        "\nFILE SYSTEM METRICS\n . Total Time (sec): {:?}\n . Total Lines: {:?}\n . Line Rate (lines/sec): {:?}\n . Total Size (bytes): {:?}\n . File Rate (bytes/sec): {:?}",
         fs_size_metrics.0, fs_line_metrics.0, fs_line_metrics.1, fs_size_metrics.1, fs_size_metrics.2
     );
     println!(
-        "\nINGESTION METRICS\n . Total Time (sec): {:?}\n . Total Ingestion Request Size (bytes): {:?}\n . Total # of Samples: {:?}\n . Sample Rate (samples/sec): {:?}\n . Ingestion Rate (bytes/sec): {:?}",
-        ingest_time_metrics.0, ingest_size_metrics.0, ingest_size_metrics.1, ingest_time_metrics.1, (ingest_size_metrics.0 / ingest_time_metrics.0 as f64)
+        "\nINGESTION METRICS\n . Total Time (sec): {:?}\n . Total Size (bytes): {:?}\n . Total number of Samples: {:?}\n . Average Request Duration (sec): {:?}\n . Average Request Size (bytes): {:?}",
+        ingest_time_metrics.0, ingest_size_metrics.0, ingest_size_metrics.1, ingest_time_metrics.1, ingest_size_metrics.2
     );
     println!(
         "\nMEMEORY METRICS:\n . Max Process Virtual Memory (bytes): {:?}\n",


### PR DESCRIPTION
This PR extends to current benchmark project by collecting various metrics during the benchmark runtime. It then writes a summary of these metrics to STDOUT and  all gathered metrics to a `metrics_output.log` file.

Tests:
Ran on local machine as well as EC2 dev/test instance.


TODO: 
- [x] Merge #294 