### PR TITLE
fix: clear pending batches when processed

### DIFF
--- a/common/state/src/lib.rs
+++ b/common/state/src/lib.rs
@@ -481,6 +481,8 @@ fn handle_file_offset_flush(
                 }
             }
         };
+        // Batch has been processed, remove it from the slotmap
+        pending.remove(key);
     };
     (Some(wb), (state, pending, span_buf, bytes_buf))
 }


### PR DESCRIPTION
Looks like we aren't currently popping batches off the pending queue in the state tracking module

Ref: LOG-14646 
 