### PR TITLE
Backport explicit Jenkins node label and integration test delay fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,11 @@ def publishGCRImage = false
 def publishDockerhubICRImages = false
 
 pipeline {
-    agent any
+    agent {
+        node {
+            label "ec2-fleet"
+        }
+    }
     options {
         timeout time: 2, unit: 'HOURS'
         timestamps()

--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -727,7 +727,8 @@ proptest! {
                         ..Default::default()
                     });
 
-                    let stderr_reader = std::io::BufReader::new(handle.stderr.take().unwrap());
+                    let mut stderr_reader = std::io::BufReader::new(handle.stderr.take().unwrap());
+                    common::wait_for_event("initialized", &mut stderr_reader);
                     std::thread::spawn(move || {
                         stderr_reader.lines().for_each(|line| debug!("{:?}", line))
                     });
@@ -824,7 +825,8 @@ fn lookback_none_lines_are_delivered() {
                 });
                 debug!("spawned agent");
 
-                let stderr_reader = std::io::BufReader::new(handle.stderr.take().unwrap());
+                let mut stderr_reader = std::io::BufReader::new(handle.stderr.take().unwrap());
+                common::wait_for_event("initialized", &mut stderr_reader);
                 std::thread::spawn(move || {
                     stderr_reader.lines().for_each(|line| debug!("{:?}", line))
                 });


### PR DESCRIPTION
This fixes the 3.4 build on the new jenkins setup