### PR TITLE
Rewrite config params handling to use ParamsBuilder everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
  "bit-vec",
 ]
@@ -1623,8 +1623,8 @@ dependencies = [
 
 [[package]]
 name = "logdna-client"
-version = "0.7.1"
-source = "git+https://github.com/logdna/logdna-rust.git?branch=0.7.x#fb26bf0300d74ffdcf6f928fada4a021a8c6215f"
+version = "0.7.2"
+source = "git+https://github.com/logdna/logdna-rust.git?branch=0.7.x#1803b6fda29e2e1f3de47b30b07a55359bb8efd7"
 dependencies = [
  "async-buf-pool",
  "async-compression",
@@ -2498,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a"
 dependencies = [
  "bitflags",
 ]
@@ -2722,9 +2722,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
 ]
@@ -2741,9 +2741,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3672,6 +3672,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/common/config/src/argv.rs
+++ b/common/config/src/argv.rs
@@ -227,36 +227,29 @@ impl ArgumentOptions {
             raw.http.gzip_level = self.gzip_level;
         }
 
-        let mut params = match raw.http.params {
-            Some(v) => v,
-            None => Params {
-                hostname: "".to_string(),
-                mac: None,
-                ip: None,
-                now: 0,
-                tags: None,
-            },
-        };
-
+        let mut params = raw.http.params.take().unwrap_or_else(Params::builder);
         if let Some(v) = self.os_hostname {
-            params.hostname = v;
+            params.hostname(v);
         }
-
-        if self.ip.is_some() {
-            params.ip = self.ip;
+        if let Some(ip) = self.ip {
+            params.ip(ip);
         }
-
-        if self.mac.is_some() {
-            params.mac = self.mac;
+        if let Some(mac) = self.mac {
+            params.mac(mac);
         }
 
         if !self.tags.is_empty() {
-            let tags = params.tags.get_or_insert(Tags::new());
+            // Params should always be valid here
+            let mut tags = params
+                .build()
+                .ok()
+                .and_then(|mut p| p.tags.take())
+                .unwrap_or_else(Tags::new);
             with_csv(self.tags).iter().for_each(|v| {
                 tags.add(v);
             });
+            params.tags(tags);
         }
-
         raw.http.params = Some(params);
 
         if self.ingest_timeout.is_some() {
@@ -482,7 +475,9 @@ mod test {
     use super::*;
 
     use crate::raw::{Config as RawConfig, K8sStartupLeaseConfig, Rules};
+
     use humanize_rs::bytes::Unit;
+
     use std::env::set_var;
 
     #[cfg(unix)]
@@ -536,8 +531,9 @@ mod test {
     #[test]
     fn merge_should_combine_existing_tags() {
         let mut config = RawConfig::default();
-        let mut params = config.http.params.unwrap();
-        params.tags = Some(Tags::from(vec!["a".to_owned()]));
+        let mut params = Params::builder();
+        params.hostname("");
+        params.tags(Tags::from(vec!["a".to_owned()]));
         config.http.params = Some(params);
         let options = ArgumentOptions {
             tags: vec!["b".to_owned()],
@@ -546,7 +542,16 @@ mod test {
         let config = options.merge(config);
 
         assert_eq!(
-            config.http.params.as_ref().unwrap().tags.as_ref().unwrap(),
+            config
+                .http
+                .params
+                .unwrap()
+                .build()
+                .as_ref()
+                .unwrap()
+                .tags
+                .as_ref()
+                .unwrap(),
             &Tags::from(vec_strings!["a", "b"])
         );
     }
@@ -557,10 +562,20 @@ mod test {
             tags: vec!["b".to_owned()],
             ..Default::default()
         };
-        let config = options.merge(RawConfig::default());
+        let mut config = options.merge(RawConfig::default());
 
+        config.http.params.as_mut().unwrap().hostname("");
         assert_eq!(
-            config.http.params.as_ref().unwrap().tags.as_ref().unwrap(),
+            config
+                .http
+                .params
+                .unwrap()
+                .build()
+                .as_ref()
+                .unwrap()
+                .tags
+                .as_ref()
+                .unwrap(),
             &Tags::from(vec_strings!["b"])
         );
     }
@@ -568,14 +583,24 @@ mod test {
     #[test]
     fn merge_should_leave_tags_when_empty() {
         let mut config = RawConfig::default();
-        let mut params = config.http.params.unwrap();
-        params.tags = Some(Tags::from(vec!["a".to_owned()]));
+        let mut params = Params::builder();
+        params.hostname("");
+        params.tags(Tags::from(vec!["a".to_owned()]));
         config.http.params = Some(params);
         let options = ArgumentOptions::default();
         let config = options.merge(config);
 
         assert_eq!(
-            config.http.params.as_ref().unwrap().tags.as_ref().unwrap(),
+            config
+                .http
+                .params
+                .unwrap()
+                .build()
+                .as_ref()
+                .unwrap()
+                .tags
+                .as_ref()
+                .unwrap(),
             &Tags::from(vec_strings!["a"])
         );
     }
@@ -583,8 +608,9 @@ mod test {
     #[test]
     fn merge_should_separate_tags_by_comma() {
         let mut config = RawConfig::default();
-        let mut params = config.http.params.unwrap();
-        params.tags = Some(Tags::from(vec!["a".to_owned()]));
+        let mut params = Params::builder();
+        params.hostname("");
+        params.tags(Tags::from(vec!["a".to_owned()]));
         config.http.params = Some(params);
         let options = ArgumentOptions {
             tags: vec!["b,c".to_owned()],
@@ -593,7 +619,16 @@ mod test {
         let config = options.merge(config);
 
         assert_eq!(
-            config.http.params.as_ref().unwrap().tags.as_ref().unwrap(),
+            config
+                .http
+                .params
+                .unwrap()
+                .build()
+                .as_ref()
+                .unwrap()
+                .tags
+                .as_ref()
+                .unwrap(),
             &Tags::from(vec_strings!["a", "b", "c"])
         );
     }
@@ -660,7 +695,7 @@ mod test {
         assert_eq!(config.http.body_size, Some(222222));
         assert_eq!(config.http.retry_dir, Some(PathBuf::from("/tmp/argv")));
         assert_eq!(config.http.retry_disk_limit, Some(123456));
-        let params = config.http.params.unwrap();
+        let params = config.http.params.unwrap().build().unwrap();
         assert_eq!(params.hostname, "my_host");
         assert_eq!(params.tags, Some(Tags::from(vec_strings!("a", "b"))));
         assert_eq!(params.ip, some_string!("1.2.3.4"));

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -190,7 +190,10 @@ impl Config {
             print_settings(&yaml_str, &config_path);
         }
 
-        info!("read the following options from cli, env and config: \n{}", yaml_str);
+        info!(
+            "read the following options from cli, env and config: \n{}",
+            yaml_str
+        );
 
         Config::try_from(raw_config)
     }

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -17,6 +17,7 @@ use async_compression::Level;
 use fs::lookback::Lookback;
 use fs::rule::{RuleDef, Rules};
 use fs::tail::DirPathBuf;
+use http::types::params::Params;
 use http::types::request::{Encoding, RequestTemplate, Schema};
 
 use crate::argv::ArgumentOptions;
@@ -189,7 +190,7 @@ impl Config {
             print_settings(&yaml_str, &config_path);
         }
 
-        info!("starting with the following options: \n{}", yaml_str);
+        info!("read the following options from cli, env and config: \n{}", yaml_str);
 
         Config::try_from(raw_config)
     }
@@ -261,11 +262,24 @@ impl TryFrom<RawConfig> for Config {
             ConfigError::MissingFieldOrEnvVar("http.endpoint", env_vars::ENDPOINT),
         )?);
 
-        template_builder.params(
-            raw.http
-                .params
-                .ok_or(ConfigError::MissingField("http.params"))?,
-        );
+        let params = raw
+            .http
+            .params
+            .and_then(|mut builder| {
+                if builder.build().is_err() {
+                    builder.hostname(get_hostname().unwrap_or_default());
+                }
+                builder.build().ok()
+            })
+            .unwrap_or_else(|| {
+                let mut builder = Params::builder();
+                builder.hostname(get_hostname().unwrap_or_default());
+                builder
+                    .build()
+                    .expect("Failed to create default http.params")
+            });
+
+        template_builder.params(params);
 
         let sys = System::new_with_specifics(RefreshKind::new());
         let info = str::replace(

--- a/common/config/src/properties.rs
+++ b/common/config/src/properties.rs
@@ -1,7 +1,7 @@
+use crate::argv;
 use crate::env_vars;
 use crate::error::ConfigError;
 use crate::raw::{Config, Rules};
-use crate::{argv, get_hostname};
 use http::types::params::{Params, Tags};
 use humanize_rs::bytes::Bytes;
 use java_properties::PropertiesIter;
@@ -148,19 +148,35 @@ fn from_property_map(map: HashMap<String, String>) -> Result<Config, ConfigError
         })?);
     }
 
-    let mut params = Params::builder()
-        .hostname(get_hostname().unwrap_or_default())
-        .build()
-        .unwrap();
-    params.tags = map.get(&TAGS).map(|s| Tags::from(argv::split_by_comma(s)));
+    if let Some(tags) = map.get(&TAGS).map(|s| Tags::from(argv::split_by_comma(s))) {
+        result
+            .http
+            .params
+            .get_or_insert_with(Params::builder)
+            .tags(tags);
+    };
 
     if let Some(value) = map.get_string(&OS_HOSTNAME) {
-        params.hostname = value;
+        result
+            .http
+            .params
+            .get_or_insert_with(Params::builder)
+            .hostname(value);
     }
-    params.ip = map.get_string(&IP);
-    params.mac = map.get_string(&MAC);
-
-    result.http.params = Some(params);
+    if let Some(ip) = map.get_string(&IP) {
+        result
+            .http
+            .params
+            .get_or_insert_with(Params::builder)
+            .ip(ip);
+    }
+    if let Some(mac) = map.get_string(&MAC) {
+        result
+            .http
+            .params
+            .get_or_insert_with(Params::builder)
+            .mac(mac);
+    }
 
     if let Some(value) = map.get(&INGEST_TIMEOUT) {
         result.http.timeout = Some(value.parse().map_err(|e| {

--- a/common/http/Cargo.toml
+++ b/common/http/Cargo.toml
@@ -10,7 +10,7 @@ metrics = { package = "metrics", path = "../metrics" }
 state = { package = "state", path = "../state" }
 
 #http
-logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.7.x", version = "0.7.1" }
+logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.7.x", version = "0.7.2" }
 
 #io
 tokio = { version = "1", features = ["fs", "io-util", "macros"] }

--- a/common/test/types/Cargo.toml
+++ b/common/test/types/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
-logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.7.x", version = "0.7.1" }
+logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.7.x", version = "0.7.2" }
 proptest = "1"
 serde_json = "1"
 http = { package = "http", path = "../../http" }


### PR DESCRIPTION
Had to completely rewrite the Params config handling to make it work properly in all cases.