### PR TITLE
chore: add better fs error messages to fs::cache::try_from

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,7 @@ dependencies = [
  "mz-http",
  "notify_stream",
  "os_str_bytes",
+ "path_abs",
  "pcre2",
  "pin-project-lite",
  "pin-utils",
@@ -2558,6 +2559,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
+name = "path_abs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "std_prelude",
+ "stfu8",
+]
+
+[[package]]
 name = "pcre2"
 version = "0.2.3"
 source = "git+https://github.com/logdna/rust-pcre2.git?branch=0.2#8096355b43e26db1eb73010e3be404aedc10f81d"
@@ -3522,6 +3535,22 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vec-collections",
+]
+
+[[package]]
+name = "std_prelude"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
+
+[[package]]
+name = "stfu8"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1310970b29733b601839578f8ba24991a97057dbedc4ac0decea835474054ee7"
+dependencies = [
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]

--- a/common/fs/Cargo.toml
+++ b/common/fs/Cargo.toml
@@ -29,6 +29,7 @@ pin-project-lite = "0.2"
 glob = "0.3"
 walkdir = "2"
 regex = "1"
+path_abs = "0.5"
 
 #logging
 lazy_static = "1"


### PR DESCRIPTION
We have noticed some mystic error messages from the results of try_from which don't tell us where the issue is happening. This PR uses a drop in replacement of std::fs to extract better error messages that include the path and action

Ref: LOG-14646