### PR TITLE
fix: panic at handling Rename notify-rs event with empty path

### DIFF
--- a/common/notify_stream/src/lib.rs
+++ b/common/notify_stream/src/lib.rs
@@ -176,9 +176,10 @@ impl Watcher {
                     EventKind::Modify(ModifyKind::Data(DataChange::Any)) => {
                         Some(Event::Write(received.paths.first().unwrap().clone()))
                     }
-                    EventKind::Modify(ModifyKind::Name(RenameMode::From)) => {
-                        Some(Event::Remove(received.paths.first().unwrap().clone()))
-                    }
+                    EventKind::Modify(ModifyKind::Name(RenameMode::From)) => received
+                        .paths
+                        .first()
+                        .map(|path| Event::Remove(path.clone())),
                     EventKind::Modify(ModifyKind::Name(RenameMode::To)) => {
                         Some(Event::Create(received.paths.first().unwrap().clone()))
                     }


### PR DESCRIPTION
- fixed panic during handling Rename-From notify-rs event with empty path
- it happens when From event is generated separately from To event due to some racing in notify-rs
- the event is ignored and rectified by explicit  FS rescan.