### PR TITLE
release cert

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,8 +273,7 @@ pipeline {
                         }
                     }
                     environment {
-                        CS_CERT_PASSWD_DEBUG = "credentials('agent-cs-cert-debug')"
-                        CS_CERT_PASSWD_RELEASE = "credentials('agent-cs-cert-release')"
+                        CSC_PASS = credentials('chocolatey-api-token')
                     }
                     steps {
                         withCredentials([[

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -272,6 +272,10 @@ pipeline {
                             environment name: 'PUBLISH_BINARIES', value: 'true'
                         }
                     }
+                    environment {
+                        CS_CERT_PASSWD_DEBUG = "credentials('agent-cs-cert-debug')"
+                        CS_CERT_PASSWD_RELEASE = "credentials('agent-cs-cert-release')"
+                    }
                     steps {
                         withCredentials([[
                             $class: 'AmazonWebServicesCredentialsBinding',

--- a/Makefile
+++ b/Makefile
@@ -472,7 +472,6 @@ build-rpm: build-release
 				"/build/target/${TARGET}/release/logdna-agent=/usr/bin/logdna-agent" \
 				"packaging/linux/logdna-agent.service=/lib/systemd/system/logdna-agent.service"'
 
-
 .PHONY: publish-s3-binary
 publish-s3-binary:
 	if [ "$(WINDOWS)" != "" ]; then \
@@ -482,14 +481,17 @@ publish-s3-binary:
 	    aws s3 cp --acl public-read target/$(TARGET)/release/logdna-agent s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/logdna-agent; \
 	fi;
 
-
 define PUBLISH_SIGNED_RULE
 .PHONY: publish-s3-binary-signed-$(1)
 publish-s3-binary-signed-$(1):
 	if [ "$(WINDOWS)" != "" ]; then \
-	    aws s3 cp --acl public-read target/$(TARGET)/$(1)/signed/logdna-agent-svc.exe s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/signed/logdna-agent-svc.exe; \
-	    aws s3 cp --acl public-read target/$(TARGET)/$(1)/signed/logdna-agent.exe s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/signed/logdna-agent.exe; \
-	    aws s3 cp --acl public-read target/$(TARGET)/$(1)/signed/mezmo-agent.msi s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/signed/mezmo-agent.msi; \
+	    $(eval BUILD_DIR := target/$(TARGET)/$(1)) \
+	    $(eval SRC_ROOT := $(CURDIR)) \
+	    bash -c " \
+	    set -eu; \
+	    export BUILD_DIR="$(BUILD_DIR)" SRC_ROOT="$(SRC_ROOT)" TARGET=$(TARGET) BUILD_VERSION=$(BUILD_VERSION) BUILD_NUMBER=$(BUILD_NUMBER); \
+	    cd packaging/windows/msi && ./publish_to_s3; \
+	    " \
 	else \
 	    echo Nothing to publish; \
 	fi;
@@ -497,16 +499,22 @@ endef
 BUILD_TYPES=debug release
 $(foreach _type, $(BUILD_TYPES), $(eval $(call PUBLISH_SIGNED_RULE,$(_type))))
 
-
 define MSI_RULE
 .PHONY: msi-$(1)
 msi-$(1): ## create signed exe(s) and msi in $(BUILD_DIR)/signed
 	$(eval BUILD_DIR := target/$(TARGET)/$(1))
-	$(eval CERT_NAME := "logdna_dev_cert.pfx")
-	aws s3 cp "s3://ecosys-vault/$(CERT_NAME)" "$(BUILD_DIR)" && \
-	aws s3 cp "s3://ecosys-vault/$(CERT_NAME).pwd" "$(BUILD_DIR)" && \
-	$(TOOLS_COMMAND) "--env BUILD_DIR=/build/$(BUILD_DIR) --env SRC_DIR=/build --env CERT_NAME=$(CERT_NAME) --env BUILD_VERSION=$(BUILD_VERSION)+$(BUILD_NUMBER)" "cd /build/packaging/windows/msi && ./mk_msi" && \
-	rm "$(BUILD_DIR)/$(CERT_NAME)" "$(BUILD_DIR)/$(CERT_NAME).pwd";
+	$(eval SRC_ROOT := $(CURDIR))
+	$(eval CERT_FILE_NAME := "mezmo_cert_$(1).pfx")
+	bash -c " \
+	set -eu; \
+	aws s3 cp s3://ecosys-vault/$(CERT_FILE_NAME) '$(BUILD_DIR)'; \
+	aws s3 cp s3://ecosys-vault/$(CERT_FILE_NAME).pwd '$(BUILD_DIR)'; \
+	$(TOOLS_COMMAND) '--env BUILD_DIR=$(BUILD_DIR) --env SRC_ROOT=/build \
+	                  --env CERT_FILE_NAME=$(CERT_FILE_NAME) --env BUILD_VERSION=$(BUILD_VERSION) \
+	                  --env BUILD_NUMBER=$(BUILD_NUMBER) --env TARGET=$(TARGET)' \
+	                  'cd /build/packaging/windows/msi && . ./mk_env && ./mk_msi'; \
+	rm '$(BUILD_DIR)/$(CERT_FILE_NAME)' '$(BUILD_DIR)/$(CERT_FILE_NAME).pwd'; \
+	"
 endef
 BUILD_TYPES=debug release
 $(foreach _type, $(BUILD_TYPES), $(eval $(call MSI_RULE,$(_type))))
@@ -515,8 +523,12 @@ define CHOCO_RULE
 .PHONY: choco-$(1)
 choco-$(1): ## create choco package using msi from logdna-agent-build-bin S3 baucket
 	$(eval BUILD_DIR := target/$(TARGET)/$(1))
-	$(eval SRC_DIR := $(CURDIR))
-	bash -c "export BUILD_DIR=$(BUILD_DIR) && export SRC_DIR=$(SRC_DIR) && pushd $(SRC_DIR)/packaging/windows/choco && ./mk"
+	$(eval SRC_ROOT := $(CURDIR))
+	bash -c " \
+	set -eu; \
+	export BUILD_DIR="$(BUILD_DIR)" SRC_ROOT="$(SRC_ROOT)" TARGET=$(TARGET) BUILD_VERSION=$(BUILD_VERSION) BUILD_NUMBER=$(BUILD_NUMBER); \
+	cd $(SRC_ROOT)/packaging/windows/choco && source ./mk_env && ./mk_choco \
+	"
 endef
 BUILD_TYPES=debug release
 $(foreach _type, $(BUILD_TYPES), $(eval $(call CHOCO_RULE,$(_type))))
@@ -525,8 +537,12 @@ define PUBLISH_CHOCO_RULE
 .PHONY: publish-choco-$(1)
 publish-choco-$(1): ## publish choco package built & located in $(BUILD_DIR)/choco, requires env CHOCO_API_KEY defined
 	$(eval BUILD_DIR := target/$(TARGET)/$(1))
-	$(eval SRC_DIR := $(CURDIR))
-	bash -c "export BUILD_DIR=$(BUILD_DIR) && export SRC_DIR=$(SRC_DIR) && pushd packaging/windows/choco && ./publish_to_choco"
+	$(eval SRC_ROOT := $(CURDIR))
+	bash -c " \
+	set -eu; \
+	export BUILD_DIR="$(BUILD_DIR)" SRC_ROOT="$(SRC_ROOT)" TARGET=$(TARGET) BUILD_VERSION=$(BUILD_VERSION) BUILD_NUMBER=$(BUILD_NUMBER); \
+	cd packaging/windows/choco && ./publish_to_choco \
+	"
 endef
 BUILD_TYPES=debug release
 $(foreach _type, $(BUILD_TYPES), $(eval $(call PUBLISH_CHOCO_RULE,$(_type))))

--- a/packaging/windows/choco/mk_choco
+++ b/packaging/windows/choco/mk_choco
@@ -12,7 +12,7 @@ for FILE in tools/* mezmo-agent.nuspec; do
   # shellcheck disable=SC2016
   envsubst '$MSI_URL,$MSI_SHA256,$BUILD_VERSION_FULL' < "$FILE" > "$SRC_ROOT/$BUILD_DIR/choco/$FILE"
 done
-docker run -i -v "$SRC_ROOT":/build --env BUILD_DIR="/build/$BUILD_DIR" --env SRC_ROOT=/build -w "/build/$BUILD_DIR/choco" chocolatey/choco choco pack -v mezmo-agent.nuspec
+docker run -i --rm -v "$SRC_ROOT":/build --env BUILD_DIR="/build/$BUILD_DIR" --env SRC_ROOT=/build -w "/build/$BUILD_DIR/choco" chocolatey/choco choco pack -v mezmo-agent.nuspec
 PKG_VER=$(grep -oPm1 "(?<=<version>)[^<]+" "$SRC_ROOT/$BUILD_DIR/choco/mezmo-agent.nuspec")
 PKG_NAME=$(grep -oPm1 "(?<=<id>)[^<]+" "$SRC_ROOT/$BUILD_DIR/choco/mezmo-agent.nuspec")
 echo "$PKG_NAME.$PKG_VER.nupkg" > "$SRC_ROOT/$BUILD_DIR/choco/mezmo-agent.nupkg.name"

--- a/packaging/windows/choco/mk_choco
+++ b/packaging/windows/choco/mk_choco
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
-set -eu
+set -eu -o pipefail
 #
-mkdir -p "$SRC_DIR/$BUILD_DIR/choco/tools"
-chmod 777 "$SRC_DIR/$BUILD_DIR/choco"
-chmod 777 "$SRC_DIR/$BUILD_DIR/choco/tools"
+mkdir -p "$SRC_ROOT/$BUILD_DIR/choco/tools"
+chmod 777 "$SRC_ROOT/$BUILD_DIR/choco"
+chmod 777 "$SRC_ROOT/$BUILD_DIR/choco/tools"
 echo fetching $MSI_URL ...
-MSI_SHA256=$(curl -sL "$MSI_URL" | sha256sum -b | awk "{print \$1}")
+MSI_SHA256=$(curl -fsL "$MSI_URL" | sha256sum -b | awk "{print \$1}")
 export MSI_SHA256
 echo copying files ...
 for FILE in tools/* mezmo-agent.nuspec; do
   # shellcheck disable=SC2016
-  envsubst '$MSI_URL,$MSI_SHA256,$BUILD_VERSION_FULL' < "$FILE" > "$SRC_DIR/$BUILD_DIR/choco/$FILE"
+  envsubst '$MSI_URL,$MSI_SHA256,$BUILD_VERSION_FULL' < "$FILE" > "$SRC_ROOT/$BUILD_DIR/choco/$FILE"
 done
-docker run -i -v "$SRC_DIR":/build --env BUILD_DIR="/build/$BUILD_DIR" --env SRC_DIR=/build -w "/build/$BUILD_DIR/choco" chocolatey/choco choco pack -v mezmo-agent.nuspec
-PKG_VER=$(grep -oPm1 "(?<=<version>)[^<]+" "$SRC_DIR/$BUILD_DIR/choco/mezmo-agent.nuspec")
-PKG_NAME=$(grep -oPm1 "(?<=<id>)[^<]+" "$SRC_DIR/$BUILD_DIR/choco/mezmo-agent.nuspec")
-echo "$PKG_NAME.$PKG_VER.nupkg" > "$SRC_DIR/$BUILD_DIR/choco/mezmo-agent.nupkg.name"
+docker run -i -v "$SRC_ROOT":/build --env BUILD_DIR="/build/$BUILD_DIR" --env SRC_ROOT=/build -w "/build/$BUILD_DIR/choco" chocolatey/choco choco pack -v mezmo-agent.nuspec
+PKG_VER=$(grep -oPm1 "(?<=<version>)[^<]+" "$SRC_ROOT/$BUILD_DIR/choco/mezmo-agent.nuspec")
+PKG_NAME=$(grep -oPm1 "(?<=<id>)[^<]+" "$SRC_ROOT/$BUILD_DIR/choco/mezmo-agent.nuspec")
+echo "$PKG_NAME.$PKG_VER.nupkg" > "$SRC_ROOT/$BUILD_DIR/choco/mezmo-agent.nupkg.name"
 echo
-echo package stored in \'"$SRC_DIR/$BUILD_DIR/choco"\'
+echo package stored in \'$SRC_ROOT/$BUILD_DIR/choco/$PKG_NAME.$PKG_VER.nupkg\'
 echo

--- a/packaging/windows/choco/mk_choco
+++ b/packaging/windows/choco/mk_choco
@@ -4,7 +4,7 @@ set -eu -o pipefail
 mkdir -p "$SRC_ROOT/$BUILD_DIR/choco/tools"
 chmod 777 "$SRC_ROOT/$BUILD_DIR/choco"
 chmod 777 "$SRC_ROOT/$BUILD_DIR/choco/tools"
-echo fetching $MSI_URL ...
+echo fetching "$MSI_URL" ...
 MSI_SHA256=$(curl -fsL "$MSI_URL" | sha256sum -b | awk "{print \$1}")
 export MSI_SHA256
 echo copying files ...
@@ -17,5 +17,5 @@ PKG_VER=$(grep -oPm1 "(?<=<version>)[^<]+" "$SRC_ROOT/$BUILD_DIR/choco/mezmo-age
 PKG_NAME=$(grep -oPm1 "(?<=<id>)[^<]+" "$SRC_ROOT/$BUILD_DIR/choco/mezmo-agent.nuspec")
 echo "$PKG_NAME.$PKG_VER.nupkg" > "$SRC_ROOT/$BUILD_DIR/choco/mezmo-agent.nupkg.name"
 echo
-echo package stored in \'$SRC_ROOT/$BUILD_DIR/choco/$PKG_NAME.$PKG_VER.nupkg\'
+echo package stored in "$SRC_ROOT/$BUILD_DIR/choco/$PKG_NAME.$PKG_VER.nupkg"
 echo

--- a/packaging/windows/choco/mk_env
+++ b/packaging/windows/choco/mk_env
@@ -1,13 +1,2 @@
 #!/usr/bin/env bash
-# source root
-export SRC_DIR="${SRC_DIR:-$(readlink -f ../../..)}"
-# relative to source root
-export BUILD_DIR="${BUILD_DIR:-target/x86_64-pc-windows-msvc/debug}"
-# comes from Jenkins
-export BUILD_NUMBER="${BUILD_NUMBER:-0}"
-agent_version=$(sed -nE "s/^version = \"(.+)\"\$$/\1/p" "$SRC_DIR/bin/Cargo.toml")
-export BUILD_VERSION="${BUILD_VERSION:-${agent_version}}"
-BUILD_VERSION_DASH=$(echo "$BUILD_VERSION" | sed -r 's/([^\.]+\.[^\.]+\.[^\.]+)\./\1-/')
-# cannot use "+" - relaced by "-build"
-export BUILD_VERSION_FULL="${BUILD_VERSION_DASH}-build${BUILD_NUMBER}"
-export MSI_URL="${MSI_URL:-https://logdna-agent-build-bin.s3.amazonaws.com/$BUILD_VERSION/x86_64-pc-windows-msvc/signed/mezmo-agent.msi}"
+source ../msi/mk_env

--- a/packaging/windows/choco/mk_env
+++ b/packaging/windows/choco/mk_env
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091
 source ../msi/mk_env

--- a/packaging/windows/choco/publish_to_choco
+++ b/packaging/windows/choco/publish_to_choco
@@ -2,7 +2,7 @@
 set -eu
 # shellcheck disable=SC1091
 source ./mk_env
-docker run -i -v $SRC_ROOT:/build -w /build --env BUILD_DIR="$BUILD_DIR" --env CHOCO_API_KEY="$CHOCO_API_KEY" chocolatey/choco bash << 'EOF'
+docker run -i --rm -v $SRC_ROOT:/build -w /build --env BUILD_DIR="$BUILD_DIR" --env CHOCO_API_KEY="$CHOCO_API_KEY" chocolatey/choco bash << 'EOF'
 set -eu
 choco apikey -k $CHOCO_API_KEY -s https://push.chocolatey.org
 choco push /build/$BUILD_DIR/choco/$(cat /build/$BUILD_DIR/choco/mezmo-agent.nupkg.name) -s https://push.chocolatey.org

--- a/packaging/windows/choco/publish_to_choco
+++ b/packaging/windows/choco/publish_to_choco
@@ -2,7 +2,7 @@
 set -eu
 # shellcheck disable=SC1091
 source ./mk_env
-docker run -i -v $SRC_DIR:/build -w /build --env BUILD_DIR="$BUILD_DIR" --env CHOCO_API_KEY="$CHOCO_API_KEY" chocolatey/choco bash << 'EOF'
+docker run -i -v $SRC_ROOT:/build -w /build --env BUILD_DIR="$BUILD_DIR" --env CHOCO_API_KEY="$CHOCO_API_KEY" chocolatey/choco bash << 'EOF'
 set -eu
 choco apikey -k $CHOCO_API_KEY -s https://push.chocolatey.org
 choco push /build/$BUILD_DIR/choco/$(cat /build/$BUILD_DIR/choco/mezmo-agent.nupkg.name) -s https://push.chocolatey.org

--- a/packaging/windows/choco/publish_to_choco
+++ b/packaging/windows/choco/publish_to_choco
@@ -2,10 +2,10 @@
 set -eu
 # shellcheck disable=SC1091
 source ./mk_env
-docker run -i --rm -v $SRC_ROOT:/build -w /build --env BUILD_DIR="$BUILD_DIR" --env CHOCO_API_KEY="$CHOCO_API_KEY" chocolatey/choco bash << 'EOF'
+docker run -i --rm -v "$SRC_ROOT":/build -w /build --env BUILD_DIR="$BUILD_DIR" --env CHOCO_API_KEY="$CHOCO_API_KEY" chocolatey/choco bash << 'EOF'
 set -eu
 choco apikey -k $CHOCO_API_KEY -s https://push.chocolatey.org
-choco push /build/$BUILD_DIR/choco/$(cat /build/$BUILD_DIR/choco/mezmo-agent.nupkg.name) -s https://push.chocolatey.org
+choco push "/build/$BUILD_DIR/choco/$(cat /build/$BUILD_DIR/choco/mezmo-agent.nupkg.name)" -s https://push.chocolatey.org
 EOF
 echo
 echo @@@@@@  SUCCESS  @@@@@@

--- a/packaging/windows/msi/mezmo-agent.wxs
+++ b/packaging/windows/msi/mezmo-agent.wxs
@@ -48,9 +48,9 @@
             <Component Id="ProductComponent" Win64="$(var.Win64)" Guid="56CD2588-B976-4198-B815-FAB7E1E57CD7">
                 <File Id="AgentSvc" Name="logdna-agent-svc.exe" DiskId="1" Source="$(env.AGENT_EXE_DIR)/logdna-agent-svc.exe" KeyPath="yes" />
                 <File Id="AgentCLI" Name="logdna-agent.exe" DiskId="1" Source="$(env.AGENT_EXE_DIR)/logdna-agent.exe" />
-                <File Id="Readme" Name="README.md" DiskId="1" Source="$(env.AGENT_SRC_DIR)/docs/WINDOWS.md" />
-                <File Id="PostInstallScript" Name="post_install.ps1" DiskId="1" Source="$(env.AGENT_SRC_DIR)/packaging/windows/msi/post_install.ps1" />
-                <File Id="CfgFile" Name="logdna.conf.templ" DiskId="1" Source="$(env.AGENT_SRC_DIR)/packaging/windows/msi/logdna.conf.templ" />
+                <File Id="Readme" Name="README.md" DiskId="1" Source="$(env.AGENT_SRC_ROOT)/docs/WINDOWS.md" />
+                <File Id="PostInstallScript" Name="post_install.ps1" DiskId="1" Source="$(env.AGENT_SRC_ROOT)/packaging/windows/msi/post_install.ps1" />
+                <File Id="CfgFile" Name="logdna.conf.templ" DiskId="1" Source="$(env.AGENT_SRC_ROOT)/packaging/windows/msi/logdna.conf.templ" />
                 <ServiceInstall Id="ServiceInstaller" Type="ownProcess" Vital="yes" Name="MezmoAgentService"
                                 DisplayName="Mezmo Agent" Description="Mezmo Agent Service"
                                 Start="auto" Account="LocalSystem" ErrorControl="normal" Arguments="" Interactive="no" />

--- a/packaging/windows/msi/mk
+++ b/packaging/windows/msi/mk
@@ -1,20 +1,15 @@
 #!/usr/bin/env bash
 set -eu
-export SRC_DIR="${SRC_DIR:-../../..}"
-export BUILD_DIR="${BUILD_DIR:-$SRC_DIR/target/x86_64-pc-windows-msvc/debug}"
-VER=$(sed -nE "s/^version = \"(.+)\"\$$/\1/p" "$SRC_DIR/bin/Cargo.toml")
-export BUILD_NUMBER="${BUILD_NUMBER:-0}"
-export BUILD_VERSION="${BUILD_VERSION:-"$VER+$BUILD_NUMBER"}"
-export CERT_NAME="${CERT_NAME:-logdna_dev_cert.pfx}"
 function finish {
-  rm -f "$BUILD_DIR/$CERT_NAME" "$BUILD_DIR/$CERT_NAME.pwd"
+  rm -f "$SRC_ROOT/$BUILD_DIR/$CERT_FILE_NAME" "$SRC_ROOT/$BUILD_DIR/$CERT_FILE_NAME.pwd"
 }
 trap finish EXIT
 #
-echo build version $BUILD_VERSION
-echo fetching key
-aws s3 cp "s3://ecosys-vault/$CERT_NAME" "$BUILD_DIR"
-aws s3 cp "s3://ecosys-vault/$CERT_NAME.pwd" "$BUILD_DIR"
+source ./mk_env
+echo build version $BUILD_VERSION_FULL
+echo fetching cert
+aws s3 cp "s3://ecosys-vault/$CERT_FILE_NAME" "$SRC_ROOT/$BUILD_DIR"
+aws s3 cp "s3://ecosys-vault/$CERT_FILE_NAME.pwd" "$SRC_ROOT/$BUILD_DIR"
 ./mk_msi
 echo
 echo @@@@@@  SUCCESS  @@@@@@

--- a/packaging/windows/msi/mk
+++ b/packaging/windows/msi/mk
@@ -4,9 +4,9 @@ function finish {
   rm -f "$SRC_ROOT/$BUILD_DIR/$CERT_FILE_NAME" "$SRC_ROOT/$BUILD_DIR/$CERT_FILE_NAME.pwd"
 }
 trap finish EXIT
-#
+# shellcheck disable=SC1091
 source ./mk_env
-echo build version $BUILD_VERSION_FULL
+echo build version "$BUILD_VERSION_FULL"
 echo fetching cert
 aws s3 cp "s3://ecosys-vault/$CERT_FILE_NAME" "$SRC_ROOT/$BUILD_DIR"
 aws s3 cp "s3://ecosys-vault/$CERT_FILE_NAME.pwd" "$SRC_ROOT/$BUILD_DIR"

--- a/packaging/windows/msi/mk_env
+++ b/packaging/windows/msi/mk_env
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# source root
+export SRC_ROOT="${SRC_ROOT:-$(readlink -f ../../..)}"
+agent_version=$(sed -nE "s/^version = \"(.+)\"\$$/\1/p" "$SRC_ROOT/bin/Cargo.toml")
+export BUILD_VERSION="${BUILD_VERSION:-${agent_version}}"
+export TARGET=${TARGET:-x86_64-pc-windows-msvc}
+# relative to source root
+export BUILD_DIR="${BUILD_DIR:-target/$TARGET/debug}"
+# comes from Jenkins
+export BUILD_NUMBER="${BUILD_NUMBER:-0}"
+# 4th dot if any replaced by dash
+BUILD_VERSION_DASH=$(echo "$BUILD_VERSION" | sed -r 's/([^\.]+\.[^\.]+\.[^\.]+)\./\1-/')
+# cannot use "+" - replaced by "-build"
+export BUILD_VERSION_FULL="${BUILD_VERSION_DASH}-build${BUILD_NUMBER}"
+export CERT_FILE_NAME="${CERT_FILE_NAME:-mezmo_cert_debug.pfx}"
+export MSI_URL="${MSI_URL:-https://logdna-agent-build-bin.s3.amazonaws.com/$BUILD_VERSION/$TARGET/signed/mezmo-agent.${BUILD_VERSION_FULL}.msi}"

--- a/packaging/windows/msi/mk_msi
+++ b/packaging/windows/msi/mk_msi
@@ -46,5 +46,5 @@ osslsigncode sign \
     -in "$SRC_ROOT/$BUILD_DIR/mezmo-agent.msi" \
     -out "$SRC_ROOT/$BUILD_DIR/signed/mezmo-agent.msi"
 echo
-echo package stored to \'$BUILD_DIR/signed/mezmo-agent.msi\'
+echo package stored to "$BUILD_DIR/signed/mezmo-agent.msi"
 echo

--- a/packaging/windows/msi/mk_msi
+++ b/packaging/windows/msi/mk_msi
@@ -5,7 +5,6 @@ set -eu
 #
 mkdir -p "$SRC_ROOT/$BUILD_DIR/signed"
 CERT_FILE="$SRC_ROOT/$BUILD_DIR/$CERT_FILE_NAME"
-#CERT_FILE=mezmo_cert.pfx
 echo signing exe files
 osslsigncode sign \
     -pkcs12 "$CERT_FILE" \
@@ -47,5 +46,5 @@ osslsigncode sign \
     -in "$SRC_ROOT/$BUILD_DIR/mezmo-agent.msi" \
     -out "$SRC_ROOT/$BUILD_DIR/signed/mezmo-agent.msi"
 echo
-echo package stored to \'$SRC_ROOT/$BUILD_DIR/signed/mezmo-agent.msi\'
+echo package stored to \'$BUILD_DIR/signed/mezmo-agent.msi\'
 echo

--- a/packaging/windows/msi/mk_msi
+++ b/packaging/windows/msi/mk_msi
@@ -3,43 +3,49 @@ set -eu
 #
 # Sign exe files
 #
-mkdir -p "$BUILD_DIR/signed"
+mkdir -p "$SRC_ROOT/$BUILD_DIR/signed"
+CERT_FILE="$SRC_ROOT/$BUILD_DIR/$CERT_FILE_NAME"
+#CERT_FILE=mezmo_cert.pfx
 echo signing exe files
 osslsigncode sign \
-    -pkcs12 "$BUILD_DIR/$CERT_NAME" \
-    -readpass "$BUILD_DIR/$CERT_NAME.pwd" \
+    -pkcs12 "$CERT_FILE" \
+    -readpass "$CERT_FILE.pwd" \
     -n "Mezmo Agent" \
     -h sha2 \
     -i "https://www.mezmo.com" \
     -t http://timestamp.comodoca.com/authenticode \
-    -in "$BUILD_DIR/logdna-agent-svc.exe" \
-    -out "$BUILD_DIR/signed/logdna-agent-svc.exe"
+    -in "$SRC_ROOT/$BUILD_DIR/logdna-agent-svc.exe" \
+    -out "$SRC_ROOT/$BUILD_DIR/signed/logdna-agent-svc.exe"
 osslsigncode sign \
-    -pkcs12 "$BUILD_DIR/$CERT_NAME" \
-    -readpass "$BUILD_DIR/$CERT_NAME.pwd" \
+    -pkcs12 "$CERT_FILE" \
+    -readpass "$CERT_FILE.pwd" \
     -n "Mezmo Agent" \
     -h sha2 \
     -i "https://www.mezmo.com" \
     -t http://timestamp.comodoca.com/authenticode \
-    -in "$BUILD_DIR/logdna-agent.exe" \
-    -out "$BUILD_DIR/signed/logdna-agent.exe"
+    -in "$SRC_ROOT/$BUILD_DIR/logdna-agent.exe" \
+    -out "$SRC_ROOT/$BUILD_DIR/signed/logdna-agent.exe"
 #
 # Create msi
 #
-export AGENT_VERSION=${BUILD_VERSION}
-export AGENT_EXE_DIR="$BUILD_DIR/signed"
-export AGENT_SRC_DIR="$SRC_DIR"
-wixl -v --ext ui ./mezmo-agent.wxs -a x64 -o "$BUILD_DIR/mezmo-agent.msi"
+export AGENT_VERSION=${BUILD_VERSION_FULL}
+export AGENT_EXE_DIR="$SRC_ROOT/$BUILD_DIR/signed"
+export AGENT_SRC_ROOT="$SRC_ROOT"
+wixl -v --ext ui ./mezmo-agent.wxs -a x64 -o "$SRC_ROOT/$BUILD_DIR/mezmo-agent.msi"
 #
 # Sign msi
 #
+echo signing msi file
 osslsigncode sign \
     -add-msi-dse \
-    -pkcs12 "$BUILD_DIR/$CERT_NAME" \
-    -readpass "$BUILD_DIR/$CERT_NAME.pwd" \
+    -pkcs12 "$CERT_FILE" \
+    -readpass "$CERT_FILE.pwd" \
     -n "Mezmo Agent" \
     -h sha2 \
     -i "https://www.mezmo.com" \
     -t http://timestamp.comodoca.com/authenticode \
-    -in "$BUILD_DIR/mezmo-agent.msi" \
-    -out "$BUILD_DIR/signed/mezmo-agent.msi"
+    -in "$SRC_ROOT/$BUILD_DIR/mezmo-agent.msi" \
+    -out "$SRC_ROOT/$BUILD_DIR/signed/mezmo-agent.msi"
+echo
+echo package stored to \'$SRC_ROOT/$BUILD_DIR/signed/mezmo-agent.msi\'
+echo

--- a/packaging/windows/msi/post_install.ps1
+++ b/packaging/windows/msi/post_install.ps1
@@ -22,5 +22,8 @@ if (-not(Test-Path -Path "$DATAFOLDER\logdna.conf" -PathType Leaf)) {
   (Get-Content -Path "$DATAFOLDER\logdna.conf") -Replace "<YOUR_INGESTION_KEY>", "$INGESTION_KEY" | Set-Content -Path "$DATAFOLDER\logdna.conf"
 }
 Remove-Item  "$INSTALLFOLDER\logdna.conf.templ" -Force -Confirm:$false
+# prefetch Mezmo CA cert
+try { $null=iwr https://www.mezmo.com -UseBasicParsing } catch {}
+Start-Sleep 1
 
 Write-Host

--- a/packaging/windows/msi/publish_to_s3
+++ b/packaging/windows/msi/publish_to_s3
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+# shellcheck disable=SC1091
+source ./mk_env
+MSI_S3_URL=s3://logdna-agent-build-bin/$BUILD_VERSION/$TARGET/signed/mezmo-agent.$BUILD_VERSION_FULL.msi
+MSI_LAST_S3_URL=s3://logdna-agent-build-bin/$BUILD_VERSION/$TARGET/signed/mezmo-agent.msi
+echo uploading to $MSI_S3_URL
+aws s3 cp --acl public-read $SRC_ROOT/$BUILD_DIR/signed/mezmo-agent.msi $MSI_S3_URL
+aws s3 cp --acl public-read $SRC_ROOT/$BUILD_DIR/signed/mezmo-agent.msi $MSI_LAST_S3_URL
+echo
+echo @@@@@@  SUCCESS  @@@@@@
+echo

--- a/packaging/windows/msi/publish_to_s3
+++ b/packaging/windows/msi/publish_to_s3
@@ -4,9 +4,9 @@ set -eu -o pipefail
 source ./mk_env
 MSI_S3_URL=s3://logdna-agent-build-bin/$BUILD_VERSION/$TARGET/signed/mezmo-agent.$BUILD_VERSION_FULL.msi
 MSI_LAST_S3_URL=s3://logdna-agent-build-bin/$BUILD_VERSION/$TARGET/signed/mezmo-agent.msi
-echo uploading to $MSI_S3_URL
-aws s3 cp --acl public-read $SRC_ROOT/$BUILD_DIR/signed/mezmo-agent.msi $MSI_S3_URL
-aws s3 cp --acl public-read $SRC_ROOT/$BUILD_DIR/signed/mezmo-agent.msi $MSI_LAST_S3_URL
+echo uploading to "$MSI_S3_URL"
+aws s3 cp --acl public-read "$SRC_ROOT/$BUILD_DIR/signed/mezmo-agent.msi" "$MSI_S3_URL"
+aws s3 cp --acl public-read "$SRC_ROOT/$BUILD_DIR/signed/mezmo-agent.msi" "$MSI_LAST_S3_URL"
 echo
 echo @@@@@@  SUCCESS  @@@@@@
 echo


### PR DESCRIPTION
- added support for code signing of msi & exe using release cert
- 3 ways to sign: 
- 1) run "packaging/windows/msi/mk" using dev cert by default (debug) 
- 2)  run "WINDOWS=1 make msi-release" or "WINDOWS=1 make msi-debug"  (release & debug) 
- 3) run Jenkins build with PUBLISH_BINARIES param enabled (release)
