### PR TITLE
Log 12405 update k8s builds to link against target image binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN dnf install --releasever=8 --forcearch="${TARGET_ARCH}" \
 
 RUN printf "/* GNU ld script\n*/\n\
 OUTPUT_FORMAT(elf64-%s)\n\
-GROUP ( /usr/lib64/libgcc_s.so.1  AS_NEEDED ( /usr/lib64/libgcc_s.so.1 ) )" $(echo ${TARGET_ARCH} | tr '_' '-' ) > $SYSROOT_PATH/usr/lib64/libgcc_s.so
+GROUP ( /usr/lib64/libgcc_s.so.1  AS_NEEDED ( /usr/lib64/libgcc_s.so.1 ) )" "$(echo ${TARGET_ARCH} | tr '_' '-' )" > $SYSROOT_PATH/usr/lib64/libgcc_s.so
 
 # Add the actual agent source files
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 # syntax = docker/dockerfile:1.0-experimental
 
+ARG UBI_VERSION=8.5
 ARG TARGET_ARCH=x86_64
 ARG BUILD_IMAGE
 # Image that runs natively on the BUILDPLATFORM to produce cross compile
 # artifacts
 
-FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi8/ubi-minimal:8.4 as target
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi8/ubi-minimal:${UBI_VERSION} as target
 
 FROM --platform=${BUILDPLATFORM} ${BUILD_IMAGE} as build
 
@@ -87,8 +88,11 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     cp ./target/${TARGET}/release/logdna-agent /logdna-agent && \
     sccache --show-stats
 
+
+ARG UBI_VERSION
+
 # Use Red Hat Universal Base Image Minimal as the final base image
-FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi8/ubi-minimal:${UBI_VERSION}
 
 ARG REPO
 ARG BUILD_TIMESTAMP

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN dnf install --releasever=8 --forcearch="${TARGET_ARCH}" \
         --installroot=$SYSROOT_PATH/ --repo=ubi-8-baseos --repo=ubi-8-appstream \
         --repo=ubi-8-codeready-builder -y $UBI_PACKAGES
 
+# Linker file to hint where the linker can find libgcc_s as the packaged symlink is broken
 RUN printf "/* GNU ld script\n*/\n\
 OUTPUT_FORMAT(elf64-%s)\n\
 GROUP ( /usr/lib64/libgcc_s.so.1  AS_NEEDED ( /usr/lib64/libgcc_s.so.1 ) )" "$(echo ${TARGET_ARCH} | tr '_' '-' )" > $SYSROOT_PATH/usr/lib64/libgcc_s.so

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -62,7 +62,7 @@ WORKDIR /work/
 RUN apt update -y \
     && apt upgrade -y \
     && apt auto-remove -y \
-    && apt install -y --no-install-recommends ca-certificates libcap2 \
+    && apt install -y --no-install-recommends ca-certificates libcap2-bin \
                    netcat-openbsd nmap dnsutils vim curl procps net-tools \
                    gdbserver \
     && rm -rf /var/cache/apt \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/opt/rust/cargo/registry  \
     sccache --show-stats
 
 # Use Debian as agent base image
-FROM debian:buster
+FROM debian:bullseye
 
 ARG REPO
 ARG BUILD_TIMESTAMP

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/opt/rust/cargo/registry  \
     sccache --show-stats
 
 # Use Debian as agent base image
-FROM debian:buster
+FROM debian:bullseye
 
 ARG REPO
 ARG BUILD_TIMESTAMP
@@ -62,7 +62,7 @@ WORKDIR /work/
 RUN apt update -y \
     && apt upgrade -y \
     && apt auto-remove -y \
