### PR TITLE
feat: helper script for starting kind cluster

### DIFF
--- a/scripts/mk
+++ b/scripts/mk
@@ -4,11 +4,11 @@ OWN_PATH=$(readlink -f "$0")
 OWN_DIR=$(dirname "$OWN_PATH")
 pushd "$OWN_DIR/.."
 export DOCKER_BUILDKIT=1
-echo "[default]" > ${PWD}/.aws_creds_static
-echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${PWD}/.aws_creds_static
-echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${PWD}/.aws_creds_static
+echo "[default]" > "${PWD}/.aws_creds_static"
+echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> "${PWD}/.aws_creds_static"
+echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> "${PWD}/.aws_creds_static"
 time make ARCH="${ARCH:-$(uname -m)}" AWS_SHARED_CREDENTIALS_FILE="${PWD}/.aws_creds_static" "$@"
-rm ${PWD}/.aws_creds_static
+rm "${PWD}/.aws_creds_static"
 echo
 echo @@@@@@  SUCCESS  @@@@@@
 echo

--- a/scripts/mk.start.kind
+++ b/scripts/mk.start.kind
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# - build "socat:local" image
+# - build "logdna-agent-kind:building" image 
+# - load images into Kind
+# - start Kind cluster
+#
+set -e
+OWN_PATH=$(readlink -f "$0")
+OWN_DIR=$(dirname "$OWN_PATH")
+pushd "$OWN_DIR/.."
+
+./docker/kind_start.sh
+sed -i "s/127.0.0.1/agent-dev-cluster-control-plane/" ./docker/.kind_config_host
+
+source ./docker/lib.sh
+
+echo "Building socat image"
+DOCKER_BUILDKIT=1 docker build -t "socat:local" ./docker/socat
+
+echo "Building Agent Image"
+image="logdna-agent-kind:building"
+DOCKER_BUILDKIT=1 docker build . \
+  -f Dockerfile.debian \
+  -t "$image" \
+  --pull \
+  --progress=plain \
+  --build-arg BUILD_IMAGE=docker.io/logdna/build-images:rust-buster-1-stable-$(get_host_arch) \
+  --build-arg SCCACHE_BUCKET=$SCCACHE_BUCKET \
+  --build-arg SCCACHE_REGION=$SCCACHE_REGION
+
+echo "Loading into kind"
+
+if [ -z "$BUILD_TAG" ]
+then
+  cluster_name=agent-dev-cluster
+else
+  cluster_name=$(echo $BUILD_TAG | tr '[:upper:]' '[:lower:]' | tail -c 32)
+fi
+
+kind load docker-image $image --name "$cluster_name"
+kind load docker-image "socat:local" --name "$cluster_name"
+
+
+echo
+echo @@@@@@  SUCCESS  @@@@@@
+echo

--- a/scripts/mk.start.kind
+++ b/scripts/mk.start.kind
@@ -11,7 +11,16 @@ OWN_DIR=$(dirname "$OWN_PATH")
 pushd "$OWN_DIR/.."
 
 ./docker/kind_start.sh
+# workaround for Rust
 sed -i "s/127.0.0.1/agent-dev-cluster-control-plane/" ./docker/.kind_config_host
+HOSTS=$(</etc/hosts)
+if [[ ! $HOSTS =~ "agent-dev-cluster-control-plane" ]]; then
+  echo "Add '127.0.0.1 agent-dev-cluster-control-plane' to /etc/hosts file!"
+  exit 1
+fi
+
+echo "Creating sample-pod & sample-job"
+KUBECONFIG=./docker/.kind_config_host kubectl apply -f ./docker/kind/test-resources.yaml
 
 source ./docker/lib.sh
 


### PR DESCRIPTION
- helper script for starting kind cluster with pre-loaded images for development

Test:
`kubectl cluster-info --context kind-agent-dev-cluster --kubeconfig ./docker/.kind_config_host`

LOG-12651