### PR TITLE
fix: name collision of local crate "http" in cargo audit run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,8 +69,8 @@ dependencies = [
  "combine",
  "env_logger",
  "futures",
- "http 0.1.0",
  "log",
+ "mz-http",
  "partial-io",
  "serial_test",
  "time 0.3.9",
@@ -481,10 +481,10 @@ dependencies = [
  "async-compression",
  "fs",
  "glob",
- "http 0.1.0",
  "humanize-rs",
  "java-properties",
  "lazy_static",
+ "mz-http",
  "path-slash",
  "regex",
  "scopeguard",
@@ -1060,11 +1060,11 @@ dependencies = [
  "futures-core",
  "futures-util",
  "glob",
- "http 0.1.0",
  "lazy_static",
  "memchr",
  "metrics",
  "middleware",
+ "mz-http",
  "notify_stream",
  "os_str_bytes",
  "pcre2",
@@ -1232,7 +1232,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.8",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1298,37 +1298,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.0"
-dependencies = [
- "async-compat",
- "async-compression",
- "bytes",
- "crossbeam",
- "futures",
- "futures-timer",
- "hyper",
- "logdna-client",
- "metrics",
- "num_cpus",
- "prometheus",
- "proptest",
- "rand",
- "serde",
- "serde_json",
- "state",
- "tempfile",
- "thiserror",
- "time 0.3.9",
- "tokio",
- "tokio-test",
- "tracing",
- "tracing-subscriber",
- "types",
- "uuid",
-]
-
-[[package]]
-name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
@@ -1345,7 +1314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http 0.2.8",
+ "http",
  "pin-project-lite",
 ]
 
@@ -1390,7 +1359,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.8",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -1409,7 +1378,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
- "http 0.2.8",
+ "http",
  "hyper",
  "log",
  "rustls",
@@ -1618,8 +1587,8 @@ dependencies = [
  "combine",
  "env_logger",
  "futures",
- "http 0.1.0",
  "metrics",
+ "mz-http",
  "partial-io",
  "serial_test",
  "systemd",
@@ -1677,8 +1646,7 @@ dependencies = [
  "chrono",
  "crossbeam",
  "futures",
- "http 0.1.0",
- "http 0.2.8",
+ "http",
  "humantime",
  "hyper",
  "hyper-rustls",
@@ -1689,6 +1657,7 @@ dependencies = [
  "lazy_static",
  "metrics",
  "middleware",
+ "mz-http",
  "parking_lot",
  "pin-project-lite",
  "pin-utils",
@@ -1764,7 +1733,7 @@ dependencies = [
  "dirs-next",
  "either",
  "futures",
- "http 0.2.8",
+ "http",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -1796,7 +1765,7 @@ checksum = "bc8c429676abe6a73b374438d5ca02caaf9ae7a635441253c589b779fa5d0622"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http 0.2.8",
+ "http",
  "json-patch",
  "k8s-openapi",
  "once_cell",
@@ -1968,7 +1937,6 @@ dependencies = [
  "float-cmp",
  "fs",
  "futures",
- "http 0.1.0",
  "hyper",
  "itertools",
  "journald",
@@ -1981,6 +1949,7 @@ dependencies = [
  "metrics",
  "middleware",
  "miniz_oxide 0.5.4",
+ "mz-http",
  "nix",
  "once_cell",
  "pin-utils",
@@ -2028,7 +1997,7 @@ dependencies = [
  "countme 2.0.4",
  "derivative",
  "futures",
- "http 0.2.8",
+ "http",
  "hyper",
  "hyper-rustls",
  "log",
@@ -2155,10 +2124,10 @@ name = "middleware"
 version = "0.1.0"
 dependencies = [
  "config",
- "http 0.1.0",
  "lazy_static",
  "memoffset 0.6.5",
  "multimap",
+ "mz-http",
  "regex",
  "serde_json",
  "thiserror",
@@ -2229,6 +2198,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "mz-http"
+version = "0.1.0"
+dependencies = [
+ "async-compat",
+ "async-compression",
+ "bytes",
+ "crossbeam",
+ "futures",
+ "futures-timer",
+ "hyper",
+ "logdna-client",
+ "metrics",
+ "num_cpus",
+ "prometheus",
+ "proptest",
+ "rand",
+ "serde",
+ "serde_json",
+ "state",
+ "tempfile",
+ "thiserror",
+ "time 0.3.9",
+ "tokio",
+ "tokio-test",
+ "tracing",
+ "tracing-subscriber",
+ "types",
+ "uuid",
 ]
 
 [[package]]
@@ -3001,15 +3001,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,16 +3558,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3846,7 +3836,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 0.2.8",
+ "http",
  "http-body",
  "http-range-header",
  "pin-project-lite",
@@ -4022,8 +4012,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "http 0.1.0",
  "logdna-client",
+ "mz-http",
  "proptest",
  "serde_json",
  "state",

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ ifneq ($(WINDOWS),)
 	ARCH_TRIPLE?=$(ARCH)-windows-msvc
 	BINDGEN_EXTRA_CLANG_ARGS:=
 	RUSTFLAGS:=
-	RUSTFLAGS:=-C link-self-contained=yes -Ctarget-feature=+crt-static -Clink-arg=-static -Clink-arg=-static-libstdc++ -Clink-arg=-static-libgcc
+	RUSTFLAGS:=-Ctarget-feature=+crt-static -Clink-arg=-static -Clink-arg=-static-libstdc++ -Clink-arg=-static-libgcc
 	CARGO_COMMAND:=cargo xwin
 	BIN_SUFFIX=.exe
 else ifeq ($(STATIC), 1)

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ lint-clippy: ## Checks for code errors
 
 .PHONY:lint-audit
 lint-audit: ## Audits packages for issues
-	$(RUST_COMMAND) "--env RUST_BACKTRACE=full" "cargo audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2022-0040"
+	$(RUST_COMMAND) "--env RUST_BACKTRACE=full" "cargo audit --ignore RUSTSEC-2020-0071"
 
 .PHONY:lint-docker
 lint-docker: ## Lint the Dockerfile for issues

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["dkhokhlov <dkhokhlov@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-http = { package = "http", path = "../common/http" }
+http = { package = "mz-http", path = "../common/http" }
 
 tokio = { package = "tokio", version = "1", features = ["macros", "process", "rt-multi-thread", "time"] }
 futures = "0.3"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -26,7 +26,7 @@ required-features = ['windows_service']
 
 [dependencies]
 #local
-http = { package = "http", path = "../common/http" }
+http = { package = "mz-http", path = "../common/http" }
 fs = { package = "fs", path = "../common/fs" }
 config = { package = "config", path = "../common/config" }
 middleware = { package = "middleware", path = "../common/middleware" }

--- a/common/config/Cargo.toml
+++ b/common/config/Cargo.toml
@@ -10,7 +10,7 @@ integration_tests = []
 [dependencies]
 #local
 fs = { package = "fs", path = "../fs" }
-http = { package = "http", path = "../http" }
+http = { package = "mz-http", path = "../http" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/common/fs/Cargo.toml
+++ b/common/fs/Cargo.toml
@@ -9,7 +9,7 @@ integration_tests = []
 
 [dependencies]
 #local
-http = { package = "http", path = "../http" }
+http = { package = "mz-http", path = "../http" }
 metrics = { package = "metrics", path = "../metrics" }
 state = { package = "state", path = "../state" }
 notify_stream = { package = "notify_stream", path = "../notify_stream" }

--- a/common/http/Cargo.toml
+++ b/common/http/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "http"
+name = "mz-http"
 version = "0.1.0"
 authors = ["CJP10 <connor.peticca@logdna.com>"]
 edition = "2018"

--- a/common/journald/Cargo.toml
+++ b/common/journald/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["jakedipity <jacob.hull@logdna.com>"]
 edition = "2018"
 
 [dependencies]
-http = { package = "http", path = "../http" }
+http = { package = "mz-http", path = "../http" }
 metrics = { package = "metrics", path = "../metrics" }
 
 tokio = { package = "tokio", version = "1", features = ["macros", "process", "rt-multi-thread", "time"] }

--- a/common/k8s/Cargo.toml
+++ b/common/k8s/Cargo.toml
@@ -10,7 +10,7 @@ integration_tests = []
 [dependencies]
 #local
 middleware = { package = "middleware", path = "../middleware" }
-http = { package = "http", path = "../http" }
+http = { package = "mz-http", path = "../http" }
 metrics = { package = "metrics", path = "../metrics" }
 backoff = { version = "0.4.0", features = ["tokio"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/common/middleware/Cargo.toml
+++ b/common/middleware/Cargo.toml
@@ -9,7 +9,7 @@ integration_tests = []
 
 [dependencies]
 #local
-http = { package = "http", path = "../http" }
+http = { package = "mz-http", path = "../http" }
 config = { package = "config", path = "../config" }
 memoffset = "0.6"
 regex = "1"

--- a/common/test/types/Cargo.toml
+++ b/common/test/types/Cargo.toml
@@ -13,5 +13,5 @@ futures = "0.3"
 logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.7.x", version = "0.7.2" }
 proptest = "1"
 serde_json = "1"
-http = { package = "http", path = "../../http" }
+http = { package = "mz-http", path = "../../http" }
 state = { package = "state", path = "../../state" }


### PR DESCRIPTION
- fixed name collision of local crate "http" in cargo audit run
- updated tempfile crate to "3.4.0"
- fixed windows build - removed unsupported flag "link-self-contained flag"

test:
- rustup update
- cargo audit --ignore RUSTSEC-2020-0071
