### PR TITLE
feat: optionally delay processing of k8s log lines

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 target
+bin/target
 bench/target
 .cargo_cache/*
 .git/*
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,7 +2231,10 @@ dependencies = [
 name = "middleware"
 version = "0.1.0"
 dependencies = [
+ "async-channel",
  "config",
+ "fs",
+ "futures",
  "lazy_static",
  "memoffset 0.6.5",
  "multimap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,6 +1727,7 @@ dependencies = [
  "async-channel",
  "backoff",
  "chrono",
+ "config",
  "crossbeam",
  "futures",
  "http",
@@ -2233,10 +2234,7 @@ dependencies = [
 name = "middleware"
 version = "0.1.0"
 dependencies = [
- "async-channel",
  "config",
- "fs",
- "futures",
  "lazy_static",
  "memoffset 0.6.5",
  "multimap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,6 +2057,7 @@ dependencies = [
  "prometheus-parse",
  "proptest",
  "rand",
+ "rate-limit-macro",
  "rcgen",
  "regex",
  "rlimit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
+ "middleware",
  "mz-http",
  "partial-io",
  "serial_test",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 http = { package = "mz-http", path = "../common/http" }
+middleware = { package = "middleware", path = "../common/middleware" }
 
 tokio = { package = "tokio", version = "1", features = ["macros", "process", "rt-multi-thread", "time"] }
 futures = "0.3"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -35,6 +35,7 @@ metrics = { package = "metrics", path = "../common/metrics" }
 journald = { package = "journald", path = "../common/journald" }
 state = { package = "state", path = "../common/state" }
 api = { package = "api", path = "../api" }
+rate-limit-macro = { package = "rate-limit-macro", path = "../common/misc/rate-limit/macro" }
 
 bytes = "1"
 time = "0.3"
@@ -55,6 +56,7 @@ miniz_oxide = "0.5"
 rand = "0.8.5"
 shell-words = "1.0"
 async-channel = "1.8"
+once_cell = "1.10"
 
 rlimit = "0.10"
 
@@ -114,7 +116,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 prometheus-parse = { git = "https://github.com/ccakes/prometheus-parse-rs", rev = "a4574e9" }
 float-cmp = "0.9.0"
-once_cell = "1.10"
 serial_test = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
 test-log = { version = "0.2", features = ["trace"] }

--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -755,10 +755,14 @@ pub async fn _main(
     fn handle_send_status(s: SendStatus) {
         match s {
             SendStatus::Retry(e) => {
-                warn!("failed sending http request, retrying: {}", e);
+                rate_limit!(rate = 1, interval = 1 * 60, {
+                    warn!("failed sending http request, retrying: {}", e);
+                });
             }
             SendStatus::RetryTimeout => {
-                warn!("failed sending http request, retrying: request timed out!");
+                rate_limit!(rate = 1, interval = 1 * 60, {
+                    warn!("failed sending http request, retrying: request timed out!");
+                });
             }
             _ => {}
         }

--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -613,10 +613,11 @@ pub async fn _main(
                             metadata_retry_delay, line
                         );
                         delayed_lines_send.send_blocking(line).unwrap();
+                        None
                     } else {
-                        debug!("Not retrying, dropping line: {:?}", line);
+                        trace!("Retrying disabled, processing line as-is: {:?}", line);
+                        Some(StrictOrLazyLines::Lazy(line))
                     }
-                    None
                 }
             }
         }
@@ -627,7 +628,7 @@ pub async fn _main(
                 None
             }
             Err(MiddlewareError::Retry) => {
-                debug!("Not retrying, dropping line: {:?}", line);
+                debug!("No more retries, processing line as-is: {:?}", line);
                 None
             }
         },

--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -273,6 +273,7 @@ pub async fn _main(
         e
     })?);
 
+    info!("initializing middleware executor");
     executor.init();
 
     // Use an internal env var to support running integration test w/o additional delays

--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -573,7 +573,7 @@ pub async fn _main(
     };
 
     let lines_stream = sources.map(|line| match line {
-        // Strict (concrete) lines
+        // Strict lines (concrete)
         StrictOrLazyLineBuilder::Strict(mut line) => match executor.process(&mut line) {
             Ok(_) => match line.build() {
                 Ok(line) => Some(StrictOrLazyLines::Strict(line)),
@@ -596,7 +596,7 @@ pub async fn _main(
                 None
             }
         },
-        // Lazy (tailed files, not fetched yet) lines
+        // Lazy lines (from tailed files, not fetched yet)
         StrictOrLazyLineBuilder::Lazy(mut line) => {
             match executor.validate(&line) {
                 Ok(_) => match executor.process(&mut line) {
@@ -650,7 +650,7 @@ pub async fn _main(
                 }
             }
         }
-        // Lazy, already delayed/retried (tailed files, not fetched yet) lines
+        // Lazy already delayed/retried lines (from tailed files, not fetched yet)
         StrictOrLazyLineBuilder::LazyDelayed(mut line) => {
             match executor.validate(&line) {
                 Ok(_) => match executor.process(&mut line) {

--- a/bin/src/stream_adapter.rs
+++ b/bin/src/stream_adapter.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 pub enum StrictOrLazyLineBuilder {
     Strict(LineBuilder),
     Lazy(LazyLineSerializer),
+    LazyDelayed(LazyLineSerializer),
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/bin/src/stream_adapter.rs
+++ b/bin/src/stream_adapter.rs
@@ -9,7 +9,7 @@ use http::types::serialize::{
 use state::GetOffset;
 use std::collections::HashMap;
 
-pub(crate) enum StrictOrLazyLineBuilder {
+pub enum StrictOrLazyLineBuilder {
     Strict(LineBuilder),
     Lazy(LazyLineSerializer),
 }

--- a/bin/tests/it/common.rs
+++ b/bin/tests/it/common.rs
@@ -94,6 +94,7 @@ pub struct AgentSettings<'a> {
     pub ingest_buffer_size: Option<&'a str>,
     pub log_level: Option<&'a str>,
     pub clear_cache_interval: Option<u32>,
+    pub metadata_retry_delay: Option<u32>,
 }
 
 impl<'a> AgentSettings<'a> {
@@ -261,6 +262,10 @@ pub fn spawn_agent(settings: AgentSettings) -> Child {
             "LOGDNA_CLEAR_CACHE_INTERVAL",
             format!("{}", clear_cache_interval),
         );
+    }
+
+    if let Some(metadata_retry_delay) = settings.metadata_retry_delay {
+        agent.env("METADATA_RETRY_DELAY", format!("{}", metadata_retry_delay));
     }
 
     agent.spawn().expect("Failed to start agent")

--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -1978,7 +1978,7 @@ async fn test_retry_line_with_missing_pod_metadata() {
     delete_pod(client.clone(), pod_name, default_namespace).await;
     delete_service(client.clone(), pod_name, default_namespace).await;
 
-    let pod_node_addr =
+    let _pod_node_addr =
         start_line_proxy_pod(client.clone(), pod_name, default_namespace, 30004).await;
 
     assert!(

--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -1995,7 +1995,7 @@ async fn test_feature_leader_grabbing_lease() {
 }
 
 #[test(tokio::test)]
-#[cfg_attr(not(feature = "k8s_tests"), ignore)]
+#[ignore]
 async fn test_retry_line_with_missing_pod_metadata() {
     let (server, _, shutdown_handle, ingester_addr) = common::start_http_ingester();
 

--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -874,7 +874,7 @@ fn get_agent_ds_yaml(
                             "name": "logdna-agent",
                             "resources": {
                                 "limits": {
-                                    "memory": "500Mi"
+                                    "memory": "5000Mi"
                                 },
                                 "requests": {
                                     "cpu": "20m"
@@ -2027,7 +2027,7 @@ async fn test_retry_line_with_missing_pod_metadata() {
             "logdna_agent::_main=debug,info",
             "never",
             "never",
-            false,
+            true,
             5,
         )
         .await;
@@ -2043,24 +2043,24 @@ async fn test_retry_line_with_missing_pod_metadata() {
         );
         info!("daemonset {} in {} is ready", agent_name, agent_namespace);
 
-        let messages = [
-            "Hello, World! 0\n",
-            "Hello, World! 1\n",
-            "Hello, World! 2\n",
-            "Hello, World! 3\n",
-            "Hello, World! 4\n",
-        ];
+        // let messages = [
+        //     "Hello, World! 0\n",
+        //     "Hello, World! 1\n",
+        //     "Hello, World! 2\n",
+        //     "Hello, World! 3\n",
+        //     "Hello, World! 4\n",
+        // ];
+        //
+        // let mut logger_stream = TcpStream::connect(pod_node_addr).await.unwrap();
+        //
+        // for msg in messages.iter() {
+        //     // Write log lines
+        //     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        //     logger_stream.write_all(msg.as_bytes()).await.unwrap();
+        // }
 
-        let mut logger_stream = TcpStream::connect(pod_node_addr).await.unwrap();
-
-        for msg in messages.iter() {
-            // Write log lines
-            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-            logger_stream.write_all(msg.as_bytes()).await.unwrap();
-        }
-
-        info!("Wait for the data to be received by the mock ingester");
-        tokio::time::sleep(tokio::time::Duration::from_millis(10_000)).await;
+        // info!("Wait for the data to be received by the mock ingester");
+        // tokio::time::sleep(tokio::time::Duration::from_millis(10_000)).await;
 
         info!("assert_log_lines");
 

--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -92,7 +92,7 @@ async fn assert_log_lines(
                         substrings_not_found.pop();
                     }
                     if print_log_lines {
-                        info!("LOG: {:?}", &line_str);
+                        info!("LOG: {:?}", line_str);
                     }
                 }
                 assert!(
@@ -525,6 +525,7 @@ async fn create_agent_ds(
         ingester_addr,
         "false",
         agent_name,
+        agent_namespace,
         log_k8s_events,
         enrich_logs_with_k8s,
         agent_log_level,
@@ -583,6 +584,7 @@ fn get_agent_ds_yaml(
     ingester_addr: &str,
     use_ssl: &str,
     agent_name: &str,
+    agent_namespace: &str,
     log_k8s_events: &str,
     enrich_logs_with_k8s: &str,
     log_level: &str,
@@ -659,7 +661,7 @@ fn get_agent_ds_yaml(
                                 },
                                 {
                                     "name": "LOGDNA_K8S_METADATA_LINE_INCLUSION",
-                                    "value": "namespace:default"
+                                    "value": format!("namespace:{}", agent_namespace)
                                 },
                                 {
                                     "name": "LOGDNA_K8S_METADATA_LINE_EXCLUSION",
@@ -1838,7 +1840,7 @@ async fn test_retry_line_with_missing_pod_metadata() {
             "debug",
             "never",
             "never",
-            false,
+            true,
         )
         .await;
 
@@ -1863,12 +1865,12 @@ async fn test_retry_line_with_missing_pod_metadata() {
         // Wait for the data to be received by the mock ingester
         tokio::time::sleep(tokio::time::Duration::from_millis(10_000)).await;
 
-        // print_pod_logs(
-        //     client.clone(),
-        //     agent_namespace,
-        //     &format!("app={}", &agent_name),
-        // )
-        // .await;
+        print_pod_logs(
+            client.clone(),
+            test_namespace,
+            &format!("app={}", &agent_pod_name),
+        )
+        .await;
 
         assert_log_lines(
             client.clone(),

--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -2052,7 +2052,7 @@ async fn test_retry_line_with_missing_pod_metadata() {
                 client.clone(),
                 agent_name,
                 agent_namespace,
-                tokio::time::Duration::from_millis(10_000),
+                tokio::time::Duration::from_millis(20_000),
             )
             .await
         );
@@ -2075,15 +2075,17 @@ async fn test_retry_line_with_missing_pod_metadata() {
         // }
 
         // info!("Wait for the data to be received by the mock ingester");
-        // tokio::time::sleep(tokio::time::Duration::from_millis(10_000)).await;
 
-        info!("assert_log_lines");
+        tokio::time::sleep(tokio::time::Duration::from_millis(10_000)).await;
+
+        let log_lines = vec!["Enabling filesystem"];
+        info!("asserting log lines: {:?}", log_lines);
 
         assert_log_lines(
             client.clone(),
             agent_namespace,
             &format!("app={}", &agent_name),
-            vec!["Enabling filesystem"],
+            log_lines,
             None,
             true,
         )

--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -2071,7 +2071,7 @@ async fn test_retry_line_with_missing_pod_metadata() {
                 client.clone(),
                 agent_name,
                 agent_namespace,
-                tokio::time::Duration::from_millis(20_000),
+                tokio::time::Duration::from_millis(120_000),
             )
             .await
         );

--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -2043,21 +2043,21 @@ async fn test_retry_line_with_missing_pod_metadata() {
         );
         info!("daemonset {} in {} is ready", agent_name, agent_namespace);
 
-        // let messages = [
-        //     "Hello, World! 0\n",
-        //     "Hello, World! 1\n",
-        //     "Hello, World! 2\n",
-        //     "Hello, World! 3\n",
-        //     "Hello, World! 4\n",
-        // ];
-        //
-        // let mut logger_stream = TcpStream::connect(pod_node_addr).await.unwrap();
-        //
-        // for msg in messages.iter() {
-        //     // Write log lines
-        //     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-        //     logger_stream.write_all(msg.as_bytes()).await.unwrap();
-        // }
+        let messages = [
+            "Hello, World! 0\n",
+            "Hello, World! 1\n",
+            "Hello, World! 2\n",
+            "Hello, World! 3\n",
+            "Hello, World! 4\n",
+        ];
+
+        let mut logger_stream = TcpStream::connect(pod_node_addr).await.unwrap();
+
+        for msg in messages.iter() {
+            // Write log lines
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            logger_stream.write_all(msg.as_bytes()).await.unwrap();
+        }
 
         info!("Wait for the data to be received by the mock ingester");
         tokio::time::sleep(tokio::time::Duration::from_millis(10_000)).await;

--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -11,7 +11,7 @@ use kube::Client;
 use test_log::test;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
-use tracing::info;
+use tracing::{debug, info};
 
 use k8s::feature_leader::FeatureLeader;
 
@@ -38,9 +38,9 @@ async fn print_pod_logs(client: Client, namespace: &str, label: &str) {
                     .unwrap()
                     .boxed();
 
-                info!("Logging agent pod {:?}", p.metadata.name);
+                debug!("Logging agent pod {:?}", p.metadata.name);
                 while let Some(line) = logs.next().await {
-                    info!(
+                    debug!(
                         "LOG [{:?}] {:?}",
                         p.metadata.name,
                         String::from_utf8_lossy(&line.unwrap())

--- a/common/config/src/argv.rs
+++ b/common/config/src/argv.rs
@@ -221,6 +221,11 @@ pub struct ArgumentOptions {
     /// Interval in sec between clearing of various unconstrained agent caches
     #[structopt(long, env = env_vars::CLEAR_CACHE_INTERVAL)]
     clear_cache_interval: Option<u32>,
+
+    /// Seconds to wait before checking for missing k8s pod metadata and then sending log line
+    /// to Mezmo as-is. Zero value or when not set means disabled (default).
+    #[structopt(long, env = env_vars::METADATA_RETRY_DELAY)]
+    metadata_retry_delay: Option<u32>,
 }
 
 impl ArgumentOptions {
@@ -389,6 +394,10 @@ impl ArgumentOptions {
 
         if self.clear_cache_interval.is_some() {
             raw.log.clear_cache_interval = self.clear_cache_interval
+        }
+
+        if self.metadata_retry_delay.is_some() {
+            raw.log.metadata_retry_delay = self.metadata_retry_delay
         }
 
         raw
@@ -715,6 +724,10 @@ mod test {
             config.log.clear_cache_interval,
             Some(raw::LogConfig::default().clear_cache_interval.unwrap())
         );
+        assert_eq!(
+            config.log.metadata_retry_delay,
+            Some(raw::LogConfig::default().metadata_retry_delay.unwrap())
+        );
     }
 
     #[test]
@@ -744,6 +757,7 @@ mod test {
             retry_dir: some_string!("/tmp/argv"),
             clear_cache_interval: Some(777),
             retry_disk_limit: Some(Bytes::new(123456, Unit::Byte).unwrap()),
+            metadata_retry_delay: Some(555),
             ..ArgumentOptions::default()
         };
         let config = argv.merge(RawConfig::default());
@@ -775,6 +789,7 @@ mod test {
         assert_eq!(config.journald.systemd_journal_tailer, Some(false));
         assert_eq!(config.startup.option, Some(String::from("always")));
         assert_eq!(config.log.clear_cache_interval, Some(777));
+        assert_eq!(config.log.metadata_retry_delay, Some(555));
     }
 
     #[test]

--- a/common/config/src/env_vars.rs
+++ b/common/config/src/env_vars.rs
@@ -34,6 +34,7 @@ pub const RETRY_DIR: &str = "MZ_RETRY_DIR";
 pub const RETRY_DISK_LIMIT: &str = "MZ_RETRY_DISK_LIMIT";
 pub const INTERNAL_FS_DELAY: &str = "MZ_INTERNAL_FS_DELAY";
 pub const CLEAR_CACHE_INTERVAL: &str = "MZ_CLEAR_CACHE_INTERVAL";
+pub const METADATA_RETRY_DELAY: &str = "MZ_METADATA_RETRY_DELAY";
 
 // unused or deprecated
 pub const INGESTION_KEY_ALTERNATE: &str = "LOGDNA_AGENT_KEY";

--- a/common/config/src/env_vars.rs
+++ b/common/config/src/env_vars.rs
@@ -61,3 +61,5 @@ pub const META_ANNOTATIONS: &str = "MZ_META_ANNOTATIONS";
 pub const META_LABELS: &str = "MZ_META_LABELS";
 
 pub const NO_CAP: &str = "MZ_NO_CAP";
+
+pub const MOCK_NO_PODS: &str = "MZ_MOCK_NO_PODS";

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -124,6 +124,7 @@ pub struct LogConfig {
     pub clear_cache_interval: Duration,
     pub tailer_cmd: Option<String>,
     pub tailer_args: Option<String>,
+    pub metadata_retry_delay: Duration,
 }
 
 #[derive(Debug)]
@@ -387,6 +388,13 @@ impl TryFrom<RawConfig> for Config {
             ) as u64),
             tailer_cmd: raw.log.tailer_cmd,
             tailer_args: raw.log.tailer_args,
+            metadata_retry_delay: Duration::from_secs(raw.log.metadata_retry_delay.unwrap_or_else(
+                || {
+                    raw::LogConfig::default()
+                        .metadata_retry_delay
+                        .unwrap_or_default()
+                },
+            ) as u64),
         };
 
         if log.use_k8s_enrichment == K8sTrackingConf::Never

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -345,7 +345,7 @@ impl TryFrom<RawConfig> for Config {
                     d.clone()
                         .try_into()
                         .map_err(|e| {
-                            warn!("{} is not a valid directory: {}", d.display(), e);
+                            warn!("{} is not a valid directory: {:?}", d.display(), e);
                         })
                         .ok()
                 })

--- a/common/config/src/properties.rs
+++ b/common/config/src/properties.rs
@@ -57,6 +57,7 @@ from_env_name!(INGEST_BUFFER_SIZE);
 from_env_name!(RETRY_DIR);
 from_env_name!(RETRY_DISK_LIMIT);
 from_env_name!(CLEAR_CACHE_INTERVAL);
+from_env_name!(METADATA_RETRY_DELAY);
 
 enum Key {
     FromEnv(&'static str),
@@ -308,6 +309,12 @@ fn from_property_map(map: HashMap<String, String>) -> Result<Config, ConfigError
     if let Some(value) = map.get(&CLEAR_CACHE_INTERVAL) {
         result.log.clear_cache_interval = Some(u32::from_str(value).map_err(|e| {
             ConfigError::PropertyInvalid(format!("clear cache interval property is invalid: {}", e))
+        })?);
+    }
+
+    if let Some(value) = map.get(&METADATA_RETRY_DELAY) {
+        result.log.clear_cache_interval = Some(u32::from_str(value).map_err(|e| {
+            ConfigError::PropertyInvalid(format!("metadata retry delay property is invalid: {}", e))
         })?);
     }
 

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -312,6 +312,8 @@ pub struct LogConfig {
     pub tailer_cmd: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tailer_args: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_retry_delay: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
@@ -475,6 +477,7 @@ impl Default for LogConfig {
             clear_cache_interval: Some(3600 * 6), // 6 hours
             tailer_cmd: None,
             tailer_args: None,
+            metadata_retry_delay: Some(0),
         }
     }
 }
@@ -508,6 +511,8 @@ impl Merge for LogConfig {
         );
         self.clear_cache_interval
             .merge(&other.clear_cache_interval, &default.clear_cache_interval);
+        self.metadata_retry_delay
+            .merge(&other.metadata_retry_delay, &default.metadata_retry_delay);
     }
 }
 

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -31,7 +31,7 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use state::{FileOffsetFlushHandle, FileOffsetWriteHandle};
 
-mod delayed_stream;
+pub mod delayed_stream;
 pub mod dir_path;
 pub mod entry;
 pub mod event;
@@ -416,7 +416,7 @@ impl FileSystem {
                     if let Err(e) = fs.insert(&path_cpy, &mut initial_dir_events, &mut entries) {
                         // It can failed due to permissions or some other restriction
                         debug!(
-                            "Initial insertion of {} failed: {}",
+                            "Initial insertion of {} failed: {:?}",
                             path_cpy.to_str().unwrap(),
                             e
                         );
@@ -464,7 +464,7 @@ impl FileSystem {
                 if let Err(e) = fs.insert(path, &mut initial_dir_events, &mut entries) {
                     // It can failed due to file restrictions
                     debug!(
-                        "Initial recursive scan insertion of {} failed: {}",
+                        "Initial recursive scan insertion of {} failed: {:?}",
                         path.to_str().unwrap(),
                         e
                     );
@@ -716,7 +716,7 @@ impl FileSystem {
                     debug!("Processing event for untracked path: {}", path.display());
                 }
                 Error::File(err) => {
-                    warn!("Processing notify event resulted in error: {}", e);
+                    warn!("Processing notify event resulted in error: {:?}", e);
                     if err.to_string().contains("(os error 24)") {
                         error!(
                             "Agent process has hit the limit of maximum number of open files. \
@@ -729,7 +729,7 @@ impl FileSystem {
                     warn!("Processing notify event resulted in FS rescan");
                 }
                 _ => {
-                    warn!("Processing notify event resulted in error: {}", e);
+                    warn!("Processing notify event resulted in error: {:?}", e);
                 }
             }
         }
@@ -1076,7 +1076,7 @@ impl FileSystem {
                             }
                             _ => {
                                 info!(
-                                    "error found when inserting child entry for {:?}: {}",
+                                    "error found when inserting child entry for {:?}: {:?}",
                                     path, e
                                 );
                             }
@@ -1148,7 +1148,7 @@ impl FileSystem {
                                     // The insert of the target failed, the changes to the symlink itself
                                     // are going to be tracked, continue
                                     warn!(
-                                        "insert target {} of symlink {} resulted in error {}",
+                                        "insert target {} of symlink {} resulted in error {:?}",
                                         target.display(),
                                         path.display(),
                                         e

--- a/common/k8s/Cargo.toml
+++ b/common/k8s/Cargo.toml
@@ -14,6 +14,7 @@ http = { package = "mz-http", path = "../http" }
 metrics = { package = "metrics", path = "../metrics" }
 backoff = { version = "0.4.0", features = ["tokio"] }
 chrono = { version = "0.4", features = ["serde"] }
+config = { package = "config", path = "../config" }
 anyhow = "1.0.57"
 hyper = "0.14"
 hyper-timeout = "0.4"

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -501,7 +501,7 @@ impl Middleware for K8sMetadata {
                 }
             }
             // line does not have metadata yet
-            return Err(MiddlewareError::Retry);
+            return Err(MiddlewareError::Retry(self.name().into()));
         }
         Ok(line)
     }

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -482,13 +482,18 @@ impl Middleware for K8sMetadata {
         &self,
         line: &'a dyn LineBufferMut,
     ) -> Result<&'a dyn LineBufferMut, MiddlewareError> {
-        // here we delay all pod lines to catchup with k8s pod metadata if delay os configured
+        // here we retry all pod lines to give time for k8s pod metadata to catchup
+        // if metadata retry delay is not configured or zero then lines will be processed as usual
         let file_name = line.get_file().unwrap_or("");
         if parse_container_path(file_name).is_some() {
             Err(MiddlewareError::Retry)
         } else {
             Ok(line)
         }
+    }
+
+    fn name(&self) -> &'static str {
+        std::any::type_name::<K8sMetadata>()
     }
 }
 

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -489,7 +489,7 @@ impl Middleware for K8sMetadata {
             let obj_ref =
                 ObjectRef::new(&parse_result.pod_name).within(&parse_result.pod_namespace);
             if let Some(ref store) = self.state.lock().unwrap().store {
-                if let Some(_) = store.get(&obj_ref) {
+                if store.get(&obj_ref).is_some() {
                     return Ok(line);
                 }
             }

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -33,7 +33,7 @@ use metrics::Metrics;
 use middleware::{Middleware, Status};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::{error, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -436,7 +436,7 @@ impl Middleware for K8sMetadata {
                         let meta_object =
                             extract_image_name_and_tag(parse_result.container_name, pod.as_ref());
                         if meta_object.is_some() && line.set_meta(json!(meta_object)).is_err() {
-                            trace!("Unable to set meta object{:?}", meta_object);
+                            debug!("Unable to set meta object{:?}", meta_object);
                             return Status::Skip;
                         }
 
@@ -449,6 +449,7 @@ impl Middleware for K8sMetadata {
                                 )
                                 .is_err()
                             {
+                                debug!("Unable to set annotations {:?}", annotations);
                                 return Status::Skip;
                             };
                         }
@@ -462,9 +463,13 @@ impl Middleware for K8sMetadata {
                                 )
                                 .is_err()
                             {
+                                debug!("Unable to set labels {:?}", labels);
                                 return Status::Skip;
                             };
                         }
+                    } else {
+                        trace!("pod metadata is not available {:?}", obj_ref);
+                        return Status::Ok(line);
                     }
                 }
             }

--- a/common/k8s/src/middleware/mod.rs
+++ b/common/k8s/src/middleware/mod.rs
@@ -12,7 +12,7 @@ lazy_static! {
     ).unwrap_or_else(|e| panic!("K8S_REG Regex::new() failed: {}", e));
 }
 
-struct ParseResult {
+pub struct ParseResult {
     pod_name: String,
     pod_namespace: String,
     container_name: String,
@@ -28,7 +28,7 @@ impl ParseResult {
     }
 }
 
-fn parse_container_path(path: &str) -> Option<ParseResult> {
+pub fn parse_container_path(path: &str) -> Option<ParseResult> {
     let captures = K8S_REG.captures(path)?;
     Some(ParseResult::new(
         captures.get(1)?.as_str().into(),

--- a/common/k8s/src/middleware/runner.rs
+++ b/common/k8s/src/middleware/runner.rs
@@ -11,7 +11,7 @@ use tokio::{
     task::JoinHandle,
     time::{sleep, Duration},
 };
-use tracing::{error, trace, warn};
+use tracing::{error, info, trace, warn};
 
 pub static SWAP_DELAY: Duration = Duration::from_secs(3);
 pub static RESET_DURATION: Duration = Duration::from_secs(60);
@@ -131,7 +131,7 @@ pub fn metadata_runner(
 ) {
     let middleware = Arc::new(K8sMetadata::new(deletion_ack_receiver));
     executor.register(middleware.clone());
-
+    info!("registered middleware: K8sMetadata");
     tokio::spawn(async move {
         trampoline(State::Init, &user_agent, &node_name, &middleware).await;
     });

--- a/common/middleware/Cargo.toml
+++ b/common/middleware/Cargo.toml
@@ -10,7 +10,9 @@ integration_tests = []
 [dependencies]
 #local
 http = { package = "mz-http", path = "../http" }
+fs = { package = "fs", path = "../fs" }
 config = { package = "config", path = "../config" }
+futures = "0.3"
 memoffset = "0.6"
 regex = "1"
 thiserror = "1.0"
@@ -19,3 +21,4 @@ tracing-subscriber = "0.3"
 serde_json = "1"
 lazy_static = "*"
 multimap = "0.8"
+async-channel = "1.8"

--- a/common/middleware/Cargo.toml
+++ b/common/middleware/Cargo.toml
@@ -10,9 +10,7 @@ integration_tests = []
 [dependencies]
 #local
 http = { package = "mz-http", path = "../http" }
-fs = { package = "fs", path = "../fs" }
 config = { package = "config", path = "../config" }
-futures = "0.3"
 memoffset = "0.6"
 regex = "1"
 thiserror = "1.0"
@@ -21,4 +19,3 @@ tracing-subscriber = "0.3"
 serde_json = "1"
 lazy_static = "*"
 multimap = "0.8"
-async-channel = "1.8"

--- a/common/middleware/src/k8s_line_rules.rs
+++ b/common/middleware/src/k8s_line_rules.rs
@@ -1,4 +1,4 @@
-use crate::{Middleware, Status};
+use crate::{Middleware, MiddlewareError, Status};
 use http::types::body::{KeyValueMap, LineBufferMut};
 use lazy_static::lazy_static;
 use multimap::MultiMap;
@@ -155,6 +155,13 @@ impl Middleware for K8sLineFilter {
             None => Status::Skip,
             Some(_) => self.process_line(line),
         }
+    }
+
+    fn validate<'a>(
+        &self,
+        line: &'a dyn LineBufferMut,
+    ) -> Result<&'a dyn LineBufferMut, MiddlewareError> {
+        Ok(line)
     }
 }
 

--- a/common/middleware/src/k8s_line_rules.rs
+++ b/common/middleware/src/k8s_line_rules.rs
@@ -163,6 +163,10 @@ impl Middleware for K8sLineFilter {
     ) -> Result<&'a dyn LineBufferMut, MiddlewareError> {
         Ok(line)
     }
+
+    fn name(&self) -> &'static str {
+        std::any::type_name::<K8sLineFilter>()
+    }
 }
 
 fn set_k8s_line_rule(rules: &[String]) -> Result<K8sLineRules, K8sLineRulesError> {

--- a/common/middleware/src/lib.rs
+++ b/common/middleware/src/lib.rs
@@ -10,12 +10,9 @@ pub mod meta_rules;
 pub enum Status<T> {
     Ok(T),
     Skip,
-    Retry,
 }
 #[derive(Debug, Error)]
 pub enum MiddlewareError {
-    #[error("line needs to be delayed and tried again")]
-    Retry,
     #[error("line needs to be dropped")]
     Skip,
 }
@@ -65,6 +62,7 @@ where
     }
 }
 
+#[derive(Default)]
 pub struct Executor {
     middlewares: Vec<Arc<dyn Middleware>>,
 }
@@ -97,7 +95,6 @@ impl Executor {
             .try_fold(line, |l, m| match m.process(l) {
                 Status::Ok(l) => Ok(l),
                 Status::Skip => Err(MiddlewareError::Skip),
-                Status::Retry => Err(MiddlewareError::Retry),
             })
     }
 }

--- a/common/middleware/src/lib.rs
+++ b/common/middleware/src/lib.rs
@@ -15,9 +15,9 @@ pub enum Status<T> {
 #[derive(Debug, Error)]
 pub enum MiddlewareError {
     #[error("line needs to be dropped")]
-    Skip,
+    Skip(String),
     #[error("line needs to be retried for processing again later")]
-    Retry,
+    Retry(String),
 }
 
 pub trait Middleware: Send + Sync + 'static {
@@ -114,7 +114,7 @@ impl Executor {
             .iter()
             .try_fold(line, |l, m| match m.process(l) {
                 Status::Ok(l) => Ok(l),
-                Status::Skip => Err(MiddlewareError::Skip),
+                Status::Skip => Err(MiddlewareError::Skip(m.name().into())),
             })
     }
 

--- a/common/middleware/src/lib.rs
+++ b/common/middleware/src/lib.rs
@@ -126,8 +126,7 @@ impl Executor {
             .iter()
             .try_fold(line, |l, m| match m.validate(l) {
                 Ok(_) => Ok(l),
-                Err(MiddlewareError::Skip) => Err(MiddlewareError::Skip),
-                Err(MiddlewareError::Retry) => Err(MiddlewareError::Retry),
+                Err(e) => Err(e),
             })
     }
 }

--- a/common/middleware/src/line_rules.rs
+++ b/common/middleware/src/line_rules.rs
@@ -180,7 +180,6 @@ mod tests {
                     );
                 }
                 Status::Skip => panic!("should not have been skipped"),
-                Status::Retry => panic!("should not have been retried"),
             }
         };
     }

--- a/common/middleware/src/line_rules.rs
+++ b/common/middleware/src/line_rules.rs
@@ -180,6 +180,7 @@ mod tests {
                     );
                 }
                 Status::Skip => panic!("should not have been skipped"),
+                Status::Retry => panic!("should not have been retried"),
             }
         };
     }

--- a/common/middleware/src/line_rules.rs
+++ b/common/middleware/src/line_rules.rs
@@ -148,11 +148,16 @@ impl Middleware for LineRules {
             Some(_) => self.process_line(line),
         }
     }
+
     fn validate<'a>(
         &self,
         line: &'a dyn LineBufferMut,
     ) -> Result<&'a dyn LineBufferMut, MiddlewareError> {
         Ok(line)
+    }
+
+    fn name(&self) -> &'static str {
+        std::any::type_name::<LineRules>()
     }
 }
 

--- a/common/middleware/src/line_rules.rs
+++ b/common/middleware/src/line_rules.rs
@@ -1,4 +1,4 @@
-use crate::{Middleware, Status};
+use crate::{Middleware, MiddlewareError, Status};
 use http::types::body::LineBufferMut;
 use regex::bytes::{Regex, RegexSet};
 use std::cmp;
@@ -147,6 +147,12 @@ impl Middleware for LineRules {
             None => Status::Skip,
             Some(_) => self.process_line(line),
         }
+    }
+    fn validate<'a>(
+        &self,
+        line: &'a dyn LineBufferMut,
+    ) -> Result<&'a dyn LineBufferMut, MiddlewareError> {
+        Ok(line)
     }
 }
 

--- a/common/middleware/src/meta_rules.rs
+++ b/common/middleware/src/meta_rules.rs
@@ -266,6 +266,10 @@ impl Middleware for MetaRules {
     ) -> Result<&'a dyn LineBufferMut, MiddlewareError> {
         Ok(line)
     }
+
+    fn name(&self) -> &'static str {
+        std::any::type_name::<MetaRules>()
+    }
 }
 
 fn os_env_hashmap() -> HashMap<String, String> {

--- a/common/middleware/src/meta_rules.rs
+++ b/common/middleware/src/meta_rules.rs
@@ -1,4 +1,4 @@
-use crate::{Middleware, Status};
+use crate::{Middleware, MiddlewareError, Status};
 use config::env_vars;
 use http::types::body::{KeyValueMap, LineBufferMut};
 use lazy_static::lazy_static;
@@ -255,8 +255,16 @@ impl MetaRules {
 
 impl Middleware for MetaRules {
     fn run(&self) {}
+
     fn process<'a>(&self, line: &'a mut dyn LineBufferMut) -> Status<&'a mut dyn LineBufferMut> {
         self.process_line(line)
+    }
+
+    fn validate<'a>(
+        &self,
+        line: &'a dyn LineBufferMut,
+    ) -> Result<&'a dyn LineBufferMut, MiddlewareError> {
+        Ok(line)
     }
 }
 


### PR DESCRIPTION
- added delayed lines source, parameterized by MZ_METADATA_RETRY_DELAY.
- "Lazy" lines can be "retried" - put back into delayed lines source queue based on result of validation of the line.
- the goal is to delay k8s lines that do not have pod metadata ready yet.


Ref: LOG-17820