### PR TITLE
fix: log flood on "No file descriptors available" error #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,8 +507,10 @@ publish-s3-binary:
 	elif [ "$(MACOS)" != "" ]; then \
 		aws s3 cp --acl public-read arm/arm-target/release/logdna-agent s3://logdna-agent-build-bin/${TARGET_TAG}/arm64/logdna-agent; \
         aws s3 cp --acl public-read x86/x86-target/x86_64-apple-darwin/release/logdna-agent s3://logdna-agent-build-bin/${TARGET_TAG}/x86_64-apple-darwin/logdna-agent; \
+        aws s3 cp --acl public-read x86/x86-target/x86_64-apple-darwin/release/logdna-agent s3://logdna-agent-build-bin/${TARGET_TAG}/x86_64-apple-darwin/build$(BUILD_NUMBER)/logdna-agent; \
 	else \
 	    aws s3 cp --acl public-read ${TARGET_DIR}/$(TARGET)/release/logdna-agent s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/logdna-agent; \
+	    aws s3 cp --acl public-read ${TARGET_DIR}/$(TARGET)/release/logdna-agent s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/build$(BUILD_NUMBER)/logdna-agent; \
 	fi;
 
 define PUBLISH_SIGNED_RULE

--- a/Makefile
+++ b/Makefile
@@ -507,10 +507,10 @@ publish-s3-binary:
 	elif [ "$(MACOS)" != "" ]; then \
 		aws s3 cp --acl public-read arm/arm-target/release/logdna-agent s3://logdna-agent-build-bin/${TARGET_TAG}/arm64/logdna-agent; \
         aws s3 cp --acl public-read x86/x86-target/x86_64-apple-darwin/release/logdna-agent s3://logdna-agent-build-bin/${TARGET_TAG}/x86_64-apple-darwin/logdna-agent; \
-        aws s3 cp --acl public-read x86/x86-target/x86_64-apple-darwin/release/logdna-agent s3://logdna-agent-build-bin/${TARGET_TAG}/x86_64-apple-darwin/build$(BUILD_NUMBER)/logdna-agent; \
+        aws s3 cp --acl public-read x86/x86-target/x86_64-apple-darwin/release/logdna-agent s3://logdna-agent-build-bin/${TARGET_TAG}/x86_64-apple-darwin.build$(BUILD_NUMBER)/logdna-agent; \
 	else \
 	    aws s3 cp --acl public-read ${TARGET_DIR}/$(TARGET)/release/logdna-agent s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/logdna-agent; \
-	    aws s3 cp --acl public-read ${TARGET_DIR}/$(TARGET)/release/logdna-agent s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET)/build$(BUILD_NUMBER)/logdna-agent; \
+	    aws s3 cp --acl public-read ${TARGET_DIR}/$(TARGET)/release/logdna-agent s3://logdna-agent-build-bin/$(TARGET_TAG)/$(TARGET).build$(BUILD_NUMBER)/logdna-agent; \
 	fi;
 
 define PUBLISH_SIGNED_RULE

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -700,10 +700,7 @@ impl FileSystem {
                 }
                 Error::File(err) => {
                     warn!("Processing notify event resulted in error: {}", e);
-                    if err
-                        .to_string()
-                        .starts_with("Too many open files (os error 24)")
-                    {
+                    if err.to_string().contains("(os error 24)") {
                         error!(
                             "Agent process has hit the upper limit of files it's allowed to open"
                         );

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -1028,10 +1028,26 @@ impl FileSystem {
 
                 for dir_entry in contents.flatten() {
                     if let Err(e) = self.insert(&dir_entry.path(), events, _entries) {
-                        info!(
-                            "error found when inserting child entry for {:?}: {}",
-                            path, e
+                        match e {
+                            Error::File(err) => {
+                                warn!(
+                                    "error found when inserting child entry for {:?}: {}",
+                                    path, err
+                                );
+                                if err.to_string().contains("(os error 24)") {
+                                    error!(
+                            "Agent process has hit the upper limit of files it's allowed to open"
                         );
+                                    std::process::exit(24);
+                                }
+                            }
+                            _ => {
+                                info!(
+                                    "error found when inserting child entry for {:?}: {}",
+                                    path, e
+                                );
+                            }
+                        }
                     }
                 }
                 new_key


### PR DESCRIPTION
- followup change - fixed difference between MUSL & GNU libc error message
- added folder with build number to store backlog of binaries in S3

Ref: LOG-17311
