### PR TITLE
fix: log flooded with error: Couldn't batch lines Io(Os { code: 3, knd: NotFound

### DIFF
--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -648,6 +648,11 @@ pub async fn _main(
                                     Err(e) => handle_client_error(e, shutdown_tx).await,
                                 }
                             }
+                            Err(http::retry::Error::Io(e))
+                                if e.kind() == std::io::ErrorKind::NotFound =>
+                            {
+                                debug!("Couldn't batch lines in retry_stream: ignoring - {:?}", e)
+                            }
                             Err(e) => error!("Couldn't batch lines in retry_stream: {:?}", e),
                         }
                     }


### PR DESCRIPTION
- downgraded NotFound to debug
- ignoring by design

Ref: LOG-14615