### PR TITLE
fix: non-existing log directory crash at startup on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
  "pcre2",
  "pin-project-lite",
  "pin-utils",
+ "regex",
  "serde_json",
  "slotmap",
  "smallvec",

--- a/api/src/tailer/mod.rs
+++ b/api/src/tailer/mod.rs
@@ -46,7 +46,7 @@ where
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     /*
-    Tailer API log lines are 'etf-8' encoded and separated by a single newline.
+    Tailer API log lines are 'utf-8' encoded and separated by a single newline.
     */
     any_partial_state(
         recognize((skip_many(none_of(b"\r\n".iter().copied())), crlf())).and_then(

--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -510,7 +510,7 @@ pub async fn _main(
     }
 
     if let Some(s) = tailer_source.as_mut() {
-        info!("Enabling tailer event source");
+        info!("Enabling api tailer source");
         sources.push(s)
     }
 

--- a/bin/tests/it/cli.rs
+++ b/bin/tests/it/cli.rs
@@ -1894,11 +1894,11 @@ async fn test_directory_created_after_initialization() {
     let (server, received, shutdown_handle, addr) = common::start_http_ingester();
     let settings = AgentSettings::with_mock_ingester(future_dir.to_str().unwrap(), &addr);
     let mut agent_handle = common::spawn_agent(settings);
-    let mut stderr_reader = std::io::BufReader::new(agent_handle.stderr.take().unwrap());
-    common::wait_for_event("Enabling filesystem", &mut stderr_reader);
-    consume_output(stderr_reader.into_inner());
-
     let (server_result, _) = tokio::join!(server, async {
+        let mut stderr_reader = std::io::BufReader::new(agent_handle.stderr.take().unwrap());
+        common::wait_for_event("Enabling filesystem", &mut stderr_reader);
+        consume_output(stderr_reader.into_inner());
+
         let file_path = future_dir.join("test.log");
         std::fs::create_dir(&future_dir).unwrap();
         File::create(&file_path).unwrap();
@@ -1917,7 +1917,6 @@ async fn test_directory_created_after_initialization() {
         assert_eq!(file_info.lines, 10);
         shutdown_handle();
     });
-
     server_result.unwrap();
     agent_handle.kill().expect("Could not kill process");
 }

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -660,14 +660,10 @@ mod tests {
         assert_eq!(config.log.log_k8s_events, K8sTrackingConf::Never);
         assert_eq!(config.log.log_metric_server_stats, K8sTrackingConf::Never);
         assert_eq!(config.log.lookback, Lookback::None);
+        let def_pathbuf = PathBuf::from(DEFAULT_LOG_DIR);
         assert_eq!(
-            config
-                .log
-                .dirs
-                .iter()
-                .map(|p| p.to_path_buf())
-                .collect::<Vec<_>>(),
-            vec![PathBuf::from(DEFAULT_LOG_DIR)]
+            config.log.dirs,
+            vec![DirPathBuf::try_from(def_pathbuf).unwrap()]
         );
         assert_eq!(config.startup, K8sLeaseConf::Never);
     }

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -348,6 +348,7 @@ impl TryFrom<RawConfig> for Config {
             dirs: raw
                 .log
                 .dirs
+                .clone()
                 .into_iter()
                 // Find valid directory paths and keep track of missing paths
                 .filter_map(|d| {
@@ -650,6 +651,10 @@ mod tests {
 
     #[test]
     fn test_default_parsed() {
+        assert_eq!(
+            raw::default_log_dirs(),
+            vec![PathBuf::from(DEFAULT_LOG_DIR)]
+        );
         let config = get_default_config();
         assert_eq!(config.log.use_k8s_enrichment, K8sTrackingConf::Always);
         assert_eq!(config.log.log_k8s_events, K8sTrackingConf::Never);
@@ -660,9 +665,9 @@ mod tests {
                 .log
                 .dirs
                 .iter()
-                .map(|p| p.to_str().unwrap())
+                .map(|p| p.to_path_buf())
                 .collect::<Vec<_>>(),
-            vec![DEFAULT_LOG_DIR]
+            vec![PathBuf::from(DEFAULT_LOG_DIR)]
         );
         assert_eq!(config.startup, K8sLeaseConf::Never);
     }

--- a/common/fs/Cargo.toml
+++ b/common/fs/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1"
 pin-project-lite = "0.2"
 glob = "0.3"
 walkdir = "2"
+regex = "1"
 
 #logging
 lazy_static = "1"

--- a/common/fs/src/cache/dir_path.rs
+++ b/common/fs/src/cache/dir_path.rs
@@ -1,9 +1,17 @@
+use regex::Regex;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
-use tracing::error;
+use tracing::{error, warn};
+
 #[cfg(not(windows))]
-use tracing::warn;
+lazy_static! {
+    static ref REGEX_FS_ROOT: Regex = Regex::new(r"^/$").unwrap();
+}
+#[cfg(windows)]
+lazy_static! {
+    static ref REGEX_FS_ROOT: Regex = Regex::new(r"^ [a-zA-Z]:[\\/]$").unwrap();
+}
 
 #[derive(Error, std::fmt::Debug)]
 pub enum DirPathBufError {
@@ -33,18 +41,9 @@ impl Deref for DirPathBuf {
 impl std::convert::TryFrom<PathBuf> for DirPathBuf {
     type Error = DirPathBufError;
     fn try_from(path: PathBuf) -> Result<Self, Self::Error> {
-        #[cfg(unix)]
         match find_valid_path(Some(path.clone()), None) {
             Ok(p) => Ok(p),
             _ => Err(DirPathBufError::NotADirPath(path)),
-        }
-
-        #[cfg(windows)]
-        {
-            Ok(DirPathBuf {
-                inner: path,
-                postfix: None,
-            })
         }
     }
 }
@@ -52,7 +51,6 @@ impl std::convert::TryFrom<PathBuf> for DirPathBuf {
 impl std::convert::TryFrom<&Path> for DirPathBuf {
     type Error = String;
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
-        #[cfg(unix)]
         if path.is_dir() {
             Ok(DirPathBuf {
                 inner: path.into(),
@@ -61,16 +59,8 @@ impl std::convert::TryFrom<&Path> for DirPathBuf {
         } else {
             path.to_str().map_or_else(
                 || Err("path is not a directory and cannot be formatted".into()),
-                |path| Err(format!("{} is not a directory", path)),
+                |path| Err(format!("{path} is not a directory")),
             )
-        }
-
-        #[cfg(windows)]
-        {
-            Ok(DirPathBuf {
-                inner: path.into(),
-                postfix: None,
-            })
         }
     }
 }
@@ -88,42 +78,43 @@ impl From<DirPathBuf> for PathBuf {
 }
 
 /// If a path does not exist, the function continue to move to the parent directory
-/// until it finds a valid directory.
-///
-/// When a valid directory is found, it adds the missing piece of the directory
-/// path to `postfix` and returns the `DirPathBuf` result.
-#[cfg(unix)]
+/// until it finds a valid directory. When a valid directory is found, it prepend the
+/// missing piece of the directory path to `postfix` and returns the `DirPathBuf` result.
 fn find_valid_path(
     path: Option<PathBuf>,
     postfix: Option<PathBuf>,
 ) -> Result<DirPathBuf, DirPathBufError> {
     match path {
-        Some(p) => {
-            if matches!(std::fs::canonicalize(&p), Ok(_)) {
-                Ok(DirPathBuf { inner: p, postfix })
+        Some(some_path) => {
+            if matches!(std::fs::canonicalize(&some_path), Ok(_)) {
+                Ok(DirPathBuf {
+                    inner: some_path,
+                    postfix,
+                })
             } else {
-                warn!("{:?} is not a directory; moving to parent directory", p);
-                let root_pathbuf = Path::new("/");
-                let mut postfix_pathbuf = PathBuf::new();
-                let mut pop_pathbuf = PathBuf::new();
-                if let Some(pop) = postfix {
-                    pop_pathbuf.push(pop);
+                warn!(
+                    "{:?} is not a directory; moving to parent directory",
+                    some_path
+                );
+                let mut some_postfix = PathBuf::new();
+                if let Some(p) = postfix {
+                    some_postfix.push(p);
                 }
-                let parent = match level_up(&p) {
-                    Some(p) => {
-                        if p == root_pathbuf {
+                let parent = match level_up(&some_path) {
+                    Some(some_parent) => {
+                        if REGEX_FS_ROOT
+                            .is_match(some_parent.to_str().expect("invalid unicode path").as_ref())
+                        {
                             warn!("root level directory was missing, as a result configured directory recursed to the root level!");
                         }
-                        p
+                        some_parent
                     }
-                    None => return Err(DirPathBufError::NotADirPath(p)),
+                    None => return Err(DirPathBufError::NotADirPath(some_path)),
                 };
-
-                let tmp_dir = parent;
-                let postfix_path = p.strip_prefix(tmp_dir).ok();
-                postfix_pathbuf.push(postfix_path.unwrap());
-                postfix_pathbuf.push(pop_pathbuf);
-                find_valid_path(level_up(&p), Some(postfix_pathbuf))
+                let pop_path = some_path.strip_prefix(&parent).unwrap();
+                let mut new_postfix = PathBuf::from(pop_path);
+                new_postfix.push(some_postfix);
+                find_valid_path(Some(parent), Some(new_postfix))
             }
         }
         None => Err(DirPathBufError::EmptyDirPath(path)),
@@ -131,7 +122,6 @@ fn find_valid_path(
 }
 
 /// Given a path, returns an `Option<PathBuf>` of the parent directory.
-#[cfg(unix)]
 fn level_up(path: &Path) -> Option<PathBuf> {
     let mut parent_path = PathBuf::new();
     match path.parent() {
@@ -143,7 +133,6 @@ fn level_up(path: &Path) -> Option<PathBuf> {
     }
 }
 
-#[cfg(not(windows))]
 #[cfg(test)]
 mod tests {
     use std::env::temp_dir;
@@ -151,7 +140,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(unix)]
     fn test_level_up() {
         let mut expe_pathbuf = PathBuf::new();
         expe_pathbuf.push("/test-directory");
@@ -167,7 +155,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
     fn test_find_valid_path() {
         let mut test_path = PathBuf::new();
         let test_postfix = PathBuf::new();
@@ -189,7 +176,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
     fn test_deep_find_valid_path() {
         let mut test_path = PathBuf::new();
         let test_postfix = PathBuf::new();
@@ -211,7 +197,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
     fn test_filename_find_valid_path() {
         let mut test_path = PathBuf::new();
         let test_postfix = PathBuf::new();
@@ -233,7 +218,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
     fn test_empty_find_valid_path() {
         let mut test_path = PathBuf::new();
         let test_postfix = PathBuf::new();
@@ -244,7 +228,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
     fn test_invalid_find_valid_path() {
         let mut test_path = PathBuf::new();
         let test_postfix = PathBuf::new();
@@ -255,7 +238,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
     fn test_root_find_valid_path() {
         let mut test_path = PathBuf::new();
         let test_postfix = PathBuf::new();
@@ -266,7 +248,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
     fn test_root_lvl_find_valid_path() {
         let mut test_path = PathBuf::new();
         let test_postfix = PathBuf::new();

--- a/common/fs/src/cache/dir_path.rs
+++ b/common/fs/src/cache/dir_path.rs
@@ -105,7 +105,7 @@ fn find_valid_path(
                         if REGEX_FS_ROOT
                             .is_match(some_parent.to_str().expect("invalid unicode path").as_ref())
                         {
-                            warn!("root level directory was missing, as a result configured directory recursed to the root level!");
+                            warn!("{:?} does not exist up to the root level!", some_path);
                         }
                         some_parent
                     }


### PR DESCRIPTION
- agent is not able to start with logging directory that is missing on windows  - LOG-9806 regression on Windows
- typos

Ref: LOG-14549
Ref: LOG-9806
