### PR TITLE
fix: bench test w/o profiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ test-journald: ## Run journald unit tests
 
 .PHONY:bench
 bench:
-	$(BENCH_COMMAND) "--privileged --env RUST_BACKTRACE=full --env RUST_LOG=$(RUST_LOG)" "PERF=\$$(find /usr/bin -type f -wholename /usr/bin/perf\* | head -n1) cargo run --release --manifest-path bench/Cargo.toml --bin=throughput /dict.txt -o /tmp/out $(PROFILE) --file-history 3 --line-count 100000000 --file-size 20000000 && mv /tmp/flamegraph.svg ."
+	$(BENCH_COMMAND) "--privileged --env RUST_BACKTRACE=full --env RUST_LOG=$(RUST_LOG)" "PERF=\$$(find /usr/bin -type f -wholename /usr/bin/perf\* | head -n1) cargo run --release --manifest-path bench/Cargo.toml --bin=throughput /dict.txt -o /tmp/out $(PROFILE) --file-history 3 --line-count 100000000 --file-size 20000000 && ([ -z '$(PROFILE)' ] || mv /tmp/flamegraph.svg . )"
 
 .PHONY:clean
 clean: ## Clean all artifacts from the build process

--- a/scripts/mk.bench
+++ b/scripts/mk.bench
@@ -2,4 +2,5 @@
 OWN_PATH=$(readlink -f "$0")
 OWN_DIR=$(dirname "$OWN_PATH")
 # use local images first
-"$OWN_DIR"/mk bench PULL=0
+"$OWN_DIR"/mk bench PULL=0 $*
+


### PR DESCRIPTION
fix for error:
`mv: cannot stat '/tmp/flamegraph.svg': No such file or directory`