-    && apt install ca-certificates libcap2 netcat-openbsd nmap \
+    && apt install ca-certificates libcap2-bin netcat-openbsd nmap \
                    dnsutils vim curl procps net-tools gdbserver -y \
     && rm -rf /var/cache/apt \
     && chmod -R 777 . \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     }
     environment {
         RUST_IMAGE_REPO = 'us.gcr.io/logdna-k8s/rust'
-        RUST_IMAGE_TAG = 'buster-1-stable'
+        RUST_IMAGE_TAG = 'bullseye-1-stable'
         SCCACHE_BUCKET = 'logdna-sccache-us-west-2'
         SCCACHE_REGION = 'us-west-2'
         CARGO_INCREMENTAL = 'false'

--- a/Makefile
+++ b/Makefile
@@ -459,7 +459,7 @@ publish-s3-binary:
 	aws s3 cp --acl public-read target/$(TARGET)/release/logdna-agent s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/logdna-agent
 
 define publish_images
-	$(eval TARGET_VERSIONS := $(TARGET_TAG) $(shell if [ "$(BETA_VERSION)" = "0" ]; then echo "$(BUILD_VERSION)-$(BUILD_DATE).$(shell docker images -q $(REPO):$(IMAGE_TAG)) $(MAJOR_VERSION) $(MAJOR_VERSION).$(MINOR_VERSION)"; fi))
+	$(eval TARGET_VERSIONS := $(TARGET_TAG) $(shell if [ "$(BETA_VERSION)" = "0" ]; then echo "$(BUILD_VERSION)-$(BUILD_DATE).$(BUILD_TAG) $(MAJOR_VERSION) $(MAJOR_VERSION).$(MINOR_VERSION)"; fi))
 	@set -e; \
 	arch=$(shell docker inspect --format "{{.Architecture}}" $(REPO):$(IMAGE_TAG)); \
 	arr=($(TARGET_VERSIONS)); \
@@ -471,7 +471,7 @@ define publish_images
 endef
 
 define publish_images_multi
-	$(eval TARGET_VERSIONS := $(TARGET_TAG) $(shell if [ "$(BETA_VERSION)" = "0" ]; then echo "$(BUILD_VERSION)-$(BUILD_DATE).$(shell docker images -q $(REPO):$(IMAGE_TAG)) $(MAJOR_VERSION) $(MAJOR_VERSION).$(MINOR_VERSION)"; fi))
+	$(eval TARGET_VERSIONS := $(TARGET_TAG) $(shell if [ "$(BETA_VERSION)" = "0" ]; then echo "$(BUILD_VERSION)-$(BUILD_DATE).$(BUILD_TAG) $(MAJOR_VERSION) $(MAJOR_VERSION).$(MINOR_VERSION)"; fi))
 	@set -e; \
 	arr=($(TARGET_VERSIONS)); \
 	for version in $${arr[@]}; do \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export ARCH ?= x86_64
 # The image repo and tag can be modified e.g.
 # `make build RUST_IMAGE=docker.io/rust:latest
 RUST_IMAGE_REPO ?= docker.io/logdna/build-images
-RUST_IMAGE_BASE ?= buster
+RUST_IMAGE_BASE ?= bullseye
 RUST_IMAGE_TAG ?= rust-$(RUST_IMAGE_BASE)-1-stable
 RUST_IMAGE ?= $(RUST_IMAGE_REPO):$(RUST_IMAGE_TAG)-$(ARCH)
 
@@ -360,7 +360,6 @@ build-image: ## Build a docker image as specified in the Dockerfile
 		--build-arg SCCACHE_BUCKET=$(SCCACHE_BUCKET) \
 		--build-arg SCCACHE_REGION=$(SCCACHE_REGION) \
 		--build-arg SCCACHE_ENDPOINT=$(SCCACHE_ENDPOINT)
-	if [ ! -z "$(PULL_OPTS)" ]; then $(DOCKER) pull $(RUST_IMAGE); fi
 
 .PHONY:build-image-debian
 build-image-debian: ## Build a docker image as specified in the Dockerfile.debian

--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,6 @@ build-image: ## Build a docker image as specified in the Dockerfile
 		--build-arg BUILD_IMAGE=$(RUST_IMAGE) \
 		--build-arg TARGET=$(TARGET) \
 		--build-arg TARGET_ARCH=$(ARCH) \
-		--build-arg RUSTFLAGS='$(RUSTFLAGS)' \
 		--build-arg BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
 		--build-arg BUILD_VERSION=$(BUILD_VERSION) \
 		--build-arg FEATURES='$(FEATURES_ARG)' \
@@ -372,7 +371,6 @@ build-image-debian: ## Build a docker image as specified in the Dockerfile.debia
 		--build-arg BUILD_ENVS="$(BUILD_ENVS)" \
 		--build-arg BUILD_IMAGE=$(RUST_IMAGE) \
 		--build-arg TARGET=$(TARGET) \
-		--build-arg RUSTFLAGS='$(RUSTFLAGS)' \
 		--build-arg BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
 		--build-arg BUILD_VERSION=$(BUILD_VERSION) \
 		--build-arg FEATURES='$(FEATURES_ARG)' \
@@ -393,7 +391,6 @@ build-image-debug: ## Build a docker image as specified in the Dockerfile.debug
 		--build-arg BUILD_ENVS="$(BUILD_ENVS)" \
 		--build-arg BUILD_IMAGE=$(RUST_IMAGE) \
 		--build-arg TARGET=$(TARGET) \
-		--build-arg RUSTFLAGS='$(RUSTFLAGS)' \
 		--build-arg BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
 		--build-arg BUILD_VERSION=$(BUILD_VERSION) \
 		--build-arg FEATURES='$(FEATURES_ARG)' \

--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,7 @@ build-image: ## Build a docker image as specified in the Dockerfile
 		--build-arg BUILD_ENVS="$(BUILD_ENVS)" \
 		--build-arg BUILD_IMAGE=$(RUST_IMAGE) \
 		--build-arg TARGET=$(TARGET) \
+		--build-arg TARGET_ARCH=$(ARCH) \
 		--build-arg RUSTFLAGS='$(RUSTFLAGS)' \
 		--build-arg BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
 		--build-arg BUILD_VERSION=$(BUILD_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ SHELLCHECK_IMAGE := $(SHELLCHECK_IMAGE)
 WORKDIR :=/build
 DOCKER := DOCKER_BUILDKIT=1 docker
 DOCKER_DISPATCH := ARCH=$(ARCH) ./docker/dispatch.sh "$(WORKDIR)" "$(shell pwd):/build:Z"
-DOCKER_JOURNALD_DISPATCH := BUILD_IMAGE=${RUST_IMAGE} ARCH=$(ARCH) ./docker/journald_dispatch.sh "$(WORKDIR)" "$(shell pwd):/build:Z"
-DOCKER_KIND_DISPATCH := BUILD_IMAGE=${RUST_IMAGE} ARCH=$(ARCH) ./docker/kind_dispatch.sh "$(WORKDIR)" "$(shell pwd):/build:Z"
+DOCKER_JOURNALD_DISPATCH := BUILD_IMAGE=$(RUST_IMAGE) ARCH=$(ARCH) ./docker/journald_dispatch.sh "$(WORKDIR)" "$(shell pwd):/build:Z"
+DOCKER_KIND_DISPATCH := BUILD_IMAGE=$(RUST_IMAGE) ARCH=$(ARCH) ./docker/kind_dispatch.sh "$(WORKDIR)" "$(shell pwd):/build:Z"
 DOCKER_PRIVATE_IMAGE := us.gcr.io/logdna-k8s/logdna-agent-v2
 DOCKER_PUBLIC_IMAGE ?= docker.io/logdna/logdna-agent
 DOCKER_IBM_IMAGE := icr.io/ext/logdna-agent

--- a/docker/journald_dispatch.sh
+++ b/docker/journald_dispatch.sh
@@ -18,8 +18,6 @@ _term() {
 # shellcheck source=/dev/null
 . "$curpath/lib.sh"
 
-echo "ARCH=$ARCH"
-
 docker build -t "$image" --build-arg "UID=$(id -u)" --build-arg "BUILD_IMAGE=$BUILD_IMAGE" --build-arg "ARCH=$ARCH" -f "$curpath/journald/Dockerfile" "$curpath/.."
 
 trap _term TERM

--- a/docker/kind/Dockerfile
+++ b/docker/kind/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.io/logdna/build-images:rust-buster-stable
+ARG BUILD_IMAGE docker.io/logdna/build-images:rust-bullseye-1-stable-x86_64
+FROM ${BUILD_IMAGE}
 STOPSIGNAL SIGRTMIN+3
 
 RUN mkdir -p /var/cache/sccache

--- a/docker/kind_dispatch.sh
+++ b/docker/kind_dispatch.sh
@@ -27,6 +27,10 @@ trap _term INT
 echo "Building socat image"
 DOCKER_BUILDKIT=1 docker build -t "socat:local" $curpath/socat
 
+if [ -z "${BUILD_IMAGE}" ]; then
+    BUILD_IMAGE="docker.io/logdna/build-images:rust-bullseye-1-stable-$(get_host_arch)"
+fi
+
 echo "Building Agent Image"
 DOCKER_BUILDKIT=1 docker build $curpath/.. \
   -f Dockerfile.debian \

--- a/docker/socat/Dockerfile
+++ b/docker/socat/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:buster-curl
+FROM buildpack-deps:bullseye-curl
 
 RUN apt update
 RUN apt install -y socat

--- a/scripts/mk.start.kind
+++ b/scripts/mk.start.kind
@@ -34,7 +34,7 @@ DOCKER_BUILDKIT=1 docker build . \
   -t "$image" \
   --pull \
   --progress=plain \
-  --build-arg BUILD_IMAGE=docker.io/logdna/build-images:rust-buster-1-stable-$(get_host_arch) \
+  --build-arg BUILD_IMAGE=docker.io/logdna/build-images:rust-bullseye-1-stable-$(get_host_arch) \
   --build-arg SCCACHE_BUCKET=$SCCACHE_BUCKET \
   --build-arg SCCACHE_REGION=$SCCACHE_REGION
 

--- a/scripts/ubi8-sysroot.sh
+++ b/scripts/ubi8-sysroot.sh
@@ -19,7 +19,7 @@ dnf install --releasever="${UBI_MAJOR_VERSION}" --forcearch="${TARGET_ARCH}" \
 
 # Linker file to hint where the linker can find libgcc_s as the packaged symlink is broken \
 printf "/* GNU ld script\n*/\n\nOUTPUT_FORMAT(elf64-%s)\n\n GROUP ( /usr/lib64/libgcc_s.so.1  AS_NEEDED ( /usr/lib64/libgcc_s.so.1 ) )" \
-       "$(echo ${TARGET_ARCH} | tr '_' '-' )" > $SYSROOT_PATH/usr/lib64/libgcc_s.so
+       "$(echo "${TARGET_ARCH}" | tr '_' '-' )" > "$SYSROOT_PATH/usr/lib64/libgcc_s.so"
 
 GCC_VERSION=8
 # Set up env vars so that the compilers know to link against the target image libraries rather than the base image's
@@ -27,13 +27,13 @@ LD_LIBRARY_PATH="-L $SYSROOT_PATH/usr/lib/gcc/${TARGET_ARCH}-redhat-linux/${GCC_
 COMMON_GNU_RUSTFLAGS="-Clink-arg=--sysroot=$SYSROOT_PATH -Clink-arg=-fuse-ld=lld"
 COMMON_GNU_CFLAGS="--sysroot $SYSROOT_PATH -isysroot=$SYSROOT_PATH"
 
-printf "CARGO_TARGET_%s_UNKNOWN_LINUX_GNU_RUSTFLAGS=\"%s -Clink-arg=--target=%s-unknown-linux-gnu\"\n" "$(printf ${TARGET_ARCH} | tr '[:lower:]' '[:upper:]')" "${COMMON_GNU_RUSTFLAGS}" "${TARGET_ARCH}"
+printf "CARGO_TARGET_%s_UNKNOWN_LINUX_GNU_RUSTFLAGS=\"%s -Clink-arg=--target=%s-unknown-linux-gnu\"\n" "$(printf "%s" "${TARGET_ARCH}" | tr '[:lower:]' '[:upper:]')" "${COMMON_GNU_RUSTFLAGS}" "${TARGET_ARCH}"
 
 cflags=$(printf "\${CFLAGS_%s_unknown_linux_gnu} %s %s" "${TARGET_ARCH}" "${COMMON_GNU_CFLAGS}" "${LD_LIBRARY_PATH}")
 cxxflags=$(printf "\${CXXFLAGS_%s_unknown_linux_gnu} %s" "${TARGET_ARCH}" "${COMMON_GNU_CFLAGS}")
 
-echo $(printf "CFLAGS_%s_unknown_linux_gnu=\"%s\"" "${TARGET_ARCH}" "${cflags}")
-echo $(printf "CXXFLAGS_%s_unknown_linux_gnu=\"%s\"" "${TARGET_ARCH}" "${cxxflags}")
+echo "CFLAGS_${TARGET_ARCH}_unknown_linux_gnu=\"${cflags}\""
+echo "CXXFLAGS_${TARGET_ARCH}_unknown_linux_gnu=\"${cxxflags}\""
 
 echo EXTRA_CFLAGS=\""${cflags}"\"
 echo EXTRA_CXXFLAGS=\""${cxxflags}"\"

--- a/scripts/ubi8-sysroot.sh
+++ b/scripts/ubi8-sysroot.sh
@@ -1,24 +1,29 @@
 #!/usr/bin/env bash
 
 TARGET_ARCH="$1"
-UBI_VERSION="$2"
+
+UBI_MAJOR_VERSION="$2"
+UBI_MINOR_VERSION="$3"
+
+UBI_VERSION="${UBI_MAJOR_VERSION}.${UBI_MINOR_VERSION}"
 
 SYSROOT_PATH="/sysroot/ubi-$UBI_VERSION"
 
 ubi_packages="systemd-libs systemd-devel glibc glibc-devel gcc libstdc++-devel libstdc++-static kernel-headers"
 
 apt-get update 1>&2 && apt-get install --no-install-recommends -y dnf 1>&2
-dnf install --releasever=8 --forcearch="${TARGET_ARCH}" \
-            --installroot=$SYSROOT_PATH/ --repo=ubi-8-baseos \
-            --repo=ubi-8-appstream --repo=ubi-8-codeready-builder -y \
+dnf install --releasever="${UBI_MAJOR_VERSION}" --forcearch="${TARGET_ARCH}" \
+            --installroot="$SYSROOT_PATH/" --repo="ubi-${UBI_MAJOR_VERSION}-baseos" \
+            --repo="ubi-${UBI_MAJOR_VERSION}-appstream" --repo="ubi-${UBI_MAJOR_VERSION}-codeready-builder" -y \
             $ubi_packages 1>&2
 
 # Linker file to hint where the linker can find libgcc_s as the packaged symlink is broken \
 printf "/* GNU ld script\n*/\n\nOUTPUT_FORMAT(elf64-%s)\n\n GROUP ( /usr/lib64/libgcc_s.so.1  AS_NEEDED ( /usr/lib64/libgcc_s.so.1 ) )" \
        "$(echo ${TARGET_ARCH} | tr '_' '-' )" > $SYSROOT_PATH/usr/lib64/libgcc_s.so
 
+GCC_VERSION=8
 # Set up env vars so that the compilers know to link against the target image libraries rather than the base image's
-LD_LIBRARY_PATH="-L $SYSROOT_PATH/usr/lib/gcc/${TARGET_ARCH}-redhat-linux/8/ -L $SYSROOT_PATH/usr/lib64"
+LD_LIBRARY_PATH="-L $SYSROOT_PATH/usr/lib/gcc/${TARGET_ARCH}-redhat-linux/${GCC_VERSION}/ -L $SYSROOT_PATH/usr/lib64"
 COMMON_GNU_RUSTFLAGS="-Clink-arg=--sysroot=$SYSROOT_PATH -Clink-arg=-fuse-ld=lld"
 COMMON_GNU_CFLAGS="--sysroot $SYSROOT_PATH -isysroot=$SYSROOT_PATH"
 

--- a/scripts/ubi8-sysroot.sh
+++ b/scripts/ubi8-sysroot.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+TARGET_ARCH="$1"
+UBI_VERSION="$2"
+
+SYSROOT_PATH="/sysroot/ubi-$UBI_VERSION"
+
+ubi_packages="systemd-libs systemd-devel glibc glibc-devel gcc libstdc++-devel libstdc++-static kernel-headers"
+
+apt-get update 1>&2 && apt-get install --no-install-recommends -y dnf 1>&2
+dnf install --releasever=8 --forcearch="${TARGET_ARCH}" \
+            --installroot=$SYSROOT_PATH/ --repo=ubi-8-baseos \
+            --repo=ubi-8-appstream --repo=ubi-8-codeready-builder -y \
+            $ubi_packages 1>&2
+
+# Linker file to hint where the linker can find libgcc_s as the packaged symlink is broken \
+printf "/* GNU ld script\n*/\n\nOUTPUT_FORMAT(elf64-%s)\n\n GROUP ( /usr/lib64/libgcc_s.so.1  AS_NEEDED ( /usr/lib64/libgcc_s.so.1 ) )" \
+       "$(echo ${TARGET_ARCH} | tr '_' '-' )" > $SYSROOT_PATH/usr/lib64/libgcc_s.so
+
+# Set up env vars so that the compilers know to link against the target image libraries rather than the base image's
+LD_LIBRARY_PATH="-L $SYSROOT_PATH/usr/lib/gcc/${TARGET_ARCH}-redhat-linux/8/ -L $SYSROOT_PATH/usr/lib64"
+COMMON_GNU_RUSTFLAGS="-Clink-arg=--sysroot=$SYSROOT_PATH -Clink-arg=-fuse-ld=lld"
+COMMON_GNU_CFLAGS="--sysroot $SYSROOT_PATH -isysroot=$SYSROOT_PATH"
+
+printf "CARGO_TARGET_%s_UNKNOWN_LINUX_GNU_RUSTFLAGS=\"%s -Clink-arg=--target=%s-unknown-linux-gnu\"\n" "$(printf ${TARGET_ARCH} | tr '[:lower:]' '[:upper:]')" "${COMMON_GNU_RUSTFLAGS}" "${TARGET_ARCH}"
+
+cflags=$(printf "\${CFLAGS_%s_unknown_linux_gnu} %s %s" "${TARGET_ARCH}" "${COMMON_GNU_CFLAGS}" "${LD_LIBRARY_PATH}")
+cxxflags=$(printf "\${CXXFLAGS_%s_unknown_linux_gnu} %s" "${TARGET_ARCH}" "${COMMON_GNU_CFLAGS}")
+
+echo $(printf "CFLAGS_%s_unknown_linux_gnu=\"%s\"" "${TARGET_ARCH}" "${cflags}")
+echo $(printf "CXXFLAGS_%s_unknown_linux_gnu=\"%s\"" "${TARGET_ARCH}" "${cxxflags}")
+
+echo EXTRA_CFLAGS=\""${cflags}"\"
+echo EXTRA_CXXFLAGS=\""${cxxflags}"\"
+echo BINDGEN_EXTRA_CLANG_ARGS=\""${cxxflags}"\"
+
+echo LDFLAGS=\""-fuse-ld=lld"\"
+echo SYSTEMD_LIB_DIR=\""$SYSROOT_PATH/lib64"\"


### PR DESCRIPTION
Fix the docker container build so that the build links against the libraries from the target/distribution image rather than the build image.