### PR TITLE
Fix Trace Crate Windows Compiler Warnings

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -1,7 +1,13 @@
 use config::{self, Config};
 use std::sync::Arc;
 use tokio::sync::Mutex;
+
+#[cfg(unix)]
 use tracing::{debug, info, trace, warn};
+
+#[cfg(windows)]
+use tracing::info;
+
 use tracing_subscriber::{filter::LevelFilter, EnvFilter, FmtSubscriber};
 
 mod _main;

--- a/common/fs/src/cache/dir_path.rs
+++ b/common/fs/src/cache/dir_path.rs
@@ -148,8 +148,10 @@ fn level_up(path: &Path) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use std::env::temp_dir;
 
+    #[cfg(unix)]
     use super::*;
 
     #[test]

--- a/common/fs/src/cache/dir_path.rs
+++ b/common/fs/src/cache/dir_path.rs
@@ -1,7 +1,12 @@
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
+
+#[cfg(unix)]
 use tracing::{error, warn};
+
+#[cfg(windows)]
+use tracing::error;
 
 #[derive(Error, std::fmt::Debug)]
 pub enum DirPathBufError {

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -1540,6 +1540,7 @@ mod tests {
     use pin_utils::pin_mut;
     use std::convert::TryInto;
     use std::fs::{copy, create_dir, hard_link, remove_dir_all, remove_file, rename, File};
+    #[cfg(unix)]
     use std::io::Write;
     use std::{io, panic};
     use tempfile::{tempdir, TempDir};

--- a/common/notify_stream/src/lib.rs
+++ b/common/notify_stream/src/lib.rs
@@ -271,9 +271,6 @@ mod tests {
     #[cfg(windows)]
     use std::sync::mpsc;
 
-    #[cfg(windows)]
-    use std::thread;
-
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     use predicates::prelude::*;
 
@@ -319,6 +316,7 @@ mod tests {
         };
     }
 
+    #[cfg(unix)]
     macro_rules! wait_and_append {
         ($file: ident) => {
             tokio::time::sleep(DELAY * 3).await;


### PR DESCRIPTION
Some of that paths in Windows didn't include some of the crate modules and were throwing warnings.