### PR TITLE
fix: block_options.set_cache_index_and_filter_blocks(true)

### DIFF
--- a/common/state/src/lib.rs
+++ b/common/state/src/lib.rs
@@ -59,6 +59,7 @@ fn _construct_agent_state(path: &Path) -> Result<AgentState, StateError> {
 
     let cache = Cache::new_lru_cache(ROCKSDB_CACHE_SIZE);
     let mut block_options = BlockBasedOptions::default();
+    block_options.set_cache_index_and_filter_blocks(true);
     block_options.set_block_cache(&cache?);
 
     let mut db_opts = Options::default();


### PR DESCRIPTION
- set block_options.set_cache_index_and_filter_blocks to true
- this limits RSS memory unbound growth in cases with high number of constantly updating log files
- background: RoicksDB index and filter blocks don't participate in the block cache, so can grow to fill all of available memory, eventually causing OOM. This setting causes those blocks to also use the block cache, and we control the block cache size
- reference: https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB#indexes-and-filter-blocks
