### PR TITLE
Cache CargoBuild in integration tests

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -56,7 +56,6 @@ libjournald = ["journald/libjournald"]
 journald_tests = ["journald/journald_tests"]
 
 [dev-dependencies]
-lazy_static = "*"
 assert_cmd = "1"
 escargot = "0.5"
 kube = { version = "0.59", default-features = false, features = ["rustls-tls"] }
@@ -84,6 +83,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 prometheus-parse = { git = "https://github.com/ccakes/prometheus-parse-rs", rev = "a4574e9" }
 float-cmp = "0.9.0"
+once_cell = "1.10"
+serial_test = "0.6"
 
 [build-dependencies]
 auditable-build = "0.1"


### PR DESCRIPTION
The integration tests have to build the agent in the background in order to be able to test it.

Locally cargo caching seems to handle this fine and doesn't do any extra work, on jenkins it is slower (possibly slower disks when validating the build cache?).

This updates the spawn_agent function to cache the cargo build commands in a global so that only one build can execute at once per test binary and each subsequent build with a particular feature set will reuse the CargoRun command