### PR TITLE
Updated Defaults in README and Include Common Glob Pattern

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -166,7 +166,7 @@ options are available:
 |`LOGDNA_LOG_DIRS`<br>**Deprecated**: `LOG_DIRS`|Comma separated list of folders to recursively monitor for log events|`/var/log/`|
 |`LOGDNA_EXCLUSION_RULES`<br>**Deprecated**: `LOGDNA_EXCLUDE`|Comma separated list of glob patterns to exclude files from monitoring <sup>1</sup>|`/var/log/wtmp,/var/log/btmp,/var/log/utmp,` <br>`/var/log/wtmpx,/var/log/btmpx,/var/log/utmpx,` <br>`/var/log/asl/**,/var/log/sa/**,/var/log/sar*,` <br>`/var/log/tallylog,/var/log/fluentd-buffers/**/*,` <br>`/var/log/pods/**/*`|
 |`LOGDNA_EXCLUSION_REGEX_RULES`<br>**Deprecated**: `LOGDNA_EXCLUDE_REGEX`|Comma separated list of regex patterns to exclude files from monitoring||
-|`LOGDNA_INCLUSION_RULES`<br>**Deprecated**: `LOGDNA_INCLUDE`|Comma separated list of glob patterns to includes files for monitoring <sup>1</sup>|`*.log,!(*.*)`|
+|`LOGDNA_INCLUSION_RULES`<br>**Deprecated**: `LOGDNA_INCLUDE`|Comma separated list of glob patterns to includes files for monitoring <sup>1</sup>|`*.log`|
 |`LOGDNA_INCLUSION_REGEX_RULES`<br>**Deprecated**: `LOGDNA_INCLUDE_REGEX`|Comma separated list of regex patterns to include files from monitoring||
 |`LOGDNA_LINE_EXCLUSION_REGEX`|Comma separated list of regex patterns to exclude log lines. When set, the Agent will NOT send log lines that match any of these patterns.||
 |`LOGDNA_LINE_INCLUSION_REGEX`|Comma separated list of regex patterns to include log lines. When set, the Agent will send ONLY log lines that match any of these patterns.||
@@ -191,6 +191,10 @@ for example:
 ```
 
 1. We support [this flavor of globber syntax](https://github.com/CJP10/globber).
+
+As listed above, by default the agent will only ingest files with a `.log` extention. Some other common globing patterns used in the `LOGDNA_INCLUSION_RULES` include: 
+
+1. Include both `.log` extention AND extention-less files: `*.log,!(*.*)`.
 
 ### Configuring the Environment
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -192,9 +192,9 @@ for example:
 
 1. We support [this flavor of globber syntax](https://github.com/CJP10/globber).
 
-As listed above, by default the agent will only ingest files with a `.log` extention. Some other common globing patterns used in the `LOGDNA_INCLUSION_RULES` include: 
+As listed above, by default the agent will only ingest files with a `.log` extention. Some other common globing patterns to include in the `LOGDNA_INCLUSION_RULES` could be: 
 
-1. Include both `.log` extention AND extention-less files: `*.log,!(*.*)`.
+1. Pattern to ingest files with both a `.log` extention AND extention-less files: `*.log,!(*.*)`
 
 ### Configuring the Environment
 


### PR DESCRIPTION
This removes the extention-less files from the default values list and makes a note about including that pattern via environment variable.