### PR TITLE
Add extra docker pull to make sure images are fixed up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,7 @@ build-image: ## Build a docker image as specified in the Dockerfile
 		--build-arg SCCACHE_BUCKET=$(SCCACHE_BUCKET) \
 		--build-arg SCCACHE_REGION=$(SCCACHE_REGION) \
 		--build-arg SCCACHE_ENDPOINT=$(SCCACHE_ENDPOINT)
+	if [ ! -z "$(PULL_OPTS)" ]; then $(DOCKER) pull $(RUST_IMAGE); fi
 
 .PHONY:build-deb
 build-deb: build-release


### PR DESCRIPTION
Docker has strange behaviour where it seems to remember the last image used for a particular tag. This can cause very strange behaviour if you use a non-host image with an explicit --platform arg and then go back to using a bare docker run