### PR TITLE
feat: winres support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,8 +1149,8 @@ dependencies = [
  "pcre2",
  "pin-project-lite",
  "pin-utils",
- "regex",
  "rate-limit-macro",
+ "regex",
  "serde_json",
  "slotmap",
  "smallvec",
@@ -2084,6 +2084,7 @@ dependencies = [
  "tracing-subscriber",
  "types",
  "wait-timeout",
+ "winres",
  "winservice",
 ]
 
@@ -4072,6 +4073,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4724,6 +4734,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "winres"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
+dependencies = [
+ "toml",
 ]
 
 [[package]]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -126,6 +126,7 @@ systemd = { package = "systemd", version = "0.10" }
 
 [build-dependencies]
 auditable-build = { version = "0.1", optional = true }
+winres = "0.1"
 
 [profile.release]
 opt-level = 2

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -1,4 +1,26 @@
 fn main() {
     #[cfg(feature = "dep_audit")]
     auditable_build::collect_dependency_list();
+
+    // only run if target os is windows
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
+        let mut res = winres::WindowsResource::new();
+        if cfg!(unix) {
+            // windres tool
+            if let Ok(path) = std::env::var("XWIN_TOOLKIT_BIN_PATH") {
+                res.set_toolkit_path(&path);
+            }
+        }
+        /*
+        // Set more stuff in the resource file
+        res.set_language(0x0409)
+            .set_manifest_file("manifest.xml");
+
+        */
+
+        if let Err(e) = res.compile() {
+            println!("cargo:error={}", e);
+            std::process::exit(1);
+        }
+    }
 }

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -11,6 +11,9 @@ fn main() {
                 res.set_toolkit_path(&path);
             }
         }
+
+        res.set_icon("../packaging/windows/msi/ui/bitmaps/Mezmo.ico");
+
         /*
         // Set more stuff in the resource file
         res.set_language(0x0409)


### PR DESCRIPTION
This allows us to use rc.exe to link manifest files in they way visual studio usually does.

Before:
```
peres -v target/x86_64-pc-windows-msvc/release/logdna-agent.exe
WARNING: Resource directory VA is zero [at resources.c:582]
```
After:
```
DEBUG: id=0x10, dataOffset=0x80000018
DEBUG: id=0x1, dataOffset=0x80000030
DEBUG: id=0x409, dataOffset=0x48
DEBUG: CodePage=0, OffsetToData=19087456[0x1234060], Reserved=0[0], Size=472[0x1d8]
File Version:                    65263.1213.1.0
Product Version:                 3.6.0.0
```
This lets us embed fairly arbitrary information in the agent exe in a way that windows tooling expects (for example being able to set an icon that shows up in explorer etc, version information that appears in the file's property pane etc.)

This would also allow us to use something like 

```
<Product [...] Version="!(bind.FileVersion.File1)" ...
 />
```

in the wix config to pull the version straight out of the agent binary so they can't get out of sync rather than having to do a dance around in the makefile