### PR TITLE
Explicitly pass cli args to Config so that it doesn't try and parse the args for it's unit test binary

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -59,7 +59,7 @@ async fn main() {
     dep_audit::get_auditable_dependency_list()
         .map_or_else(|e| trace!("{}", e), |d| trace!("{}", d));
 
-    let config = match Config::new() {
+    let config = match Config::new(std::env::args_os()) {
         Ok(v) => v,
         Err(e) => {
             error!("config error: {}", e);

--- a/common/config/src/argv.rs
+++ b/common/config/src/argv.rs
@@ -4,6 +4,7 @@ use http::types::params::{Params, Tags};
 use humanize_rs::bytes::Bytes;
 use k8s::K8sTrackingConf;
 use std::env::var as env_var;
+use std::ffi::OsString;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -366,8 +367,12 @@ impl ArgumentOptions {
     }
 
     /// Parse command line options, default env vars and additional (deprecated) env vars.
-    pub fn from_args_with_all_env_vars() -> ArgumentOptions {
-        let options: ArgumentOptions = ArgumentOptions::from_args();
+    pub fn from_args_with_all_env_vars<I>(iter: I) -> ArgumentOptions
+    where
+        I: IntoIterator,
+        I::Item: Into<OsString> + Clone,
+    {
+        let options: ArgumentOptions = ArgumentOptions::from_iter(iter);
         ArgumentOptions::parse_deprecated(options)
     }
 

--- a/common/http/Cargo.toml
+++ b/common/http/Cargo.toml
@@ -13,7 +13,7 @@ state = { package = "state", path = "../state" }
 logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.6.x", version = "0.6" }
 
 #io
-tokio = { version = "1", features = ["fs", "io-util"] }
+tokio = { version = "1", features = ["fs", "macros", "io-util"] }
 async-compat = "0.2.1"
 #utils
 log = "0.4"


### PR DESCRIPTION
This is a very small change so that we now pass the cli args explicitly to Config rather than it reading from the environment itself.

This allows us to pass arguments to the unit test binaries again eg `cargo test -- --nocapture` without Config attempting to parse them and exiting when it finds an arg it doesn't understand.