### PR TITLE
fix: delay k8s metadata cleanup until file is deleted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
@@ -87,6 +96,18 @@ dependencies = [
  "tracing",
  "tracing-test",
  "win32job",
+]
+
+[[package]]
+name = "arc-interner"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655ae79d4a7661f2f9a8f6daf95af32897eafdea938df06aeb127cea02b5f4ac"
+dependencies = [
+ "ahash 0.3.8",
+ "dashmap 4.0.2",
+ "once_cell",
+ "serde",
 ]
 
 [[package]]
@@ -517,6 +538,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "proc-macro-hack",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,7 +587,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 dependencies = [
- "dashmap",
+ "dashmap 5.4.0",
  "once_cell",
  "rustc-hash",
 ]
@@ -624,6 +667,12 @@ checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "cstr-argument"
@@ -747,6 +796,16 @@ dependencies = [
  "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1661,6 +1720,8 @@ name = "k8s"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-interner",
+ "async-channel",
  "backoff",
  "chrono",
  "crossbeam",
@@ -1812,7 +1873,7 @@ version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b698eb8998b46683b0dc3c2ce72c80bc308fc8159f25afa719668c290a037a57"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "async-trait",
  "backoff",
  "derivative",
@@ -1955,6 +2016,7 @@ dependencies = [
  "anyhow",
  "api",
  "assert_cmd",
+ "async-channel",
  "async-trait",
  "auditable",
  "auditable-build",
@@ -2850,6 +2912,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -3822,6 +3890,15 @@ name = "time-macros"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "tinyvec"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -54,6 +54,7 @@ auditable = { version = "0.1", optional = true }
 miniz_oxide = "0.5"
 rand = "0.8.5"
 shell-words = "1.0"
+async-channel = "1.8"
 
 [target.'cfg(any(windows))'.dependencies]
 winservice = { git = "https://github.com/dkhokhlov/winservice.git" }

--- a/common/fs/Cargo.toml
+++ b/common/fs/Cargo.toml
@@ -38,7 +38,7 @@ tracing-subscriber = "0.3"
 
 #async
 async-trait = "0.1"
-async-channel = "1"
+async-channel = "1.8"
 tokio = {version= "1", features= ["fs", "io-util"]}
 tokio-util = {version= "0.7", features= ["compat"]}
 tokio-stream = "0.1"

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -274,6 +274,8 @@ pub struct FileSystem {
 
     fo_state_handles: Option<(FileOffsetWriteHandle, FileOffsetFlushHandle)>,
 
+    deletion_ack_sender: async_channel::Sender<Vec<PathBuf>>,
+
     _c: countme::Count<Self>,
 }
 
@@ -315,6 +317,7 @@ impl FileSystem {
         initial_offsets: HashMap<FileId, SpanVec>,
         rules: Rules,
         fo_state_handles: Option<(FileOffsetWriteHandle, FileOffsetFlushHandle)>,
+        deletion_ack_sender: async_channel::Sender<Vec<PathBuf>>,
     ) -> Self {
         let (resume_events_send, resume_events_recv) = async_channel::unbounded();
         let (retry_events_send, retry_events_recv) = async_channel::unbounded();
@@ -383,6 +386,7 @@ impl FileSystem {
             retry_events_send,
             ignored_dirs,
             fo_state_handles,
+            deletion_ack_sender,
             _c: countme::Count::new(),
         };
 
@@ -1201,7 +1205,11 @@ impl FileSystem {
                 self.symlinks.remove(link);
             }
         }
+
         info!("unwatching {:?}", path);
+        if let Err(e) = self.deletion_ack_sender.try_send(vec![path.clone()]) {
+            warn!("unable to notify about deleted path \"{:?}\": {}", &path, e);
+        }
     }
 
     // FIXME: We should not remove dangling symlinks nor the parent dir of the missing target
@@ -1660,6 +1668,7 @@ mod tests {
             HashMap::new(),
             rules,
             None,
+            async_channel::unbounded().0,
         )
     }
 

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -154,7 +154,8 @@ async fn handle_event(
                         }
                     }
                     if let Entry::File { data, .. } = entry {
-                        data.borrow_mut().deref_mut().tail(paths).await
+                        let mut tailed_file = data.borrow_mut();
+                        tailed_file.deref_mut().tail(paths).await
                     } else {
                         None
                     }
