### PR TITLE
feat(image-tag): Add image name and tag to meta object

### DIFF
--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -1070,8 +1070,12 @@ async fn test_k8s_enrichment() {
 
         let result = map.iter().find(|(k, _)| k.contains("sample-pod"));
         assert!(result.is_some());
+
         let (_, pod_file_info) = result.unwrap();
         let label = pod_file_info.label.as_ref();
+        let meta = pod_file_info.meta.as_ref();
+
+        assert_eq!(meta.unwrap()["Image Name"].as_str().unwrap(), "busybox");
         assert!(label.is_some());
         assert_eq!(label.unwrap()["app.kubernetes.io/name"], "sample-pod");
         assert_eq!(

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -126,11 +126,9 @@ impl Middleware for K8sMetadata {
                 if let Some(pod) = self.store.get(&obj_ref) {
                     let meta_object =
                         extract_image_name_and_tag(parse_result.container_name, pod.as_ref());
-                    if meta_object.is_some() {
-                        if line.set_meta(json!(meta_object)).is_err() {
-                            log::trace!("Unable to set meta object{:?}", meta_object);
-                            return Status::Skip;
-                        }
+                    if meta_object.is_some() && line.set_meta(json!(meta_object)).is_err() {
+                        log::trace!("Unable to set meta object{:?}", meta_object);
+                        return Status::Skip;
                     }
 
                     if let Some(ref annotations) = pod.metadata.annotations {

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -13,11 +13,13 @@ use kube::{
     },
     Api, Client,
 };
+use serde_json::json;
 use std::pin::Pin;
 
 use backoff::ExponentialBackoff;
 use metrics::Metrics;
 use middleware::{Middleware, Status};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -28,6 +30,16 @@ pub enum Error {
     Utf(#[from] std::string::FromUtf8Error),
     #[error(transparent)]
     K8s(#[from] kube::Error),
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MetaObject {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename(serialize = "Image Name"))]
+    pub image_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename(serialize = "Tag"))]
+    pub tag: Option<String>,
 }
 
 pub struct K8sMetadata {
@@ -112,6 +124,12 @@ impl Middleware for K8sMetadata {
                 let obj_ref =
                     ObjectRef::new(&parse_result.pod_name).within(&parse_result.pod_namespace);
                 if let Some(pod) = self.store.get(&obj_ref) {
+                    let meta_object =
+                        extract_image_name_and_tag(parse_result.container_name, pod.as_ref());
+                    if line.set_meta(json!(meta_object)).is_err() {
+                        return Status::Skip;
+                    }
+
                     if let Some(ref annotations) = pod.metadata.annotations {
                         if line
                             .set_annotations(
@@ -124,6 +142,7 @@ impl Middleware for K8sMetadata {
                             return Status::Skip;
                         };
                     }
+
                     if let Some(ref labels) = pod.metadata.labels {
                         if line
                             .set_labels(
@@ -143,10 +162,41 @@ impl Middleware for K8sMetadata {
     }
 }
 
+fn extract_image_name_and_tag(container_name: String, pod: &Pod) -> MetaObject {
+    if let Some(spec) = &pod.spec {
+        for container in &spec.containers {
+            if container.name.eq_ignore_ascii_case(&container_name) && container.image.is_some() {
+                let container_image = container.image.clone().unwrap();
+
+                if let Some(split) = container_image.split_once(':') {
+                    let image = split.0.to_string();
+                    let image_tag = split.1.to_string();
+                    return MetaObject {
+                        image_name: Some(image),
+                        tag: Some(image_tag),
+                    };
+                } else {
+                    let image = container_image;
+                    return MetaObject {
+                        image_name: Some(image),
+                        tag: None,
+                    };
+                }
+            }
+        }
+    }
+
+    MetaObject {
+        image_name: None,
+        tag: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use http::types::body::{LineBuilder, LineMeta};
+    use k8s_openapi::api::core::v1::{Container, PodSpec};
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
     use std::collections::BTreeMap;
     use std::convert::TryFrom;
@@ -235,6 +285,54 @@ mod tests {
             } else {
                 panic!("Unexpected status");
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_extract_image_tag() {
+        let test_pod = create_pod(Some("test:tag".to_string()));
+        let result = extract_image_name_and_tag("Container".to_string(), &test_pod);
+
+        assert_eq!("test".to_string(), result.image_name.unwrap());
+        assert_eq!("tag".to_string(), result.tag.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_extract_image_tag_no_tag() {
+        let test_pod = create_pod(Some("test".to_string()));
+        let result = extract_image_name_and_tag("Container".to_string(), &test_pod);
+
+        assert_eq!("test".to_string(), result.image_name.unwrap());
+        assert_eq!(None, result.tag);
+    }
+
+    #[tokio::test]
+    async fn test_extract_image_tag_no_value() {
+        let test_pod = create_pod(None);
+        let result = extract_image_name_and_tag("Container".to_string(), &test_pod);
+
+        assert_eq!(None, result.image_name);
+        assert_eq!(None, result.tag);
+    }
+
+    fn create_pod(image: Option<String>) -> Pod {
+        let meta = ObjectMeta {
+            ..Default::default()
+        };
+
+        let spec = PodSpec {
+            containers: vec![Container {
+                name: "Container".to_string(),
+                image,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        Pod {
+            metadata: meta,
+            spec: Some(spec),
+            status: None,
         }
     }
 

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -127,10 +127,9 @@ impl Middleware for K8sMetadata {
                     let meta_object =
                         extract_image_name_and_tag(parse_result.container_name, pod.as_ref());
                     if meta_object.is_none() || line.set_meta(json!(meta_object)).is_err() {
-                        return Status::Skip;
-                    } else {
                         log::trace!("Unable to set meta object{:?}", meta_object);
-                    }
+                        return Status::Skip;    
+                    } 
 
                     if let Some(ref annotations) = pod.metadata.annotations {
                         if line

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -126,10 +126,12 @@ impl Middleware for K8sMetadata {
                 if let Some(pod) = self.store.get(&obj_ref) {
                     let meta_object =
                         extract_image_name_and_tag(parse_result.container_name, pod.as_ref());
-                    if meta_object.is_none() || line.set_meta(json!(meta_object)).is_err() {
-                        log::trace!("Unable to set meta object{:?}", meta_object);
-                        return Status::Skip;    
-                    } 
+                    if meta_object.is_some() {
+                        if line.set_meta(json!(meta_object)).is_err() {
+                            log::trace!("Unable to set meta object{:?}", meta_object);
+                            return Status::Skip;
+                        }
+                    }
 
                     if let Some(ref annotations) = pod.metadata.annotations {
                         if line

--- a/common/k8s/src/middleware/mod.rs
+++ b/common/k8s/src/middleware/mod.rs
@@ -13,13 +13,15 @@ lazy_static! {
 struct ParseResult {
     pod_name: String,
     pod_namespace: String,
+    container_name: String,
 }
 
 impl ParseResult {
-    fn new(pod_name: String, pod_namespace: String) -> ParseResult {
+    fn new(pod_name: String, pod_namespace: String, container_name: String) -> ParseResult {
         ParseResult {
             pod_name,
             pod_namespace,
+            container_name,
         }
     }
 }
@@ -29,5 +31,6 @@ fn parse_container_path(path: &str) -> Option<ParseResult> {
     Some(ParseResult::new(
         captures.get(1)?.as_str().into(),
         captures.get(2)?.as_str().into(),
+        captures.get(3)?.as_str().into(),
     ))
 }

--- a/common/test/mock-ingester/src/lib.rs
+++ b/common/test/mock-ingester/src/lib.rs
@@ -6,6 +6,7 @@ use hyper::service::Service;
 use hyper::{Body, Request, Response};
 use serde::{Deserialize, Serialize};
 
+use serde_json::Value;
 use thiserror::Error;
 use tokio::macros::support::{Future, Pin};
 use tokio::sync::Mutex;
@@ -48,6 +49,7 @@ pub struct FileInfo {
     pub lines: usize,
     pub annotation: Option<HashMap<String, String>>,
     pub label: Option<HashMap<String, String>>,
+    pub meta: Option<Value>
 }
 
 #[derive(Debug, Error)]
@@ -73,6 +75,7 @@ pub struct Line {
     host: Option<String>,
     app: Option<String>,
     level: Option<String>,
+    meta: Option<Value>
 }
 
 // #[derive(Debug)]
@@ -180,6 +183,7 @@ impl Service<Request<Body>> for Svc {
                             lines: 0,
                             annotation: None,
                             label: None,
+                            meta: None
                         }
                     });
 
@@ -187,6 +191,7 @@ impl Service<Request<Body>> for Svc {
                     file_info.label = line.label.clone();
                     file_info.lines += 1;
                     file_info.values.push(raw_line);
+                    file_info.meta = line.meta;
                 }
             }
 

--- a/common/test/mock-ingester/src/lib.rs
+++ b/common/test/mock-ingester/src/lib.rs
@@ -49,7 +49,7 @@ pub struct FileInfo {
     pub lines: usize,
     pub annotation: Option<HashMap<String, String>>,
     pub label: Option<HashMap<String, String>>,
-    pub meta: Option<Value>
+    pub meta: Option<Value>,
 }
 
 #[derive(Debug, Error)]
@@ -75,7 +75,7 @@ pub struct Line {
     host: Option<String>,
     app: Option<String>,
     level: Option<String>,
-    meta: Option<Value>
+    meta: Option<Value>,
 }
 
 // #[derive(Debug)]
@@ -183,7 +183,7 @@ impl Service<Request<Body>> for Svc {
                             lines: 0,
                             annotation: None,
                             label: None,
-                            meta: None
+                            meta: None,
                         }
                     });
 


### PR DESCRIPTION
Summary:
Parsing out container image and tag from appropriate container, sending via _meta object

Test Plan:

Manually test on web application
Unit tests

Ref: Log-10828