### PR TITLE
fix: refresh kubernetes metadata watcher on stream error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,10 +19,11 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
+ "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
@@ -265,6 +266,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -1628,12 +1635,13 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "json-patch"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3fa5a61630976fc4c353c70297f2e93f1930e3ccee574d59d618ccbd5154ce"
+checksum = "e712e62827c382a77b87f590532febb1f8b2fdbc3eefa1ee37fe7281687075ef"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror",
  "treediff",
 ]
 
@@ -1688,11 +1696,11 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ae2c04fcee6b01b04e3aadd56bb418932c8e0a9d8a93f48bc68c6bdcdb559d"
+checksum = "3d1985030683a2bac402cbda61222195de80d3f66b4c87ab56e5fea379bd98c3"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.20.0",
  "bytes",
  "chrono",
  "serde",
@@ -1722,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.73.1"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68b954ea9ad888de953fb1488bd8f377c4c78d82d4642efa5925189210b50b7"
+checksum = "414d80c69906a91e8ecf4ae16d0fb504e19aa6b099135d35d85298b4e4be3ed3"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1734,11 +1742,11 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.73.1"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150dc7107d9acf4986088f284a0a6dddc5ae37ef1ffdf142f6811dc5998dd58"
+checksum = "6dc5ae0b9148b4e2ebb0dabda06a0cd65b1eed2f41d792d49787841a68050283"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.20.0",
  "bytes",
  "chrono",
  "dirs-next",
