### PR TITLE
feature: fs cache refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328b822bdcba4d4e402be8d9adb6eebf269f969f8eadef977a553ff3c4fbcb58"
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+dependencies = [
+ "dashmap",
+ "once_cell",
+ "rustc-hash",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +652,19 @@ dependencies = [
  "darling_core 0.14.1",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -911,6 +935,7 @@ dependencies = [
  "async-channel",
  "async-trait",
  "bytes",
+ "countme 3.0.1",
  "env_logger",
  "futures",
  "futures-core",
@@ -1786,7 +1811,7 @@ dependencies = [
  "async-compression",
  "async-trait",
  "bytes",
- "countme",
+ "countme 2.0.4",
  "derivative",
  "futures",
  "http 0.2.8",

--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -357,6 +357,7 @@ pub async fn _main(
             let tailer = tail::Tailer::new(watched_dirs, rules, lookback, offsets);
             async move { tail::process(tailer).expect("except Failed to create FS Tailer") }
         },
+        config.log.clear_cache_interval,  // we restart tailer to clear fs cache
     )
     .await
     .filter_map(|r| async {

--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -357,7 +357,7 @@ pub async fn _main(
             let tailer = tail::Tailer::new(watched_dirs, rules, lookback, offsets);
             async move { tail::process(tailer).expect("except Failed to create FS Tailer") }
         },
-        config.log.clear_cache_interval,  // we restart tailer to clear fs cache
+        config.log.clear_cache_interval, // we restart tailer to clear fs cache
     )
     .await
     .filter_map(|r| async {

--- a/bin/tests/it/cli.rs
+++ b/bin/tests/it/cli.rs
@@ -2325,3 +2325,36 @@ async fn test_endurance_writes() {
     server_result.unwrap();
     agent_handle.kill().expect("Could not kill process");
 }
+
+#[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
+fn test_clear_cache() {
+    let _ = env_logger::Builder::from_default_env().try_init();
+    let dir = tempdir().expect("Could not create temp dir").into_path();
+    let file_path = dir.join("file1.log");
+    File::create(&file_path).expect("Could not create file");
+
+    let mut settings = AgentSettings::new(dir.to_str().unwrap());
+    settings.clear_cache_interval = Some(3);
+
+    let mut agent_handle = common::spawn_agent(settings);
+
+    let mut stderr_reader = BufReader::new(agent_handle.stderr.take().unwrap());
+
+    common::wait_for_file_event("initialize", &file_path, &mut stderr_reader);
+
+    debug!("got event, appending to file");
+    common::append_to_file(&file_path, 5, 50).expect("Could not append");
+    thread::sleep(std::time::Duration::from_millis(5000));
+    common::append_to_file(&file_path, 5, 50).expect("Could not append");
+
+    debug!("waiting for restarting");
+    common::wait_for_event("restarting stream, interval=3", &mut stderr_reader);
+    debug!("got restarting");
+
+    consume_output(stderr_reader.into_inner());
+
+    common::assert_agent_running(&mut agent_handle);
+
+    agent_handle.kill().expect("Could not kill process");
+}

--- a/bin/tests/it/cli.rs
+++ b/bin/tests/it/cli.rs
@@ -2352,6 +2352,16 @@ fn test_clear_cache() {
     common::wait_for_event("restarting stream, interval=3", &mut stderr_reader);
     debug!("got restarting");
 
+    // check that fs tailer is functional after restart
+    thread::sleep(std::time::Duration::from_millis(1000));
+    debug!("delete & append again");
+    fs::remove_file(&file_path).expect("Could not remove file");
+    // Immediately, start appending in a new file
+    common::append_to_file(&file_path, 5, 5).expect("Could not append");
+
+    debug!("waiting for watching");
+    common::wait_for_file_event("watching", &file_path, &mut stderr_reader);
+
     consume_output(stderr_reader.into_inner());
 
     common::assert_agent_running(&mut agent_handle);

--- a/bin/tests/it/common.rs
+++ b/bin/tests/it/common.rs
@@ -255,7 +255,10 @@ pub fn spawn_agent(settings: AgentSettings) -> Child {
     }
 
     if let Some(clear_cache_interval) = settings.clear_cache_interval {
-        agent.env("LOGDNA_CLEAR_CACHE_INTERVAL", format!("{}", clear_cache_interval));
+        agent.env(
+            "LOGDNA_CLEAR_CACHE_INTERVAL",
+            format!("{}", clear_cache_interval),
+        );
     }
 
     agent.spawn().expect("Failed to start agent")

--- a/bin/tests/it/common.rs
+++ b/bin/tests/it/common.rs
@@ -92,6 +92,7 @@ pub struct AgentSettings<'a> {
     pub ingest_timeout: Option<&'a str>,
     pub ingest_buffer_size: Option<&'a str>,
     pub log_level: Option<&'a str>,
+    pub clear_cache_interval: Option<u32>,
 }
 
 impl<'a> AgentSettings<'a> {

--- a/bin/tests/it/common.rs
+++ b/bin/tests/it/common.rs
@@ -254,6 +254,10 @@ pub fn spawn_agent(settings: AgentSettings) -> Child {
         agent.env("MZ_SYSTEMD_JOURNAL_TAILER", log_journal_d);
     }
 
+    if let Some(clear_cache_interval) = settings.clear_cache_interval {
+        agent.env("LOGDNA_CLEAR_CACHE_INTERVAL", format!("{}", clear_cache_interval));
+    }
+
     agent.spawn().expect("Failed to start agent")
 }
 

--- a/common/config/src/argv.rs
+++ b/common/config/src/argv.rs
@@ -219,7 +219,7 @@ pub struct ArgumentOptions {
 
     /// Interval in sec between clearing of various unconstrained agent caches
     #[structopt(long, env = env_vars::CLEAR_CACHE_INTERVAL)]
-    clear_cache_interval: Option<u32>
+    clear_cache_interval: Option<u32>,
 }
 
 impl ArgumentOptions {
@@ -527,8 +527,8 @@ mod test {
 
     use humanize_rs::bytes::Unit;
 
-    use std::env::set_var;
     use crate::raw;
+    use std::env::set_var;
 
     #[cfg(unix)]
     static EXCLUSION_GLOB_DEFAULT: &str = "/var/log/wtmp,/var/log/btmp,/var/log/utmp,/var/log/wtmpx,/var/log/btmpx,/var/log/utmpx,/var/log/asl/**,/var/log/sa/**,/var/log/sar*,/var/log/tallylog,/var/log/fluentd-buffers/**/*,/var/log/pods/**/*";
@@ -710,7 +710,10 @@ mod test {
         assert_eq!(config.log.metrics_port, None);
         assert_eq!(config.startup, K8sStartupLeaseConfig { option: None });
         assert_eq!(config.log.log_metric_server_stats, None);
-        assert_eq!(config.log.clear_cache_interval, Some(raw::LogConfig::default().clear_cache_interval.unwrap()));
+        assert_eq!(
+            config.log.clear_cache_interval,
+            Some(raw::LogConfig::default().clear_cache_interval.unwrap())
+        );
     }
 
     #[test]

--- a/common/config/src/argv.rs
+++ b/common/config/src/argv.rs
@@ -216,6 +216,10 @@ pub struct ArgumentOptions {
     /// etc. Numbers need to be integer values.
     #[structopt(long, env = env_vars::RETRY_DISK_LIMIT)]
     retry_disk_limit: Option<Bytes<u64>>,
+
+    /// Interval in sec between clearing of various unconstrained agent caches
+    #[structopt(long, env = env_vars::CLEAR_CACHE_INTERVAL)]
+    clear_cache_interval: Option<u32>
 }
 
 impl ArgumentOptions {
@@ -380,6 +384,10 @@ impl ArgumentOptions {
             with_csv(self.line_redact)
                 .iter()
                 .for_each(|v| regex.push(v.clone()));
+        }
+
+        if self.clear_cache_interval.is_some() {
+            raw.log.clear_cache_interval = self.clear_cache_interval
         }
 
         raw

--- a/common/config/src/argv.rs
+++ b/common/config/src/argv.rs
@@ -528,6 +528,7 @@ mod test {
     use humanize_rs::bytes::Unit;
 
     use std::env::set_var;
+    use crate::raw;
 
     #[cfg(unix)]
     static EXCLUSION_GLOB_DEFAULT: &str = "/var/log/wtmp,/var/log/btmp,/var/log/utmp,/var/log/wtmpx,/var/log/btmpx,/var/log/utmpx,/var/log/asl/**,/var/log/sa/**,/var/log/sar*,/var/log/tallylog,/var/log/fluentd-buffers/**/*,/var/log/pods/**/*";
@@ -709,6 +710,7 @@ mod test {
         assert_eq!(config.log.metrics_port, None);
         assert_eq!(config.startup, K8sStartupLeaseConfig { option: None });
         assert_eq!(config.log.log_metric_server_stats, None);
+        assert_eq!(config.log.clear_cache_interval, Some(raw::LogConfig::default().clear_cache_interval.unwrap()));
     }
 
     #[test]
@@ -736,6 +738,7 @@ mod test {
             ingest_timeout: Some(1111111),
             ingest_buffer_size: Some(222222),
             retry_dir: some_string!("/tmp/argv"),
+            clear_cache_interval: Some(777),
             retry_disk_limit: Some(Bytes::new(123456, Unit::Byte).unwrap()),
             ..ArgumentOptions::default()
         };
@@ -767,6 +770,7 @@ mod test {
         assert_eq!(config.journald.paths, Some(vec_paths!["/a"]));
         assert_eq!(config.journald.systemd_journal_tailer, Some(false));
         assert_eq!(config.startup.option, Some(String::from("always")));
+        assert_eq!(config.log.clear_cache_interval, Some(777));
     }
 
     #[test]

--- a/common/config/src/env_vars.rs
+++ b/common/config/src/env_vars.rs
@@ -33,6 +33,7 @@ pub const INGEST_BUFFER_SIZE: &str = "MZ_INGEST_BUFFER_SIZE";
 pub const RETRY_DIR: &str = "MZ_RETRY_DIR";
 pub const RETRY_DISK_LIMIT: &str = "MZ_RETRY_DISK_LIMIT";
 pub const INTERNAL_FS_DELAY: &str = "MZ_INTERNAL_FS_DELAY";
+pub const CLEAR_CACHE_INTERVAL: &str = "MZ_CLEAR_CACHE_INTERVAL";
 
 // unused or deprecated
 pub const INGESTION_KEY_ALTERNATE: &str = "LOGDNA_AGENT_KEY";

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -124,6 +124,7 @@ pub struct LogConfig {
     pub k8s_metadata_include: Vec<String>,
     pub k8s_metadata_exclude: Vec<String>,
     pub log_metric_server_stats: K8sTrackingConf,
+    pub clear_cache_interval: Duration,
 }
 
 #[derive(Debug)]
@@ -381,6 +382,13 @@ impl TryFrom<RawConfig> for Config {
                 raw.log.log_metric_server_stats,
                 env_vars::LOG_METRIC_SERVER_STATS,
                 K8sTrackingConf::Never,
+            ),
+            clear_cache_interval: Duration::from_secs(
+                raw.log.clear_cache_interval.unwrap_or_else( ||
+                    raw::LogConfig::default()
+                        .clear_cache_interval
+                        .unwrap_or_default(),
+                ) as u64,
             ),
         };
 

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -383,13 +383,13 @@ impl TryFrom<RawConfig> for Config {
                 env_vars::LOG_METRIC_SERVER_STATS,
                 K8sTrackingConf::Never,
             ),
-            clear_cache_interval: Duration::from_secs(
-                raw.log.clear_cache_interval.unwrap_or_else( ||
+            clear_cache_interval: Duration::from_secs(raw.log.clear_cache_interval.unwrap_or_else(
+                || {
                     raw::LogConfig::default()
                         .clear_cache_interval
-                        .unwrap_or_default(),
-                ) as u64,
-            ),
+                        .unwrap_or_default()
+                },
+            ) as u64),
         };
 
         if log.use_k8s_enrichment == K8sTrackingConf::Never

--- a/common/config/src/properties.rs
+++ b/common/config/src/properties.rs
@@ -55,6 +55,7 @@ from_env_name!(INGEST_TIMEOUT);
 from_env_name!(INGEST_BUFFER_SIZE);
 from_env_name!(RETRY_DIR);
 from_env_name!(RETRY_DISK_LIMIT);
+from_env_name!(CLEAR_CACHE_INTERVAL);
 
 enum Key {
     FromEnv(&'static str),
@@ -301,6 +302,12 @@ fn from_property_map(map: HashMap<String, String>) -> Result<Config, ConfigError
         argv::split_by_comma(value)
             .iter()
             .for_each(|v| regex_rules.push(v.to_string()));
+    }
+
+    if let Some(value) = map.get(&CLEAR_CACHE_INTERVAL) {
+        result.log.clear_cache_interval = Some(u32::from_str(value).map_err(|e| {
+            ConfigError::PropertyInvalid(format!("clear cache interval property is invalid: {}", e))
+        })?);
     }
 
     // Properties parser is very permissive

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -300,6 +300,8 @@ pub struct LogConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub k8s_metadata_exclude: Option<Vec<String>>,
     pub log_metric_server_stats: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clear_cache_interval: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
@@ -460,6 +462,7 @@ impl Default for LogConfig {
             k8s_metadata_include: None,
             k8s_metadata_exclude: None,
             log_metric_server_stats: None,
+            clear_cache_interval: Some(3600 * 3)  // 3 hours
         }
     }
 }
@@ -491,6 +494,8 @@ impl Merge for LogConfig {
             &other.log_metric_server_stats,
             &default.log_metric_server_stats,
         );
+        self.clear_cache_interval
+            .merge(&other.clear_cache_interval, &default.clear_cache_interval);
     }
 }
 

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -462,7 +462,7 @@ impl Default for LogConfig {
             k8s_metadata_include: None,
             k8s_metadata_exclude: None,
             log_metric_server_stats: None,
-            clear_cache_interval: Some(3600 * 3)  // 3 hours
+            clear_cache_interval: Some(3600 * 3), // 3 hours
         }
     }
 }

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -462,7 +462,7 @@ impl Default for LogConfig {
             k8s_metadata_include: None,
             k8s_metadata_exclude: None,
             log_metric_server_stats: None,
-            clear_cache_interval: Some(3600 * 3), // 3 hours
+            clear_cache_interval: Some(3600 * 6), // 6 hours
         }
     }
 }

--- a/common/fs/Cargo.toml
+++ b/common/fs/Cargo.toml
@@ -41,6 +41,8 @@ futures-core = "0.3"
 futures-util = "0.3"
 os_str_bytes = "6"
 
+countme = {version = "3.0.1", features=["enable"]}
+
 [target.'cfg(windows)'.dependencies]
 winapi-util = { version = "0.1" }
 

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -371,10 +371,6 @@ impl FileSystem {
             _c: countme::Count::new()
         };
 
-        countme::enable(true);
-        let counts = countme::get::<FileSystem>();
-        eprintln!("@@@@@@@@@@@@@@@@ total={}  live={}  max_live={}", counts.total, counts.live, counts.max_live);
-
         let entries = fs.entries.clone();
         let mut entries = entries.borrow_mut();
 

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -368,7 +368,7 @@ impl FileSystem {
             retry_events_recv,
             retry_events_send,
             ignored_dirs,
-            _c: countme::Count::new()
+            _c: countme::Count::new(),
         };
 
         let entries = fs.entries.clone();

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -259,6 +259,8 @@ pub struct FileSystem {
     retry_events_send: async_channel::Sender<(WatchEvent, EventTimestamp, u32)>,
 
     ignored_dirs: HashSet<PathBuf>,
+
+    _c: countme::Count<Self>,
 }
 
 #[cfg(unix)]
@@ -366,7 +368,12 @@ impl FileSystem {
             retry_events_recv,
             retry_events_send,
             ignored_dirs,
+            _c: countme::Count::new()
         };
+
+        countme::enable(true);
+        let counts = countme::get::<FileSystem>();
+        eprintln!("@@@@@@@@@@@@@@@@ total={}  live={}  max_live={}", counts.total, counts.live, counts.max_live);
 
         let entries = fs.entries.clone();
         let mut entries = entries.borrow_mut();

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -300,7 +300,7 @@ where
             stream,
             pending: None,
             start_time: Some(Instant::now()),
-            restart_interval: restart_interval,
+            restart_interval,
         }
     }
 }
