### PR TITLE
fix: log flood on "No file descriptors available" error

### DIFF
--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -609,7 +609,7 @@ pub async fn _main(
                             Ok(s) => handle_send_status(s),
                             Err(e) => handle_client_error(e, shutdown_tx).await,
                         },
-                        Err(e) => error!("Couldn't batch lines {:?}", e),
+                        Err(e) => error!("Couldn't batch lines in lines_driver: {:?}", e),
                     }
                 })
                 .await
@@ -648,7 +648,7 @@ pub async fn _main(
                                     Err(e) => handle_client_error(e, shutdown_tx).await,
                                 }
                             }
-                            Err(e) => error!("Couldn't batch lines {:?}", e),
+                            Err(e) => error!("Couldn't batch lines in retry_stream: {:?}", e),
                         }
                     }
                 })

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -694,6 +694,18 @@ impl FileSystem {
                 Error::WatchEvent(path) => {
                     debug!("Processing event for untracked path: {}", path.display());
                 }
+                Error::File(err) => {
+                    warn!("Processing notify event resulted in error: {}", e);
+                    if err
+                        .to_string()
+                        .starts_with("Too many open files (os error 24)")
+                    {
+                        error!(
+                            "Agent process has hit the upper limit of files it's allowed to open"
+                        );
+                        std::process::exit(24);
+                    }
+                }
                 _ => {
                     warn!("Processing notify event resulted in error: {}", e);
                 }


### PR DESCRIPTION
- added handling of condition when number of tracked files exceeds maximum number of open file descriptors ulimit
- primary error: "fs::cache: Processing notify event resulted in error: error reading file: Custom { kind: Uncategorized, error: Error<Too many open files (os error 24)"
- the error is treated as fatal with exit(24).

Test:
- with default ulimit 1024 copy 1200 new log files to log dir folder.
- expected: agent to exit with the panic message "Agent process has hit the upper limit of files it's allowed to open"

ref: LOG-17311