### PR TITLE
[Fix] Change K8s Startup Lease Default Value

### DIFF
--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -883,7 +883,7 @@ async fn test_k8s_enrichment() {
             "never",
             "always",
             "warn",
-            "off",
+            "never",
         )
         .await;
 
@@ -1017,7 +1017,7 @@ async fn test_k8s_events_logged() {
             "always",
             "always",
             "warn",
-            "off",
+            "never",
         )
         .await;
 
@@ -1212,7 +1212,7 @@ async fn test_k8s_startup_leases_always_start() {
 
 #[tokio::test]
 #[cfg_attr(not(feature = "k8s_tests"), ignore)]
-async fn test_k8s_startup_leases_off_start() {
+async fn test_k8s_startup_leases_never_start() {
     let _ = env_logger::Builder::from_default_env().try_init();
 
     let (server, received, shutdown_handle, ingester_addr) = common::start_http_ingester();
@@ -1263,7 +1263,7 @@ async fn test_k8s_startup_leases_off_start() {
             "always",
             "always",
             "info",
-            "off",
+            "never",
         )
         .await;
         tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -129,8 +129,8 @@ pub struct JournaldConfig {
 
 #[derive(Clone, core::fmt::Debug, Display, EnumString, PartialEq)]
 pub enum K8sLeaseConf {
-    #[strum(serialize = "off")]
-    Off,
+    #[strum(serialize = "never")]
+    Never,
 
     #[strum(serialize = "attempt")]
     Attempt,
@@ -141,7 +141,7 @@ pub enum K8sLeaseConf {
 
 impl Default for K8sLeaseConf {
     fn default() -> Self {
-        K8sLeaseConf::Off
+        K8sLeaseConf::Never
     }
 }
 
@@ -385,7 +385,7 @@ impl TryFrom<RawConfig> for Config {
         let startup = parse_k8s_enum_config_or_warn(
             raw.startup.option,
             env_vars::K8S_STARTUP_LEASE,
-            K8sLeaseConf::Off,
+            K8sLeaseConf::Never,
         );
 
         let journald = JournaldConfig {
@@ -558,7 +558,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![DEFAULT_LOG_DIR]
         );
-        assert_eq!(config.startup, K8sLeaseConf::Off);
+        assert_eq!(config.startup, K8sLeaseConf::Never);
     }
 
     #[cfg(unix)]

--- a/docs/README.md
+++ b/docs/README.md
@@ -194,7 +194,7 @@ options are available:
 |`LOGDNA_REDACT_REGEX`|Comma separated list of regex patterns used to mask matching sensitive information (such as PII) before sending it in the log line.||
 |`LOGDNA_JOURNALD_PATHS`|Comma separated list of paths (directories or files) of journald paths to monitor||
 |`LOGDNA_LOOKBACK`|The lookback strategy on startup|`none`|
-|`LOGDNA_K8S_STARTUP_LEASE`|Determines whether or not to use K8 leases on startup|`Off`|
+|`LOGDNA_K8S_STARTUP_LEASE`|Determines whether or not to use K8 leases on startup|`never`|
 |`LOGDNA_USE_K8S_LOG_ENRICHMENT`|Determines whether the agent should query the K8s API to enrich log lines from other pods.|`always`|
 |`LOGDNA_LOG_K8S_EVENTS`|Determines whether the agent should log Kubernetes resource events. This setting only affects tracking and logging Kubernetes resource changes via watches. When disabled, the agent may still query k8s metadata to enrich log lines from other pods depending on the value of `LOGDNA_USE_K8S_LOG_ENRICHMENT` setting value.|`never`|
 |`LOGDNA_DB_PATH`|The directory in which the agent will store its state database. Note that the agent must have write access to the directory and be a persistent volume.|`/var/lib/logdna`|
@@ -264,7 +264,7 @@ The valid values for this option are:
 The lease startup configuration uses Kubernetes Leases to limit the number of agents that can start at one time on a cluster. When enabled, the agent will "claim" a lease before starting. Once started, the agent will then release the lease. If no leases are available, the agent will wait for one to become available. This feature would only be needed if running the agent on a cluster large enough that you'd risk crashing `etcd` if all the the agents tried to connect at once.
 
 The valid values for this option are:
-* When set to **`Off`** (default):
+* When set to **`never`** (default):
   * The agent will start normally and will not attempt to obtain a lease before starting.
 * When set to **`attempt`**:
   * The agent will attempt to connect to a lease before starting, but will start anyway after a number of unsuccessful attempts.


### PR DESCRIPTION
This changes the K8's lease startup default value from `off` -> `never`. The reason being that `off` is a special keyword in yaml so if, for some reason, a user wanted to explicitly set the default to `off`, they would need put the value in quotes to ensure it was handled as a string, i.e. `"off"`. 

With this change the default value is in line with other default values and doesn't need to be quoted if used explicitly.  