### PR TITLE
Refactor Metrics Recorder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
  "logdna-client",
  "metrics",
  "num_cpus",
- "prometheus",
+ "prometheus 0.12.0",
  "proptest",
  "rand",
  "serde",
@@ -1650,9 +1650,19 @@ dependencies = [
  "lazy_static",
  "log",
  "num",
- "prometheus",
+ "prometheus 0.12.0",
  "tikv-jemalloc-ctl",
  "tokio",
+]
+
+[[package]]
+name = "metrics-recorder"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "hyper",
+ "prometheus 0.13.0",
+ "prometheus-parse",
 ]
 
 [[package]]
@@ -2211,6 +2221,21 @@ dependencies = [
  "memchr",
  "parking_lot",
  "procfs",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
  "protobuf",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,7 @@ dependencies = [
  "kube-runtime",
  "lazy_static",
  "log",
+ "logdna-metrics-recorder",
  "logdna-mock-ingester",
  "metrics",
  "middleware",
@@ -1586,6 +1587,17 @@ dependencies = [
  "time 0.3.6",
  "tokio",
  "utf-8",
+]
+
+[[package]]
+name = "logdna-metrics-recorder"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "hyper",
+ "prometheus 0.13.0",
+ "prometheus-parse",
+ "tokio",
 ]
 
 [[package]]
@@ -1653,16 +1665,6 @@ dependencies = [
  "prometheus 0.12.0",
  "tikv-jemalloc-ctl",
  "tokio",
-]
-
-[[package]]
-name = "metrics-recorder"
-version = "0.1.0"
-dependencies = [
- "futures",
- "hyper",
- "prometheus 0.13.0",
- "prometheus-parse",
 ]
 
 [[package]]
@@ -3034,9 +3036,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ members = [
     "common/middleware",
     "common/journald",
     "common/state",
-    "bench"
+    "bench",
+    "utils/metrics-recorder"
 ]
 
 [profile.release]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -70,6 +70,7 @@ rustls = "0.20"
 rustls-pemfile = "0.2"
 rcgen = "0.8"
 logdna_mock_ingester = { package = "logdna-mock-ingester", path = "../common/test/mock-ingester" }
+logdna-metrics-recorder = { package = "logdna-metrics-recorder", path = "../utils/metrics-recorder" }
 test_types = { package = "types", path = "../common/test/types" }
 proptest = "1"
 tokio-test = "0.4"

--- a/bin/tests/common.rs
+++ b/bin/tests/common.rs
@@ -1,7 +1,5 @@
 use core::time;
 
-use hyper::{Client, StatusCode};
-use prometheus_parse::{Sample, Scrape};
 use rand::seq::IteratorRandom;
 
 use std::fs;
@@ -12,13 +10,10 @@ use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
 use std::sync::mpsc::TryRecvError;
 use std::thread;
-use std::time::Duration;
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
 
-use futures::future::{AbortHandle, Abortable};
-use futures::stream::{Stream, StreamExt};
-use futures::{stream, Future};
+use futures::Future;
 use log::debug;
 use logdna_mock_ingester::{
     http_ingester, http_ingester_with_processors, https_ingester_with_processors, FileLineCounter,
@@ -460,108 +455,4 @@ pub fn start_ingester(
         shutdown_handle,
         format!("localhost:{}", port),
     )
-}
-
-// The compiler/linter believes this function isn't used anywhere but it is currently
-// used in the retries and http integration tests. This flag disables that false positive.
-#[allow(dead_code)]
-pub async fn fetch_agent_metrics(
-    metrics_port: u16,
-) -> Result<(StatusCode, Option<String>), hyper::Error> {
-    let client = Client::new();
-    let url = format!("http://127.0.0.1:{}/metrics", metrics_port)
-        .parse()
-        .unwrap();
-
-    let resp = client.get(url).await?;
-    let status = resp.status();
-    let body = if status == StatusCode::OK {
-        let buf = hyper::body::to_bytes(resp).await?;
-        let body_str = std::str::from_utf8(&buf).unwrap().to_string();
-        Some(body_str)
-    } else {
-        None
-    };
-
-    Ok((status, body))
-}
-
-// The compiler/linter believes this function isn't used anywhere but it is currently
-// used in the retries and http integration tests. This flag disables that false positive.
-#[allow(dead_code)]
-fn stream_agent_metrics(
-    metrics_port: u16,
-    scrape_delay: Option<Duration>,
-) -> impl Stream<Item = Sample> {
-    stream::unfold(Vec::new(), move |state| async move {
-        let mut state = loop {
-            if !state.is_empty() {
-                break state;
-            }
-
-            // Hitting the metrics endpoint too quick may result in subsequent queries without
-            // any data points. Depending on need, one can specify a delay before scrapping giving
-            // the agent time to generate some new metric data.
-            if let Some(delay) = scrape_delay {
-                tokio::time::sleep(delay).await;
-            }
-
-            match fetch_agent_metrics(metrics_port).await {
-                Ok((StatusCode::OK, Some(body))) => {
-                    let body = body.lines().map(|l| Ok(l.to_string()));
-                    break Scrape::parse(body)
-                        .expect("failed to parse the metrics response")
-                        .samples;
-                }
-                Ok((status, _)) => panic!(
-                    "The /metrics endpoint returned status code {:?}, expected 200.",
-                    status
-                ),
-                Err(err) => panic!(
-                    "Failed to make HTTP request to metrics endpoint - reason: {:?}",
-                    err
-                ),
-            }
-        };
-
-        state.pop().map(|metric| (metric, state))
-    })
-}
-
-// The compiler/linter believes this function isn't used anywhere but it is currently
-// used in the retries and http integration tests. This flag disables that false positive.
-#[allow(dead_code)]
-pub struct MetricsRecorder {
-    server: tokio::task::JoinHandle<Vec<Sample>>,
-    abort_handle: AbortHandle,
-}
-
-impl MetricsRecorder {
-    // The compiler/linter believes this function isn't used anywhere but it is currently
-    // used in the retries and http integration tests. This flag disables that false positive.
-    #[allow(dead_code)]
-    pub fn start(port: u16, scrape_delay: Option<Duration>) -> MetricsRecorder {
-        let (abort_handle, abort_registration) = AbortHandle::new_pair();
-        MetricsRecorder {
-            server: tokio::spawn({
-                async move {
-                    Abortable::new(stream_agent_metrics(port, scrape_delay), abort_registration)
-                        .collect::<Vec<Sample>>()
-                        .await
-                }
-            }),
-            abort_handle,
-        }
-    }
-
-    // The compiler/linter believes this function isn't used anywhere but it is currently
-    // used in the retries and http integration tests. This flag disables that false positive.
-    #[allow(dead_code)]
-    pub async fn stop(self) -> Vec<Sample> {
-        self.abort_handle.abort();
-        match self.server.await {
-            Ok(data) => data,
-            Err(e) => panic!("error waiting for thread: {}", e),
-        }
-    }
 }

--- a/bin/tests/metrics.rs
+++ b/bin/tests/metrics.rs
@@ -9,6 +9,7 @@ use tempfile::tempdir;
 
 use common::AgentSettings;
 pub use common::*;
+use logdna_metrics_recorder::*;
 
 fn check_fs_bytes(samples: &[Sample]) {
     let fs_bytes = samples

--- a/bin/tests/retries.rs
+++ b/bin/tests/retries.rs
@@ -1,5 +1,6 @@
 use common::AgentSettings;
 pub use common::*;
+use logdna_metrics_recorder::*;
 use prometheus_parse::Value;
 use rand::Rng;
 use std::fs::File;

--- a/utils/metrics-recorder/Cargo.toml
+++ b/utils/metrics-recorder/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "metrics-recorder"
+name = "logdna-metrics-recorder"
 version = "0.1.0"
 edition = "2021"
 
@@ -8,3 +8,4 @@ futures = "0.3.19"
 hyper = "0.14.16"
 prometheus = "0.13.0"
 prometheus-parse = { git = "https://github.com/ccakes/prometheus-parse-rs", rev = "a4574e9" }
+tokio = { version = "1", features = ["rt-multi-thread", "signal"] }

--- a/utils/metrics-recorder/Cargo.toml
+++ b/utils/metrics-recorder/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "metrics-recorder"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+futures = "0.3.19"
+hyper = "0.14.16"
+prometheus = "0.13.0"
+prometheus-parse = { git = "https://github.com/ccakes/prometheus-parse-rs", rev = "a4574e9" }

--- a/utils/metrics-recorder/Cargo.toml
+++ b/utils/metrics-recorder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "logdna-metrics-recorder"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 futures = "0.3.19"

--- a/utils/metrics-recorder/src/lib.rs
+++ b/utils/metrics-recorder/src/lib.rs
@@ -1,0 +1,110 @@
+use std::fs::File;
+use futures::future::{AbortHandle, Abortable};
+use futures::stream;
+use futures::stream::{Stream, StreamExt};
+use hyper::{Client, StatusCode};
+use std::time::Duration;
+use prometheus_parse::{Sample, Scrape, Value};
+
+#[allow(dead_code)]
+pub async fn fetch_agent_metrics(
+    metrics_port: u16,
+) -> Result<(StatusCode, Option<String>), hyper::Error> {
+    let client = Client::new();
+    let url = format!("http://127.0.0.1:{}/metrics", metrics_port)
+        .parse()
+        .unwrap();
+
+    let resp = client.get(url).await?;
+    let status = resp.status();
+    let body = if status == StatusCode::OK {
+        let buf = hyper::body::to_bytes(resp).await?;
+        let body_str = std::str::from_utf8(&buf).unwrap().to_string();
+        Some(body_str)
+    } else {
+        None
+    };
+
+    Ok((status, body))
+}
+
+#[allow(dead_code)]
+fn stream_agent_metrics(
+    metrics_port: u16,
+    scrape_delay: Option<Duration>,
+) -> impl Stream<Item = Sample> {
+    stream::unfold(Vec::new(), move |state| async move {
+        let mut state = loop {
+            if !state.is_empty() {
+                break state;
+            }
+
+            // Hitting the metrics endpoint too quick may result in subsequent queries without
+            // any data points. Depending on need, one can specify a delay before scrapping giving
+            // the agent time to generate some new metric data.
+            if let Some(delay) = scrape_delay {
+                tokio::time::sleep(delay).await;
+            }
+
+            match fetch_agent_metrics(metrics_port).await {
+                Ok((StatusCode::OK, Some(body))) => {
+                    let body = body.lines().map(|l| Ok(l.to_string()));
+                    break Scrape::parse(body)
+                        .expect("failed to parse the metrics response")
+                        .samples;
+                }
+                Ok((status, _)) => panic!(
+                    "The /metrics endpoint returned status code {:?}, expected 200.",
+                    status
+                ),
+                Err(err) => panic!(
+                    "Failed to make HTTP request to metrics endpoint - reason: {:?}",
+                    err
+                ),
+            }
+        };
+
+        state.pop().map(|metric| (metric, state))
+    })
+}
+
+#[allow(dead_code)]
+pub struct MetricsRecorder {
+    server: tokio::task::JoinHandle<Vec<Sample>>,
+    abort_handle: AbortHandle,
+}
+
+impl MetricsRecorder {
+    #[allow(dead_code)]
+    pub fn start(port: u16, scrape_delay: Option<Duration>) -> MetricsRecorder {
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        MetricsRecorder {
+            server: tokio::spawn({
+                async move {
+                    Abortable::new(stream_agent_metrics(port, scrape_delay), abort_registration)
+                        .collect::<Vec<Sample>>()
+                        .await
+                }
+            }),
+            abort_handle,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn stop(self) -> Vec<Sample> {
+        self.abort_handle.abort();
+        match self.server.await {
+            Ok(data) => data,
+            Err(e) => panic!("error waiting for thread: {}", e),
+        }
+    }
+}
+
+fn data_pair_for(name: &str) -> impl Fn(&Sample) -> Option<(i64, f64)> + '_ {
+    move |s: &Sample| match (&s.value, &s.labels.get("outcome")) {
+        (Value::Untyped(raw), Some("success")) if s.metric.as_str() == name => {
+            Some((s.timestamp.timestamp_millis(), *raw))
+        }
+        _ => None,
+    }
+}

--- a/utils/metrics-recorder/src/lib.rs
+++ b/utils/metrics-recorder/src/lib.rs
@@ -1,10 +1,9 @@
-use std::fs::File;
 use futures::future::{AbortHandle, Abortable};
 use futures::stream;
 use futures::stream::{Stream, StreamExt};
 use hyper::{Client, StatusCode};
+use prometheus_parse::{Sample, Scrape};
 use std::time::Duration;
-use prometheus_parse::{Sample, Scrape, Value};
 
 #[allow(dead_code)]
 pub async fn fetch_agent_metrics(
@@ -97,14 +96,5 @@ impl MetricsRecorder {
             Ok(data) => data,
             Err(e) => panic!("error waiting for thread: {}", e),
         }
-    }
-}
-
-fn data_pair_for(name: &str) -> impl Fn(&Sample) -> Option<(i64, f64)> + '_ {
-    move |s: &Sample| match (&s.value, &s.labels.get("outcome")) {
-        (Value::Untyped(raw), Some("success")) if s.metric.as_str() == name => {
-            Some((s.timestamp.timestamp_millis(), *raw))
-        }
-        _ => None,
     }
 }

--- a/utils/metrics-recorder/src/lib.rs
+++ b/utils/metrics-recorder/src/lib.rs
@@ -5,7 +5,6 @@ use hyper::{Client, StatusCode};
 use prometheus_parse::{Sample, Scrape};
 use std::time::Duration;
 
-#[allow(dead_code)]
 pub async fn fetch_agent_metrics(
     metrics_port: u16,
 ) -> Result<(StatusCode, Option<String>), hyper::Error> {
@@ -27,7 +26,6 @@ pub async fn fetch_agent_metrics(
     Ok((status, body))
 }
 
-#[allow(dead_code)]
 fn stream_agent_metrics(
     metrics_port: u16,
     scrape_delay: Option<Duration>,
@@ -67,14 +65,12 @@ fn stream_agent_metrics(
     })
 }
 
-#[allow(dead_code)]
 pub struct MetricsRecorder {
     server: tokio::task::JoinHandle<Vec<Sample>>,
     abort_handle: AbortHandle,
 }
 
 impl MetricsRecorder {
-    #[allow(dead_code)]
     pub fn start(port: u16, scrape_delay: Option<Duration>) -> MetricsRecorder {
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
         MetricsRecorder {
@@ -89,7 +85,6 @@ impl MetricsRecorder {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn stop(self) -> Vec<Sample> {
         self.abort_handle.abort();
         match self.server.await {


### PR DESCRIPTION
The PR is a prerequisite to #290. It pulls the existing `metrics-recorder` out of `bin/tests` and puts it into its own package so that it can be used in tests as well as bench. 