### PR TITLE
Fix: Add Default Inclusion Rule to Include Extention-less Files

### DIFF
--- a/common/config/src/argv.rs
+++ b/common/config/src/argv.rs
@@ -617,10 +617,7 @@ mod test {
         assert_eq!(
             config.log.include,
             Some(Rules {
-                glob: vec![
-                    "*.log".parse().unwrap(),
-                    "!(*.*)".parse().unwrap(),
-                ],
+                glob: vec!["*.log".parse().unwrap(), "!(*.*)".parse().unwrap()],
                 regex: Vec::new(),
             })
         );
@@ -725,7 +722,7 @@ mod test {
 
         assert_eq!(
             inclusion.glob,
-            vec_strings!["*.log", "!(*.*)","included.ext", "another.*"]
+            vec_strings!["*.log", "!(*.*)", "included.ext", "another.*"]
         );
         assert_eq!(inclusion.regex, vec_strings!["a", "b", "c"])
     }

--- a/common/config/src/argv.rs
+++ b/common/config/src/argv.rs
@@ -617,7 +617,10 @@ mod test {
         assert_eq!(
             config.log.include,
             Some(Rules {
-                glob: vec!["*.log".parse().unwrap()],
+                glob: vec![
+                    "*.log".parse().unwrap(),
+                    "!(*.*)".parse().unwrap(),
+                ],
                 regex: Vec::new(),
             })
         );
@@ -722,7 +725,7 @@ mod test {
 
         assert_eq!(
             inclusion.glob,
-            vec_strings!["*.log", "included.ext", "another.*"]
+            vec_strings!["*.log", "!(*.*)","included.ext", "another.*"]
         );
         assert_eq!(inclusion.regex, vec_strings!["a", "b", "c"])
     }

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -376,7 +376,10 @@ impl Default for LogConfig {
             db_path: None,
             metrics_port: None,
             include: Some(Rules {
-                glob: vec!["*.log".parse().unwrap()],
+                glob: vec![
+                    "*.log".parse().unwrap(),
+                    "!(*.*)".parse().unwrap(),
+                ],
                 regex: Vec::new(),
             }),
             exclude: Some(Rules {
@@ -461,6 +464,23 @@ mod tests {
         assert!(new_config.is_ok());
         let new_config = new_config.unwrap();
         assert_eq!(config, new_config);
+    }
+
+    #[test]
+    fn test_default_glob() {
+        let default_glob = LogConfig::default()
+            .include
+            .unwrap()
+            .glob
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<String>>();
+        assert_eq!(
+            default_glob,
+            vec![
+                String::from("*.log"),
+                String::from("!(*.*)")
+            ])
     }
 
     #[test]

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -376,10 +376,7 @@ impl Default for LogConfig {
             db_path: None,
             metrics_port: None,
             include: Some(Rules {
-                glob: vec![
-                    "*.log".parse().unwrap(),
-                    "!(*.*)".parse().unwrap(),
-                ],
+                glob: vec!["*.log".parse().unwrap(), "!(*.*)".parse().unwrap()],
                 regex: Vec::new(),
             }),
             exclude: Some(Rules {
@@ -477,10 +474,8 @@ mod tests {
             .collect::<Vec<String>>();
         assert_eq!(
             default_glob,
-            vec![
-                String::from("*.log"),
-                String::from("!(*.*)")
-            ])
+            vec![String::from("*.log"), String::from("!(*.*)")]
+        )
     }
 
     #[test]


### PR DESCRIPTION
The default behavior of the agent was to include only files with a `.log` extention. However, the documentation states that this it should include extention-less file as well. This PR adds a new default glob that will include extention-less files by default.

Tests:
Ran locally and confirmed that extention-less files were not being included by default, after the fix, I could see extention-less files being consumed. Also, tested that the behavior is the same regardless of glob order.  