### PR TITLE
Set TOOLS_IMAGE_TAG in Jenkins environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
     environment {
         RUST_IMAGE_REPO = 'us.gcr.io/logdna-k8s/rust'
         RUST_IMAGE_TAG = 'bullseye-1-stable'
+        TOOLS_IMAGE_TAG = 'bullseye-1-stable'
         SCCACHE_BUCKET = 'logdna-sccache-us-west-2'
         SCCACHE_REGION = 'us-west-2'
         CARGO_INCREMENTAL = 'false'


### PR DESCRIPTION
This sets the TOOLS_IMAGE_TAG env var when running under Jenkins. We need to do this as the gcr image tags that Jenkins uses are different from the docker.io tags that are set by default in the Makefile.