### PR TITLE
fix: k8s enrichment test always fails on ARM platform

### DIFF
--- a/docker/kind_dispatch.sh
+++ b/docker/kind_dispatch.sh
@@ -24,6 +24,9 @@ _term() {
 trap _term TERM
 trap _term INT
 
+echo "Building socat image"
+DOCKER_BUILDKIT=1 docker build -t "socat:local" $curpath/socat
+
 echo "Building Agent Image"
 DOCKER_BUILDKIT=1 docker build $curpath/.. \
   -f Dockerfile.debian \
@@ -45,6 +48,7 @@ else
 fi
 
 kind load docker-image $image --name $cluster_name
+kind load docker-image "socat:local" --name $cluster_name
 
 echo "Creating k8s resources"
 KUBECONFIG=$curpath/.kind_config_host kubectl apply -f $curpath/kind/test-resources.yaml

--- a/docker/socat/Dockerfile
+++ b/docker/socat/Dockerfile
@@ -1,0 +1,4 @@
+FROM buildpack-deps:buster-curl
+
+RUN apt update
+RUN apt install -y socat

--- a/scripts/mk.k8s-test
+++ b/scripts/mk.k8s-test
@@ -1,0 +1,5 @@
+#!/bin/bash
+OWN_PATH=$(readlink -f "$0")
+OWN_DIR=$(dirname "$OWN_PATH")
+# use local images first
+"$OWN_DIR"/mk k8s-test PULL=0


### PR DESCRIPTION
- replaced "alpine/socat" image by local image built before tests
- increased wait time after pod startups to eliminate intermittent test failures (all platforms)  


LOG-12446