### PR TITLE
Log 13962 retry

### DIFF
--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -319,8 +319,7 @@ impl TryFrom<RawConfig> for Config {
                 .ok_or(ConfigError::MissingField("http.body_size"))?,
             retry_dir: raw.http.retry_dir.unwrap_or_else(|| {
                 if cfg!(windows) {
-                    let temp = std::env::var("temp");
-                    if let Ok(temp) = temp {
+                    if let Ok(temp) = std::env::var("temp") {
                         let dir = format!("{}/{}", temp, "logdna");
                         return PathBuf::from(dir);
                     }

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -317,10 +317,16 @@ impl TryFrom<RawConfig> for Config {
                 .http
                 .body_size
                 .ok_or(ConfigError::MissingField("http.body_size"))?,
-            retry_dir: raw
-                .http
-                .retry_dir
-                .unwrap_or_else(|| PathBuf::from("/tmp/logdna")),
+            retry_dir: raw.http.retry_dir.unwrap_or_else(|| {
+                if cfg!(windows) {
+                    let temp = std::env::var("temp");
+                    if let Ok(temp) = temp {
+                        let dir = format!("{}/{}", temp, "logdna");
+                        return PathBuf::from(dir);
+                    }
+                }
+                PathBuf::from("/tmp/logdna")
+            }),
             retry_disk_limit: raw.http.retry_disk_limit,
             retry_base_delay: Duration::from_millis(
                 raw.http.retry_base_delay_ms.unwrap_or(15_000) as u64


### PR DESCRIPTION
Fixes retry logging file location on windows specifically
Test plan: Integration Test Unit Test Manual Testing via observing leader logs
Ref: LOG-13962