### PR TITLE
chore: remove rust-toolchain.toml now that clippy is fixed

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,0 @@
-[toolchain]
-channel = "1.69"
-components = [ "rustfmt", "cargo", "clippy", "rustc", "llvm-tools-preview" ]
-targets = ["x86_64-apple-darwin", "x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
-profile = "default"


### PR DESCRIPTION
This removes the rust-toolchain.toml as the bug in clippy that it was working around has been fixed.

I'd prefer to leave it and change channel to "stable", but having the additional targets (which are required for it to work at all) also means a lot of unnecessary installations happen inside docker build steps even though the targets aren't necessary for that step