@@ -330,7 +330,10 @@ where
                     this.start_time.set(Some(Instant::now()));
                     let stream_fut = (this.f)(this.params);
                     this.pending.set(Some(stream_fut));
-                    info!("restarting stream, interval={}", this.restart_interval.as_secs());
+                    info!(
+                        "restarting stream, interval={}",
+                        this.restart_interval.as_secs()
+                    );
                 }
             }
             if let Some(p) = this.pending.as_mut().as_pin_mut() {

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -330,7 +330,7 @@ where
                     this.start_time.set(Some(Instant::now()));
                     let stream_fut = (this.f)(this.params);
                     this.pending.set(Some(stream_fut));
-                    info!("restarting stream");
+                    info!("restarting stream, interval={}", this.restart_interval.as_secs());
                 }
             }
             if let Some(p) = this.pending.as_mut().as_pin_mut() {
@@ -555,6 +555,7 @@ mod test {
             (watched_dirs, rules, Lookback::None, initial_offsets),
             |_: &String| false,
             |&_| async { futures::stream::empty() },
+            Duration::from_secs(3600),
         )
         .await;
 
@@ -579,6 +580,7 @@ mod test {
             (watched_dirs, rules, Lookback::None, initial_offsets),
             |_: &usize| false,
             |&_| async { futures::stream::iter(vec![1, 2, 3]) },
+            Duration::from_secs(3600),
         )
         .await;
 
@@ -616,6 +618,7 @@ mod test {
                     Some((cur, state))
                 }))
             },
+            Duration::from_secs(3600),
         )
         .await;
 
@@ -659,6 +662,7 @@ mod test {
                     }
                 }))
             },
+            Duration::from_secs(3600),
         )
         .await;
 


### PR DESCRIPTION
- added config.log.clear_cache_interval, default is 6 hours
- fs tailer gets restarted periodically using clear_cache_interval to clear fs cache 

LOG_15140