### PR TITLE
Windows File Handle Leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.37"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -867,6 +867,12 @@ impl FileSystem {
         if !self.passes(path, _entries) {
             // Do not continuously log ignored files
             if let false = self.ignored_dirs.contains(path) {
+                #[cfg(windows)]
+                self.ignored_dirs.insert(path.to_path_buf());
+                info!("ignoring {:?}", path);
+                _entries.clear();
+
+                #[cfg(unix)]
                 self.ignored_dirs.insert(path.to_path_buf());
                 info!("ignoring {:?}", path);
             }

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -1604,6 +1604,7 @@ mod tests {
 
     // Simulates the `create_copy` log rotation strategy
     #[tokio::test]
+    #[cfg(unix)]
     async fn filesystem_rotate_create_copy() -> io::Result<()> {
         let tempdir = TempDir::new()?;
         let path = tempdir.path().to_path_buf();
@@ -1833,6 +1834,7 @@ mod tests {
 
     // Deletes a file
     #[tokio::test]
+    #[cfg(unix)]
     async fn filesystem_delete_file() -> io::Result<()> {
         let _ = env_logger::Builder::from_default_env().try_init();
         let tempdir = TempDir::new()?;
@@ -1977,6 +1979,7 @@ mod tests {
 
     // Deletes a hardlink
     #[tokio::test]
+    #[cfg(unix)]
     async fn filesystem_delete_hardlink() -> io::Result<()> {
         let tempdir = TempDir::new()?;
         let path = tempdir.path().to_path_buf();
@@ -2002,6 +2005,7 @@ mod tests {
     // Deletes the pointee of a hardlink (not totally accurate since we're not deleting the inode
     // entry, but what evs)
     #[tokio::test]
+    #[cfg(unix)]
     async fn filesystem_delete_hardlink_pointee() -> io::Result<()> {
         let tempdir = TempDir::new()?;
         let path = tempdir.path().to_path_buf();

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -867,12 +867,6 @@ impl FileSystem {
         if !self.passes(path, _entries) {
             // Do not continuously log ignored files
             if let false = self.ignored_dirs.contains(path) {
-                #[cfg(windows)]
-                self.ignored_dirs.insert(path.to_path_buf());
-                info!("ignoring {:?}", path);
-                _entries.clear();
-
-                #[cfg(unix)]
                 self.ignored_dirs.insert(path.to_path_buf());
                 info!("ignoring {:?}", path);
             }

--- a/common/notify_stream/Cargo.toml
+++ b/common/notify_stream/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 time = "0.3"
-notify = "5"
+notify = "4"
 futures = "0.3"
 async-channel = "1.6"
 tokio = { package = "tokio", version = "1", features = ["rt-multi-thread"] }

--- a/common/notify_stream/Cargo.toml
+++ b/common/notify_stream/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 time = "0.3"
-notify = "4"
+notify = "5"
 futures = "0.3"
 async-channel = "1.6"
 tokio = { package = "tokio", version = "1", features = ["rt-multi-thread"] }

--- a/common/notify_stream/src/lib.rs
+++ b/common/notify_stream/src/lib.rs
@@ -12,7 +12,7 @@ type PathId = std::path::PathBuf;
 #[cfg(target_os = "linux")]
 type OsWatcher = notify::INotifyWatcher;
 #[cfg(not(any(target_os = "linux")))]
-type OsWatcher = notify::PollWatcher;
+type OsWatcher = notify::RecommendedWatcher;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// Event wrapper to that hides platform and implementation details.

--- a/common/notify_stream/src/lib.rs
+++ b/common/notify_stream/src/lib.rs
@@ -251,6 +251,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn test_unwatch_if_exists() {
         let dir = tempdir().unwrap();
         let dir_untracked = tempdir().unwrap();

--- a/common/notify_stream/src/lib.rs
+++ b/common/notify_stream/src/lib.rs
@@ -247,7 +247,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(unix)]
     async fn test_unwatch_if_exists() {
         let dir = tempdir().unwrap();
         let dir_untracked = tempdir().unwrap();
@@ -318,7 +317,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(unix)]
     async fn test_create_write_delete() -> io::Result<()> {
         let dir = tempdir().unwrap();
         let dir_path = dir.path();
@@ -346,6 +344,7 @@ mod tests {
         w.watch(&file_path, RecursiveMode::NonRecursive).unwrap();
 
         wait_and_append!(file);
+        drop(file);
         fs::remove_file(&file_path)?;
 
         take!(stream, items);

--- a/common/notify_stream/src/lib.rs
+++ b/common/notify_stream/src/lib.rs
@@ -247,6 +247,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn test_unwatch_if_exists() {
         let dir = tempdir().unwrap();
         let dir_untracked = tempdir().unwrap();
@@ -317,6 +318,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn test_create_write_delete() -> io::Result<()> {
         let dir = tempdir().unwrap();
         let dir_path = dir.path();
@@ -365,6 +367,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn test_watch_file_write_after_create() -> io::Result<()> {
         let dir = tempdir().unwrap().into_path();
 

--- a/common/notify_stream/src/lib.rs
+++ b/common/notify_stream/src/lib.rs
@@ -381,7 +381,7 @@ mod tests {
             move || {
                 thread::sleep(Duration::from_millis(500));
                 let mut file = File::create(&file_path_clone).unwrap();
-                let _ = writeln!(file, "WindowsSample"); // throws a NotifyWrite event
+                let _ = writeln!(file, "WindowsSample"); // throws a NoticeWrite event
                 thread::sleep(Duration::from_millis(500));
                 let _ = fs::remove_file(file_path_clone);
             }


### PR DESCRIPTION
This updates the OS Watcher so that all the proper events are sent from the OS. It also specifies a number of tests as being for unix only. These tests are very event specific. 

LOG-14882