### PR TITLE
Pin rustls to 0.20.2 as 0.20.3 and 0.20.4 have spurious error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,7 +1146,7 @@ dependencies = [
  "http 0.2.6",
  "hyper",
  "log",
- "rustls 0.20.4",
+ "rustls 0.20.2",
  "rustls-native-certs 0.6.1",
  "tokio",
  "tokio-rustls 0.23.2",
@@ -1460,7 +1460,7 @@ dependencies = [
  "kube-core 0.69.1",
  "pem 1.0.2",
  "pin-project 1.0.10",
- "rustls 0.20.4",
+ "rustls 0.20.2",
  "rustls-pemfile",
  "secrecy",
  "serde",
@@ -1667,7 +1667,7 @@ dependencies = [
  "proptest",
  "rand",
  "rcgen",
- "rustls 0.20.4",
+ "rustls 0.20.2",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1702,7 +1702,7 @@ dependencies = [
  "hyper-rustls 0.23.0",
  "log",
  "pin-project 1.0.10",
- "rustls 0.20.4",
+ "rustls 0.20.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1736,7 +1736,7 @@ dependencies = [
  "hyper-rustls 0.23.0",
  "log",
  "rcgen",
- "rustls 0.20.4",
+ "rustls 0.20.2",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2635,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.4"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
 dependencies = [
  "log",
  "ring",
@@ -3285,7 +3285,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
 dependencies = [
- "rustls 0.20.4",
+ "rustls 0.20.2",
  "tokio",
  "webpki 0.22.0",
 ]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -65,7 +65,7 @@ pnet = "0.28"
 itertools = "0.10"
 predicates = "2"
 tempfile = "3"
-rustls = "0.20"
+rustls = "=0.20.2"
 rustls-pemfile = "0.2"
 rcgen = "0.8"
 logdna_mock_ingester = { package = "logdna-mock-ingester", path = "../common/test/mock-ingester" }


### PR DESCRIPTION
Very simple PR to specify a precise version of rustls which doesn't produce the ServerHelloDone log messages