@@ -1770,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.73.1"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8c429676abe6a73b374438d5ca02caaf9ae7a635441253c589b779fa5d0622"
+checksum = "98331c6f1354893f7c50da069e43a3fd1c84e55bbedc7765d9db22ec3291d07d"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1800,11 +1808,12 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.73.1"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e9e9da456f0101b77f864a9da44866b9891ad4740db508b4b269343ebeb01d"
+checksum = "b698eb8998b46683b0dc3c2ce72c80bc308fc8159f25afa719668c290a037a57"
 dependencies = [
  "ahash",
+ "async-trait",
  "backoff",
  "derivative",
  "futures",
@@ -4060,9 +4069,9 @@ dependencies = [
 
 [[package]]
 name = "treediff"
-version = "3.0.2"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761e8d5ad7ce14bb82b7e61ccc0ca961005a275a060b9644a2431aa11553c2ff"
+checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
 dependencies = [
  "serde_json",
 ]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -39,7 +39,7 @@ api = { package = "api", path = "../api" }
 bytes = "1"
 time = "0.3"
 async-trait = "0.1"
-kube = { version = "0.73", default-features = false, features = ["rustls-tls"] }
+kube = { version = "0.80", default-features = false, features = ["rustls-tls"] }
 env_logger = "0.9"
 anyhow = "1"
 serde_yaml = "0.8"
@@ -86,9 +86,9 @@ dhat-ad-hoc = []  # if you are doing ad hoc profiling
 [dev-dependencies]
 assert_cmd = "2"
 escargot = "0.5"
-kube = { version = "0.73.0", default-features = false, features = ["rustls-tls"] }
-kube-runtime = "0.73.0"
-k8s-openapi = { version = "0.15.0", default_features = false, features = ["v1_18"] }
+kube = { version = "0.80.0", default-features = false, features = ["rustls-tls"] }
+kube-runtime = "0.80.0"
+k8s-openapi = { version = "0.17.0", default_features = false, features = ["v1_20"] }
 pnet = "0.28"
 itertools = "0.10"
 rustls-pemfile = "0.2"

--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -24,7 +24,7 @@ use k8s::event_source::K8sEventStream;
 use k8s::lease::{get_available_lease, K8S_STARTUP_LEASE_LABEL, K8S_STARTUP_LEASE_RETRY_ATTEMPTS};
 
 use k8s::create_k8s_client_default_from_env;
-use k8s::middleware::K8sMetadata;
+use k8s::middleware::metadata_runner;
 use kube::Client as Kube_Client;
 use metrics::Metrics;
 use middleware::k8s_line_rules::K8sLineFilter;
@@ -154,21 +154,7 @@ pub async fn _main(
                     && std::env::var_os("KUBERNETES_SERVICE_HOST").is_some()
                 {
                     let node_name = std::env::var("NODE_NAME").ok();
-                    match K8sMetadata::new(k8s_client.clone(), node_name.as_deref()).await {
-                        Ok((driver, v)) => {
-                            tokio::spawn(driver);
-                            executor.register(v);
-                            info!("Registered k8s metadata middleware");
-                        }
-                        Err(e) => {
-                            let message = format!(
-                                "The agent could not access k8s api after several attempts: {}",
-                                e
-                            );
-                            error!("{}", message);
-                            panic!("{}", message);
-                        }
-                    };
+                    metadata_runner(user_agent, node_name, &mut executor);
                 }
 
                 let pod_name = std::env::var("POD_NAME").ok();

--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -11,7 +11,7 @@ use k8s_openapi::api::coordination::v1::Lease;
 use k8s_openapi::api::core::v1::{Endpoints, Namespace, Pod, Service, ServiceAccount};
 use k8s_openapi::api::rbac::v1::{ClusterRole, ClusterRoleBinding, Role, RoleBinding};
 use kube::api::{Api, ListParams, LogParams, PostParams, WatchEvent};
-use kube::{Client, ResourceExt};
+use kube::Client;
 use tracing::{debug, info};
 
 use test_log::test;
@@ -28,7 +28,7 @@ async fn print_pod_logs(client: Client, namespace: &str, label: &str) {
             async move {
                 let mut logs = pods
                     .log_stream(
-                        &p.name(),
+                        &p.metadata.name.clone().unwrap(),
                         &LogParams {
                             follow: true,
                             tail_lines: None,
@@ -39,11 +39,11 @@ async fn print_pod_logs(client: Client, namespace: &str, label: &str) {
                     .unwrap()
                     .boxed();
 
-                debug!("Logging agent pod {}", p.name());
+                debug!("Logging agent pod {:?}", p.metadata.name);
                 while let Some(line) = logs.next().await {
                     debug!(
                         "LOG [{:?}] {:?}",
-                        p.name(),
+                        p.metadata.name,
                         String::from_utf8_lossy(&line.unwrap())
                     );
                 }

--- a/common/k8s/Cargo.toml
+++ b/common/k8s/Cargo.toml
@@ -29,8 +29,8 @@ lazy_static = "1"
 tokio = { package = "tokio", version = "1", features = ["macros", "process", "signal", "rt-multi-thread", "time"] }
 futures = "0.3"
 thiserror = "1.0"
-kube = { version = "0.73.0", default-features = false, features = ["rustls-tls", "client", "runtime", "gzip"] }
-k8s-openapi = { version = "0.15", default_features = false, features = ["v1_18"] }
+kube = { version = "0.80.0", default-features = false, features = ["rustls-tls", "client", "runtime", "gzip"] }
+k8s-openapi = { version = "0.17.0", default_features = false, features = ["v1_20"] }
 kube-derive = "0.73.0"
 parking_lot = "0.12"
 serde = { version = "1", features = ["derive"]}

--- a/common/k8s/src/kube_stats/pod_stats.rs
+++ b/common/k8s/src/kube_stats/pod_stats.rs
@@ -259,6 +259,7 @@ mod tests {
             tolerations: None,
             topology_spread_constraints: None,
             volumes: None,
+            set_hostname_as_fqdn: None,
         }
     }
 

--- a/common/k8s/src/lib.rs
+++ b/common/k8s/src/lib.rs
@@ -27,7 +27,6 @@ fn create_k8s_client(
     user_agent: hyper::http::header::HeaderValue,
     config: Config,
 ) -> Result<Client, kube::Error> {
-    let timeout = config.timeout;
     let default_ns = config.default_namespace.clone();
 
     let client: hyper::Client<_, Body> = {
@@ -40,8 +39,8 @@ fn create_k8s_client(
         ));
 
         let mut connector = TimeoutConnector::new(connector);
-        connector.set_connect_timeout(timeout);
-        connector.set_read_timeout(timeout);
+        connector.set_connect_timeout(config.connect_timeout);
+        connector.set_read_timeout(config.read_timeout);
 
         hyper::Client::builder().build(connector)
     };
@@ -76,7 +75,8 @@ pub fn create_k8s_client_default_from_env(
         return Err(K8sError::K8sNotInClusterError());
     }
 
-    let config = Config::from_cluster_env()?;
+    let config = Config::incluster_dns()?;
+
     Ok(create_k8s_client(user_agent, config)?)
 }
 

--- a/common/k8s/src/middleware/mod.rs
+++ b/common/k8s/src/middleware/mod.rs
@@ -1,8 +1,10 @@
 use regex::Regex;
 
 mod metadata;
+mod runner;
 
 pub use metadata::*;
+pub use runner::*;
 
 lazy_static! {
     static ref K8S_REG: Regex = Regex::new(

--- a/common/k8s/src/middleware/runner.rs
+++ b/common/k8s/src/middleware/runner.rs
@@ -1,0 +1,134 @@
+use crate::{
+    create_k8s_client_default_from_env,
+    middleware::{K8sMetadata, StoreSwapIntent},
+};
+use futures::StreamExt;
+use hyper::http::header::HeaderValue;
+use middleware::Executor;
+use std::{cmp::min, sync::Arc, time::SystemTime};
+use tokio::{
+    task::JoinHandle,
+    time::{sleep, Duration},
+};
+use tracing::{error, trace, warn};
+
+pub static SWAP_DELAY: Duration = Duration::from_secs(3);
+pub static RESET_DURATION: Duration = Duration::from_secs(60);
+pub static INITIAL_BACKOFF_SECS: u32 = 2;
+pub static MAX_BACKOFF_SECS: u32 = 30;
+
+enum State<'a> {
+    Init,
+    Creating(u32),
+    Kicking(u32, kube::Client),
+    Swapping(u32, JoinHandle<()>, StoreSwapIntent<'a>),
+    Running(u32, JoinHandle<()>),
+}
+
+async fn step_trampoline<'a>(
+    state: State<'a>,
+    user_agent: &'a HeaderValue,
+    node_name: &'a Option<String>,
+    middleware: &'a K8sMetadata,
+) -> State<'a> {
+    match state {
+        State::Init => State::Creating(0),
+        State::Creating(attempts) => {
+            let middleware_k8s_client = create_k8s_client_default_from_env(user_agent.clone())
+                .unwrap_or_else(|e| {
+                    let message =
+                        format!("unable to create client for k8s metadata watcher: {:?}", e);
+                    panic!("{}", message);
+                });
+            State::Kicking(attempts, middleware_k8s_client)
+        }
+        State::Kicking(attempts, client) => {
+            let (thread_handle, swap_intent) =
+                match middleware.kick_over(client, node_name.as_deref()) {
+                    Ok((stream, swap_intent)) => {
+                        trace!("k8s metadata watcher kicked over!");
+                        (
+                            tokio::spawn(async move {
+                                trace!("k8s metadata watcher thread started, processing events!");
+                                stream.for_each(|_| async {}).await;
+                                trace!("k8s metadata watcher thread exiting!");
+                            }),
+                            swap_intent,
+                        )
+                    }
+                    Err(e) => {
+                        let message = format!(
+                            "The agent could not access k8s api after several attempts: {}",
+                            e
+                        );
+                        error!("{}", message);
+                        panic!("{}", message);
+                    }
+                };
+            State::Swapping(attempts, thread_handle, swap_intent)
+        }
+        State::Swapping(attempts, thread_handle, swap_intent) => {
+            if attempts != 0 {
+                trace!("delaying k8s metadata watcher rotation so new store can populate...");
+                sleep(SWAP_DELAY).await;
+            }
+            swap_intent.swap();
+            trace!("k8s metadata watcher store swapped!");
+            State::Running(attempts, thread_handle)
+        }
+        State::Running(mut attempts, thread_handle) => {
+            let start = SystemTime::now();
+            if let Err(e) = thread_handle.await {
+                warn!(
+                    "encountered error when refreshing k8s metadata watcher: {:?}",
+                    e
+                )
+            };
+            trace!("k8s metadata watcher stream exhausted, recreating...");
+            if let Ok(elapsed) = start.elapsed() {
+                if elapsed >= RESET_DURATION {
+                    attempts = 0;
+                } else {
+                    let sleep_secs = min(
+                        INITIAL_BACKOFF_SECS
+                            .checked_pow(attempts)
+                            .unwrap_or(MAX_BACKOFF_SECS),
+                        MAX_BACKOFF_SECS,
+                    );
+                    let sleep_duration = Duration::from_secs(u64::from(sleep_secs));
+                    warn!(
+                        "delaying k8s metadata watcher rotation with backoff of {} seconds",
+                        sleep_secs
+                    );
+                    sleep(sleep_duration).await;
+                }
+            }
+
+            State::Creating(attempts + 1)
+        }
+    }
+}
+
+async fn trampoline<'a>(
+    mut state: State<'a>,
+    user_agent: &'a HeaderValue,
+    node_name: &'a Option<String>,
+    middleware: &'a K8sMetadata,
+) {
+    loop {
+        state = step_trampoline(state, user_agent, node_name, middleware).await;
+    }
+}
+
+pub fn metadata_runner(
+    user_agent: HeaderValue,
+    node_name: Option<String>,
+    executor: &mut Executor,
+) {
+    let middleware = Arc::new(K8sMetadata::default());
+    executor.register(middleware.clone());
+
+    tokio::spawn(async move {
+        trampoline(State::Init, &user_agent, &node_name, &middleware).await;
+    });
+}

--- a/common/state/src/lib.rs
+++ b/common/state/src/lib.rs
@@ -8,7 +8,7 @@ pub use offsets::{Offset, OffsetMap};
 pub use span::{Span, SpanError, SpanVec};
 
 #[cfg(feature = "state")]
-pub use state::{AgentState, StateError};
+pub use crate::state::{AgentState, StateError};
 
 use async_channel::SendError;
 use futures::channel::oneshot;


### PR DESCRIPTION
In some cases, for unknown reasons, the k8s metadata watcher stream can
become inactive after receiving an error. This causes the cache to
become stale over time and for labels and annotations to be stale or
completely missing.

This PR fixes the issue by taking direct control of error handling on
stream errors and recreates the metadata watcher to start fresh.

Ref: LOG-16194