### PR TITLE
fix: delay k8s metadata cleanup until file is deleted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
@@ -87,6 +96,18 @@ dependencies = [
  "tracing",
  "tracing-test",
  "win32job",
+]
+
+[[package]]
+name = "arc-interner"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655ae79d4a7661f2f9a8f6daf95af32897eafdea938df06aeb127cea02b5f4ac"
+dependencies = [
+ "ahash 0.3.8",
+ "dashmap 4.0.2",
+ "once_cell",
+ "serde",
 ]
 
 [[package]]
@@ -517,6 +538,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "proc-macro-hack",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,7 +587,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 dependencies = [
- "dashmap",
+ "dashmap 5.4.0",
  "once_cell",
  "rustc-hash",
 ]
@@ -624,6 +667,12 @@ checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "cstr-argument"
@@ -747,6 +796,16 @@ dependencies = [
  "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1661,6 +1720,8 @@ name = "k8s"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-interner",
+ "async-channel",
  "backoff",
  "chrono",
  "crossbeam",
@@ -1812,7 +1873,7 @@ version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b698eb8998b46683b0dc3c2ce72c80bc308fc8159f25afa719668c290a037a57"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "async-trait",
  "backoff",
  "derivative",
@@ -1955,6 +2016,7 @@ dependencies = [
  "anyhow",
  "api",
  "assert_cmd",
+ "async-channel",
  "async-trait",
  "auditable",
  "auditable-build",
@@ -2850,6 +2912,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -3822,6 +3890,15 @@ name = "time-macros"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "tinyvec"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -54,6 +54,7 @@ auditable = { version = "0.1", optional = true }
 miniz_oxide = "0.5"
 rand = "0.8.5"
 shell-words = "1.0"
+async-channel = "1.8"
 
 [target.'cfg(any(windows))'.dependencies]
 winservice = { git = "https://github.com/dkhokhlov/winservice.git" }

--- a/common/fs/Cargo.toml
+++ b/common/fs/Cargo.toml
@@ -38,7 +38,7 @@ tracing-subscriber = "0.3"
 
 #async
 async-trait = "0.1"
-async-channel = "1"
+async-channel = "1.8"
 tokio = {version= "1", features= ["fs", "io-util"]}
 tokio-util = {version= "0.7", features= ["compat"]}
 tokio-stream = "0.1"

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -274,6 +274,8 @@ pub struct FileSystem {
 
     fo_state_handles: Option<(FileOffsetWriteHandle, FileOffsetFlushHandle)>,
 
+    deletion_ack_sender: async_channel::Sender<Vec<PathBuf>>,
+
     _c: countme::Count<Self>,
 }
 
@@ -315,6 +317,7 @@ impl FileSystem {
         initial_offsets: HashMap<FileId, SpanVec>,
         rules: Rules,
         fo_state_handles: Option<(FileOffsetWriteHandle, FileOffsetFlushHandle)>,
+        deletion_ack_sender: async_channel::Sender<Vec<PathBuf>>,
     ) -> Self {
         let (resume_events_send, resume_events_recv) = async_channel::unbounded();
         let (retry_events_send, retry_events_recv) = async_channel::unbounded();
@@ -383,6 +386,7 @@ impl FileSystem {
             retry_events_send,
             ignored_dirs,
             fo_state_handles,
+            deletion_ack_sender,
             _c: countme::Count::new(),
         };
 
@@ -1153,6 +1157,7 @@ impl FileSystem {
         };
 
         let path = entry.path().to_path_buf();
+        let _ = self.deletion_ack_sender.try_send(vec![path.clone()]);
         let entries = match self.watch_descriptors.get_mut(&path) {
             Some(v) => v,
             None => {
@@ -1648,6 +1653,7 @@ mod tests {
             HashMap::new(),
             rules,
             None,
+            async_channel::unbounded().0,
         )
     }
 

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -154,7 +154,8 @@ async fn handle_event(
                         }
                     }
                     if let Entry::File { data, .. } = entry {
-                        data.borrow_mut().deref_mut().tail(paths).await
+                        let mut tailed_file = data.borrow_mut();
+                        tailed_file.deref_mut().tail(paths).await
                     } else {
                         None
                     }
@@ -259,6 +260,7 @@ impl Tailer {
         lookback_config: Lookback,
         initial_offsets: Option<HashMap<FileId, SpanVec>>,
         fo_state_handles: Option<(FileOffsetWriteHandle, FileOffsetFlushHandle)>,
+        deletion_ack_sender: async_channel::Sender<Vec<std::path::PathBuf>>,
     ) -> Self {
         Self {
             fs_cache: Arc::new(Mutex::new(FileSystem::new(
@@ -267,6 +269,7 @@ impl Tailer {
                 initial_offsets.unwrap_or_default(),
                 rules,
                 fo_state_handles,
+                deletion_ack_sender,
             ))),
             event_times: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -441,6 +444,7 @@ mod test {
                     Lookback::None,
                     None,
                     None,
+                    async_channel::unbounded().0,
                 );
 
                 let stream = process(tailer).expect("failed to read events");
@@ -489,6 +493,7 @@ mod test {
                     Lookback::SmallFiles,
                     None,
                     None,
+                    async_channel::unbounded().0,
                 );
 
                 let stream = process(tailer).expect("failed to read events");
@@ -539,6 +544,7 @@ mod test {
                     Lookback::Start,
                     None,
                     None,
+                    async_channel::unbounded().0,
                 );
 
                 let stream = process(tailer).expect("failed to read events");

--- a/common/k8s/Cargo.toml
+++ b/common/k8s/Cargo.toml
@@ -40,6 +40,8 @@ serde_with = "1.3.1"
 pin-utils = "0.1"
 pin-project-lite = "0.2"
 rand = "0.8.5"
+arc-interner = "0.7.0"
+async-channel = "1.8"
 
 [dev-dependencies]
 hyper_http = { package = "http", version = "0.2" }

--- a/common/k8s/src/middleware/runner.rs
+++ b/common/k8s/src/middleware/runner.rs
@@ -2,6 +2,7 @@ use crate::{
     create_k8s_client_default_from_env,
     middleware::{K8sMetadata, StoreSwapIntent},
 };
+use async_channel::Receiver;
 use futures::StreamExt;
 use hyper::http::header::HeaderValue;
 use middleware::Executor;
@@ -69,7 +70,9 @@ async fn step_trampoline<'a>(
                 trace!("delaying k8s metadata watcher rotation so new store can populate...");
                 sleep(K8S_WATCHER_ROTATION_DELAY).await;
             }
-            swap_intent.swap();
+            if let Err(e) = swap_intent.swap() {
+                error!("k8s metadata watcher store swap failed: {}", e);
+            };
             trace!("k8s metadata watcher store swapped!");
             State::Running(thread_handle)
         }
@@ -98,11 +101,12 @@ async fn trampoline<'a>(
 }
 
 pub fn metadata_runner(
+    deletion_ack_receiver: Receiver<Vec<std::path::PathBuf>>,
     user_agent: HeaderValue,
     node_name: Option<String>,
     executor: &mut Executor,
 ) {
-    let middleware = Arc::new(K8sMetadata::default());
+    let middleware = Arc::new(K8sMetadata::new(deletion_ack_receiver));
     executor.register(middleware.clone());
 
     tokio::spawn(async move {


### PR DESCRIPTION
In some cases, logs ingested closed to when a pod is deleted might cause
the logs to not be able to collect metadata information since the info
has been removed from our cache. This fix makes sure that metadata info
lives as long as the file exists to prevent this from happening.