### PR TITLE
Log 13962 retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "assert_cmd"
@@ -278,9 +278,9 @@ checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "byteorder"
@@ -673,9 +673,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encoding"
@@ -1067,9 +1067,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -1255,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5528d9c2817db4e10cc78f8d4c8228906e5854f389ff6b076cee3572a09d35"
+checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2844,9 +2844,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -319,8 +319,7 @@ impl TryFrom<RawConfig> for Config {
                 .ok_or(ConfigError::MissingField("http.body_size"))?,
             retry_dir: raw.http.retry_dir.unwrap_or_else(|| {
                 if cfg!(windows) {
-                    let temp = std::env::var("temp");
-                    if let Ok(temp) = temp {
+                    if let Ok(temp) = std::env::var("temp") {
                         let dir = format!("{}/{}", temp, "logdna");
                         return PathBuf::from(dir);
                     }

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -317,10 +317,16 @@ impl TryFrom<RawConfig> for Config {
                 .http
                 .body_size
                 .ok_or(ConfigError::MissingField("http.body_size"))?,
-            retry_dir: raw
-                .http
-                .retry_dir
-                .unwrap_or_else(|| PathBuf::from("/tmp/logdna")),
+            retry_dir: raw.http.retry_dir.unwrap_or_else(|| {
+                if cfg!(windows) {
+                    let temp = std::env::var("temp");
+                    if let Ok(temp) = temp {
+                        let dir = format!("{}/{}", temp, "logdna");
+                        return PathBuf::from(dir);
+                    }
+                }
+                PathBuf::from("/tmp/logdna")
+            }),
             retry_disk_limit: raw.http.retry_disk_limit,
             retry_base_delay: Duration::from_millis(
                 raw.http.retry_base_delay_ms.unwrap_or(15_000) as u64


### PR DESCRIPTION
Fixes retry logging file location on windows specifically 

Test plan: Integration Test
Unit Test
 Manual Testing via observing leader logs 
Ref: LOG-13962