### PR TITLE
Ensure test waits for agent to start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,11 +320,16 @@ release: ## Create a new release from the current beta and push to github
 	git push --follow-tags
 	git checkout $(TARGET_BRANCH) || git checkout -b $(TARGET_BRANCH)
 
+DEB_VERSION=1
+DEB_ARCH_NAME_x86_64=amd64
+DEB_ARCH_NAME_aarch64=arm64
+
 .PHONY:build-image
 build-image: ## Build a docker image as specified in the Dockerfile
 	$(DOCKER) build . -t $(REPO):$(IMAGE_TAG) \
 		$(PULL_OPTS) \
 		--progress=plain \
+		--platform=linux/${DEB_ARCH_NAME_${ARCH}} \
 		--secret id=aws,src=$(AWS_SHARED_CREDENTIALS_FILE) \
 		--rm \
 		--build-arg BUILD_ENVS="$(BUILD_ENVS)" \
@@ -340,10 +345,6 @@ build-image: ## Build a docker image as specified in the Dockerfile
 		--build-arg SCCACHE_BUCKET=$(SCCACHE_BUCKET) \
 		--build-arg SCCACHE_REGION=$(SCCACHE_REGION) \
 		--build-arg SCCACHE_ENDPOINT=$(SCCACHE_ENDPOINT)
-
-DEB_VERSION=1
-DEB_ARCH_NAME_x86_64=amd64
-DEB_ARCH_NAME_aarch64=arm64
 
 .PHONY:build-deb
 build-deb: build-release

--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -728,7 +728,8 @@ proptest! {
                         ..Default::default()
                     });
 
-                    let stderr_reader = std::io::BufReader::new(handle.stderr.take().unwrap());
+                    let mut stderr_reader = std::io::BufReader::new(handle.stderr.take().unwrap());
+                    common::wait_for_event("initialized", &mut stderr_reader);
                     std::thread::spawn(move || {
                         stderr_reader.lines().for_each(|line| debug!("{:?}", line))
                     });
@@ -825,7 +826,8 @@ fn lookback_none_lines_are_delivered() {
                 });
                 debug!("spawned agent");
 
-                let stderr_reader = std::io::BufReader::new(handle.stderr.take().unwrap());
+                let mut stderr_reader = std::io::BufReader::new(handle.stderr.take().unwrap());
+                common::wait_for_event("initialized", &mut stderr_reader);
                 std::thread::spawn(move || {
                     stderr_reader.lines().for_each(|line| debug!("{:?}", line))
                 });


### PR DESCRIPTION
This adds a wait to the start of the lookback integration tests so they wait for the agent to actually print some output before continuing with the test