### PR TITLE
fix: log flood on "No file descriptors available" error #3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,9 +1906,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -2055,6 +2055,7 @@ dependencies = [
  "rand",
  "rcgen",
  "regex",
+ "rlimit",
  "rustls",
  "rustls-pemfile 0.2.1",
  "serde",
@@ -3173,6 +3174,15 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b5b8be0bc0ef630d24f8fa836b3a3463479b2343b29f9a8fa905c71a8c7b69b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -56,6 +56,8 @@ rand = "0.8.5"
 shell-words = "1.0"
 async-channel = "1.8"
 
+rlimit = "0.10"
+
 [target.'cfg(any(windows))'.dependencies]
 winservice = { git = "https://github.com/dkhokhlov/winservice.git" }
 flexi_logger = { version = "0.22", features = ["async"] }

--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -640,7 +640,18 @@ pub async fn _main(
                             {
                                 debug!("Couldn't batch lines in retry_stream: ignoring - {:?}", e)
                             }
-                            Err(e) => error!("Couldn't batch lines in retry_stream: {:?}", e),
+                            Err(e) => {
+                                error!("Couldn't batch lines in retry_stream: {:?}", e);
+                                if e.to_string().contains("Too many open files")
+                                    || e.to_string().contains("No file descriptors available")
+                                {
+                                    error!(
+                            "Agent process has hit the limit of maximum number of open files. \
+                            Try to increase the open file limit."
+                                    );
+                                    std::process::exit(24);
+                                }
+                            }
                         }
                     }
                 })

--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -647,7 +647,7 @@ pub async fn _main(
                                 {
                                     error!(
                             "Agent process has hit the limit of maximum number of open files. \
-                            Try to increase the open file limit."
+                            Try to increase the Open Files system limit."
                                     );
                                     std::process::exit(24);
                                 }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -66,6 +66,14 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        info!(
+            "Open Files limits: {:?}",
+            rlimit::getrlimit(rlimit::Resource::NOFILE).unwrap()
+        );
+    }
+
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
     let shutdown_tx = Arc::new(Mutex::new(Some(shutdown_tx)));
 

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> anyhow::Result<()> {
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
         info!(
-            "Open Files limits: {:?}",
+            "Open Files limits in the system: {:?}",
             rlimit::getrlimit(rlimit::Resource::NOFILE).unwrap()
         );
     }

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -703,7 +703,7 @@ impl FileSystem {
                     if err.to_string().contains("(os error 24)") {
                         error!(
                             "Agent process has hit the limit of maximum number of open files. \
-                            Try to increase the open file limit."
+                            Try to increase the Open Files system limit."
                         );
                         std::process::exit(24);
                     }

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -702,7 +702,8 @@ impl FileSystem {
                     warn!("Processing notify event resulted in error: {}", e);
                     if err.to_string().contains("(os error 24)") {
                         error!(
-                            "Agent process has hit the upper limit of files it's allowed to open"
+                            "Agent process has hit the limit of maximum number of open files. \
+                            Try to increase the open file limit."
                         );
                         std::process::exit(24);
                     }

--- a/utils/mock_ingester.py
+++ b/utils/mock_ingester.py
@@ -1,11 +1,16 @@
 from flask import Flask, request
-
+# 
+# To tell agent to use this mock ingester:
+#
+#  export LOGDNA_HOST=localhost:8080
+#  export LOGDNA_USE_SSL=false
+#
 app = Flask(__name__)
 
-@app.route('/logs/agent', methods=['POST'])
+@app.route('/logs/agent', methods=['GET', 'POST'])
 def index():
     print(request.__dict__)
     return ''
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=80)
+    app.run(host='0.0.0.0', port=8080)


### PR DESCRIPTION
- followup change - fixed error case in retry stream
- print "open files" system limits at startup (except windows)


Ref: LOG-17311