### PR TITLE
ci: add CHOCOLATEY_API_TOKEN to Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
         SCCACHE_REGION = 'us-west-2'
         CARGO_INCREMENTAL = 'false'
         DOCKER_BUILDKIT = '1'
+        CHOCOLATELY_API_TOKEN = credentials('chocolately-api-token')
     }
     parameters {
         booleanParam(name: 'PUBLISH_GCR_IMAGE', description: 'Publish docker image to Google Container Registry (GCR)', defaultValue: false)


### PR DESCRIPTION
expose chocolately API token as `CHOCOLATELY_API_TOKEN` for use anywhere
in the Jenkins job

ref: REL-1200
