### PR TITLE
Fix chrono rustsec and bump deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ lint-clippy: ## Checks for code errors
 
 .PHONY:lint-audit
 lint-audit: ## Audits packages for issues
-	$(RUST_COMMAND) "--env RUST_BACKTRACE=full" "cargo audit --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071"
+	$(RUST_COMMAND) "--env RUST_BACKTRACE=full" "cargo audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2022-0040"
 
 .PHONY:lint-docker
 lint-docker: ## Lint the Dockerfile for issues


### PR DESCRIPTION
This
* Adds a new ignore for RUSTSEC-2022-0040 in owning_ref for cargo audit (which is only used in the bench tool, and not even the unsound code path)
* Bumps chrono to a version not affected by the underlying vulnerability in libc's `localtime_r`