### PR TITLE
Log 13584 deserialize params as paramsbuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,8 +1623,8 @@ dependencies = [
 
 [[package]]
 name = "logdna-client"
-version = "0.7.0"
-source = "git+https://github.com/logdna/logdna-rust.git?branch=0.7.x#c4522000cf5a6f0b3be4645ca8e7e117628eeb62"
+version = "0.7.1"
+source = "git+https://github.com/logdna/logdna-rust.git?branch=0.7.x#fb26bf0300d74ffdcf6f928fada4a021a8c6215f"
 dependencies = [
  "async-buf-pool",
  "async-compression",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 
 [[package]]
 name = "cache-padded"
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -1623,8 +1623,8 @@ dependencies = [
 
 [[package]]
 name = "logdna-client"
-version = "0.6.0"
-source = "git+https://github.com/logdna/logdna-rust.git?branch=0.6.x#0dc51b85dbc988d48a972a8f2e207a8124cb0061"
+version = "0.7.0"
+source = "git+https://github.com/logdna/logdna-rust.git?branch=0.7.x#c4522000cf5a6f0b3be4645ca8e7e117628eeb62"
 dependencies = [
  "async-buf-pool",
  "async-compression",
@@ -1825,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2018,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 dependencies = [
  "memchr",
 ]
@@ -2094,9 +2094,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
+checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
  "base64",
 ]
@@ -2486,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fa2d386df8533b02184941c76ae2e0d0c1d053f5d43339169d80f21275fc5e"
+checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
@@ -2614,9 +2614,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
+checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
 
 [[package]]
 name = "rusty-fork"
@@ -2722,9 +2722,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
@@ -2741,9 +2741,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2776,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec0091e1f5aa338283ce049bd9dfefd55e1f168ac233e85c1ffe0038fb48cbe"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
@@ -2829,9 +2829,12 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "slotmap"
@@ -2931,9 +2934,9 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -2955,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.24.6"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6e19da72a8d75be4d40e4dd4686afca31507f26c3ffdf6bd3073278d9de0a0"
+checksum = "54cb4ebf3d49308b99e6e9dc95e989e2fdbdc210e4f67c39db0bb89ba927001c"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -3128,10 +3131,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -3340,9 +3344,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-normalization"

--- a/common/http/Cargo.toml
+++ b/common/http/Cargo.toml
@@ -10,7 +10,7 @@ metrics = { package = "metrics", path = "../metrics" }
 state = { package = "state", path = "../state" }
 
 #http
-logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.6.x", version = "0.6" }
+logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.7.x", version = "0.7" }
 
 #io
 tokio = { version = "1", features = ["fs", "io-util", "macros"] }

--- a/common/http/Cargo.toml
+++ b/common/http/Cargo.toml
@@ -10,7 +10,7 @@ metrics = { package = "metrics", path = "../metrics" }
 state = { package = "state", path = "../state" }
 
 #http
-logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.7.x", version = "0.7" }
+logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.7.x", version = "0.7.1" }
 
 #io
 tokio = { version = "1", features = ["fs", "io-util", "macros"] }

--- a/common/test/types/Cargo.toml
+++ b/common/test/types/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
-logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.6.x", version = "0.6" }
+logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.7.x", version = "0.7" }
 proptest = "1"
 serde_json = "1"
 http = { package = "http", path = "../../http" }

--- a/common/test/types/Cargo.toml
+++ b/common/test/types/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
-logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.7.x", version = "0.7" }
+logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.7.x", version = "0.7.1" }
 proptest = "1"
 serde_json = "1"
 http = { package = "http", path = "../../http" }


### PR DESCRIPTION
This adds a trivial custom deserializer for the Params field that first attempts to deserialize it as a ParamsBuilder object and ensures that hostname is correctly defaulted rather than failing to parse the config