@@ -259,6 +260,7 @@ impl Tailer {
         lookback_config: Lookback,
         initial_offsets: Option<HashMap<FileId, SpanVec>>,
         fo_state_handles: Option<(FileOffsetWriteHandle, FileOffsetFlushHandle)>,
+        deletion_ack_sender: async_channel::Sender<Vec<std::path::PathBuf>>,
     ) -> Self {
         Self {
             fs_cache: Arc::new(Mutex::new(FileSystem::new(
@@ -267,6 +269,7 @@ impl Tailer {
                 initial_offsets.unwrap_or_default(),
                 rules,
                 fo_state_handles,
+                deletion_ack_sender,
             ))),
             event_times: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -441,6 +444,7 @@ mod test {
                     Lookback::None,
                     None,
                     None,
+                    async_channel::unbounded().0,
                 );
 
                 let stream = process(tailer).expect("failed to read events");
@@ -489,6 +493,7 @@ mod test {
                     Lookback::SmallFiles,
                     None,
                     None,
+                    async_channel::unbounded().0,
                 );
 
                 let stream = process(tailer).expect("failed to read events");
@@ -539,6 +544,7 @@ mod test {
                     Lookback::Start,
                     None,
                     None,
+                    async_channel::unbounded().0,
                 );
 
                 let stream = process(tailer).expect("failed to read events");

--- a/common/k8s/Cargo.toml
+++ b/common/k8s/Cargo.toml
@@ -40,6 +40,8 @@ serde_with = "1.3.1"
 pin-utils = "0.1"
 pin-project-lite = "0.2"
 rand = "0.8.5"
+arc-interner = "0.7.0"
+async-channel = "1.8"
 
 [dev-dependencies]
 hyper_http = { package = "http", version = "0.2" }

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -1,7 +1,19 @@
 use crate::errors::K8sError;
-use crate::middleware::parse_container_path;
-use futures::StreamExt;
-use futures::TryStreamExt;
+use crate::middleware::{parse_container_path, ParseResult};
+
+use std::{
+    collections::HashMap,
+    fmt,
+    ops::DerefMut,
+    sync::{Arc, Mutex},
+};
+
+use arc_interner::ArcIntern;
+use async_channel::Receiver;
+use futures::{
+    stream::{self, select},
+    StreamExt, TryStreamExt,
+};
 use http::types::body::{KeyValueMap, LineBufferMut};
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
@@ -15,7 +27,6 @@ use kube::{
     Api, Client, ResourceExt,
 };
 use serde_json::json;
-use std::{fmt, sync::Mutex};
 
 use backoff::ExponentialBackoff;
 use metrics::Metrics;
@@ -32,6 +43,8 @@ pub enum Error {
     Utf(#[from] std::string::FromUtf8Error),
     #[error(transparent)]
     K8s(#[from] kube::Error),
+    #[error("Failed to lock state")]
+    K8sMiddlewareState,
 }
 
 #[derive(Debug)]
@@ -71,17 +84,131 @@ impl<'a> StoreSwapIntent<'a> {
         StoreSwapIntent { parent, store }
     }
 
-    pub fn swap(self) {
-        *self.parent.store.lock().unwrap() = Some(self.store);
+    pub fn swap(self) -> Result<(), Error> {
+        self.parent
+            .state
+            .lock()
+            .as_mut()
+            .map(|state| {
+                state.store = Some(self.store);
+            })
+            .map_err(|_| Error::K8sMiddlewareState)
+    }
+}
+
+#[derive(Eq, Hash, PartialEq, Clone, Debug)]
+pub struct ContainerIdent {
+    name: ArcIntern<String>,
+}
+
+#[derive(Eq, Hash, PartialEq, Clone, Debug)]
+pub struct PodIdent {
+    name: ArcIntern<String>,
+}
+
+#[derive(Eq, Hash, PartialEq, Clone, Debug)]
+struct PodContainers {
+    pod_ident: PodIdent,
+    containers: Vec<ContainerIdent>,
+}
+
+impl From<&ParseResult> for ContainerIdent {
+    fn from(parse_result: &ParseResult) -> Self {
+        ContainerIdent {
+            name: ArcIntern::new(parse_result.container_name.clone()),
+        }
+    }
+}
+
+impl From<&ParseResult> for PodIdent {
+    fn from(parse_result: &ParseResult) -> Self {
+        let mut pod_namespace = parse_result.pod_namespace.clone();
+        let pod_name = parse_result.pod_name.clone();
+        pod_namespace.push('-');
+        pod_namespace.push_str(&pod_name);
+        PodIdent {
+            name: ArcIntern::new(pod_namespace),
+        }
+    }
+}
+
+impl From<(&str, &str)> for PodIdent {
+    fn from((pod_namespace, pod_name): (&str, &str)) -> Self {
+        let mut buf = pod_namespace.to_string();
+        buf.push('-');
+        buf.push_str(pod_name);
+        PodIdent {
+            name: ArcIntern::new(buf),
+        }
+    }
+}
+
+impl From<&Pod> for PodContainers {
+    fn from(pod: &Pod) -> Self {
+        let pod_ident: PodIdent = pod
+            .metadata
+            .namespace
+            .as_deref()
+            .zip(pod.metadata.name.as_deref())
+            .map(|pair| pair.into())
+            .unwrap();
+        Self {
+            pod_ident,
+            containers: pod
+                .spec
+                .as_ref()
+                .map(|spec| {
+                    spec.containers
+                        .iter()
+                        .map(|container| ContainerIdent {
+                            name: ArcIntern::new(container.name.clone()),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+        }
     }
 }
 
 #[derive(Default)]
+struct DeletionState {
+    pending_deletions: HashMap<PodIdent, WatcherEvent<Pod>>,
+    pod_lookup: HashMap<PodIdent, PodContainers>,
+}
+
+#[derive(Default)]
+struct K8sMetadataState {
+    store: Option<reflector::Store<Pod>>,
+    deletion_state: Arc<tokio::sync::Mutex<DeletionState>>,
+}
+
 pub struct K8sMetadata {
-    store: Mutex<Option<reflector::Store<Pod>>>,
+    state: Mutex<K8sMetadataState>,
+    deletion_ack_recv: Arc<Receiver<Vec<std::path::PathBuf>>>,
 }
 
 impl K8sMetadata {
+    pub fn new(deletion_ack_recv: Receiver<Vec<std::path::PathBuf>>) -> Self {
+        Self {
+            state: Mutex::new(K8sMetadataState::default()),
+            deletion_ack_recv: Arc::new(deletion_ack_recv),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_store(
+        deletion_ack_recv: Receiver<Vec<std::path::PathBuf>>,
+        store: reflector::Store<Pod>,
+    ) -> Self {
+        Self {
+            state: Mutex::new(K8sMetadataState {
+                store: Some(store),
+                ..Default::default()
+            }),
+            deletion_ack_recv: Arc::new(deletion_ack_recv),
+        }
+    }
+
     pub fn kick_over(
         &self,
         client: Client,
@@ -104,11 +231,134 @@ impl K8sMetadata {
             ListParams::default()
         };
 
-        let watched = StreamBackoff::new(watcher(api, params), ExponentialBackoff::default());
+        let watcher = Box::pin(StreamBackoff::new(
+            watcher(api, params),
+            ExponentialBackoff::default(),
+        ));
+
+        let (deletion_ack_recv, deletion_state) = {
+            let state = self.state.lock().map_err(|_| Error::K8sMiddlewareState)?;
+            // Take the deletion ack stream, copy the deletion state stream
+            (self.deletion_ack_recv.clone(), state.deletion_state.clone())
+        };
+
+        let delete_stream = stream::unfold(
+            (deletion_state.clone(), deletion_ack_recv),
+            move |(deletion_state, deletion_ack_recv)| async move {
+                let next_event = loop {
+                    if let Ok(Some((deleted_container, deleted_container_pod))) = deletion_ack_recv
+                        .recv()
+                        .await
+                        .map_err(|e| {
+                            warn!("unable to receive delete events: {}", e);
+                            e
+                        })
+                        .map(|deleted_container_paths| {
+                            deleted_container_paths
+                                .into_iter()
+                                .filter_map(|path| {
+                                    path.into_os_string()
+                                        .into_string()
+                                        .ok()
+                                        .as_deref()
+                                        .and_then(parse_container_path)
+                                })
+                                .next()
+                                .map(|parse_result| {
+                                    (
+                                        <&ParseResult as Into<ContainerIdent>>::into(&parse_result),
+                                        <&ParseResult as Into<PodIdent>>::into(&parse_result),
+                                    )
+                                })
+                        })
+                    {
+                        let mut lock_guard = deletion_state.lock().await;
+                        let DeletionState {
+                            ref mut pod_lookup,
+                            ref mut pending_deletions,
+                        } = lock_guard.deref_mut();
+                        if let std::collections::hash_map::Entry::Occupied(pod_containers_entry) =
+                            pod_lookup
+                                .entry(deleted_container_pod.clone())
+                                .and_modify(|pod| {
+                                    pod.containers.retain(|container| {
+                                        container.name != deleted_container.name
+                                    });
+                                })
+                        {
+                            let pod_containers = pod_containers_entry.get();
+                            break match Ok(pod_containers
+                                .containers
+                                .is_empty()
+                                .then(|| pending_deletions.remove(&deleted_container_pod))
+                                .flatten())
+                            .transpose()
+                            {
+                                Some(event) => {
+                                    pod_containers_entry.remove();
+                                    Some(event)
+                                }
+                                _ => continue,
+                            };
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    }
+                };
+                next_event
+                    .map(move |next_event| (Some(next_event), (deletion_state, deletion_ack_recv)))
+            },
+        );
+
+        let watch_stream = stream::unfold(
+            (watcher, deletion_state),
+            move |(mut watcher, deletion_state)| async move {
+                // Check if we have a delete acknowledgement
+                let next_event = loop {
+                    let next_event = {
+                        // No deletes to process, just read from the watcher
+                        let next_event = watcher.next().await;
+                        if let Some(Ok(event)) = next_event {
+                            let pod_container: Option<PodContainers> =
+                                if let WatcherEvent::Deleted(ref pod) = event {
+                                    Some(pod.into())
+                                } else {
+                                    None
+                                };
+
+                            if let Some(pod_container) = pod_container {
+                                let mut lock_guard = deletion_state.lock().await;
+                                let DeletionState {
+                                    ref mut pod_lookup,
+                                    ref mut pending_deletions,
+                                } = lock_guard.deref_mut();
+
+                                pod_lookup
+                                    .insert(pod_container.pod_ident.clone(), pod_container.clone());
+                                pending_deletions.insert(pod_container.pod_ident, event);
+                                continue;
+                            } else {
+                                Some(Ok(event))
+                            }
+                        } else {
+                            next_event
+                        }
+                    };
+
+                    break next_event;
+                };
+                next_event.map(move |next_event| (Some(next_event), (watcher, deletion_state)))
+            },
+        );
+
+        let stream = select(delete_stream, watch_stream).filter_map(std::future::ready);
+
         let swap_intent = StoreSwapIntent::new(self, store.clone());
 
         Ok((
-            reflector(store_writer, watched)
+            reflector(store_writer, stream)
                 .map_ok(|event| {
                     event.modify(|pod| {
                         pod.managed_fields_mut().clear();
@@ -166,7 +416,7 @@ impl Middleware for K8sMetadata {
             if let Some(parse_result) = parse_container_path(file_name) {
                 let obj_ref =
                     ObjectRef::new(&parse_result.pod_name).within(&parse_result.pod_namespace);
-                if let Some(ref store) = *self.store.lock().unwrap() {
+                if let Some(ref store) = self.state.lock().unwrap().store {
                     if let Some(pod) = store.get(&obj_ref) {
                         let meta_object =
                             extract_image_name_and_tag(parse_result.container_name, pod.as_ref());
@@ -426,9 +676,7 @@ mod tests {
             };
             store_w.apply_watcher_event(&WatcherEvent::Applied(pod));
         }
-        K8sMetadata {
-            store: Mutex::new(Some(store_w.as_reader())),
-        }
+        K8sMetadata::with_store(async_channel::unbounded().1, store_w.as_reader())
     }
 
     fn get_pod_metadata(name: impl Into<String>, namespace: impl Into<String>) -> PodMetadata {


### PR DESCRIPTION
In some cases, logs ingested closed to when a pod is deleted might cause the logs to not be able to collect metadata information since the info has been removed from our cache. This fix makes sure that metadata info lives as long as the file exists to prevent this from happening.