### PR TITLE
clippy ignore

### DIFF
--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -42,6 +42,7 @@ fn get_file_for_path(fs: &FileSystem, next_path: &std::path::Path) -> Option<Ent
     None
 }
 
+#[allow(clippy::await_holding_refcell_ref)]
 async fn handle_event(
     event: Event,
     fs: &FileSystem,


### PR DESCRIPTION
Ignore newly introduced clippy lint warning.

Posted a ticket to refactor the fs module to remove the pattern that's provoking it: https://logdna.atlassian.net/browse/LOG-13066