### PR TITLE
fix: log flood "hit rate limit snoozing"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,12 +439,12 @@ dependencies = [
  "async-compression",
  "fs",
  "globber",
- "http 0.1.0",
  "humanize-rs",
  "java-properties",
  "k8s",
  "lazy_static",
  "log",
+ "mz-http",
  "scopeguard",
  "serde",
  "serde_yaml",
@@ -846,13 +846,13 @@ dependencies = [
  "futures-core",
  "futures-util",
  "globber",
- "http 0.1.0",
  "inotify",
  "lazy_static",
  "log",
  "memchr",
  "metrics",
  "middleware",
+ "mz-http",
  "pcre2",
  "pin-project-lite",
  "serde_json",
@@ -1003,7 +1003,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.9",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1058,36 +1058,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.1.0"
-dependencies = [
- "async-compat",
- "async-compression",
- "bytes",
- "crossbeam",
- "futures",
- "futures-timer",
- "hyper",
- "log",
- "logdna-client",
- "metrics",
- "num_cpus",
- "prometheus 0.12.0",
- "proptest",
- "rand",
- "serde",
- "serde_json",
- "state",
- "tempfile",
- "thiserror",
- "time 0.3.21",
- "tokio",
- "tokio-test",
- "types",
- "uuid",
-]
-
-[[package]]
-name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
@@ -1104,7 +1074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http 0.2.9",
+ "http",
  "pin-project-lite",
 ]
 
@@ -1149,7 +1119,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.9",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -1168,7 +1138,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
- "http 0.2.9",
+ "http",
  "hyper",
  "log",
  "rustls",
@@ -1338,10 +1308,10 @@ dependencies = [
  "combine",
  "env_logger 0.9.3",
  "futures",
- "http 0.1.0",
  "log",
  "metrics",
  "mio 0.7.14",
+ "mz-http",
  "partial-io",
  "serial_test 0.5.1",
  "systemd",
@@ -1396,8 +1366,7 @@ dependencies = [
  "chrono",
  "crossbeam",
  "futures",
- "http 0.1.0",
- "http 0.2.9",
+ "http",
  "humantime",
  "hyper",
  "hyper-rustls",
@@ -1408,6 +1377,7 @@ dependencies = [
  "log",
  "metrics",
  "middleware",
+ "mz-http",
  "parking_lot 0.11.2",
  "pin-project-lite",
  "pin-utils",
@@ -1458,7 +1428,7 @@ dependencies = [
  "dirs-next",
  "either",
  "futures",
- "http 0.2.9",
+ "http",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -1490,7 +1460,7 @@ checksum = "da41f98f213796a68fcd4510c88b5fd36de131c1ea30d152474c3f2e1bef1a72"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http 0.2.9",
+ "http",
  "json-patch",
  "k8s-openapi",
  "once_cell",
@@ -1638,7 +1608,6 @@ dependencies = [
  "float-cmp",
  "fs",
  "futures",
- "http 0.1.0",
  "hyper",
  "itertools",
  "journald",
@@ -1652,6 +1621,7 @@ dependencies = [
  "metrics",
  "middleware",
  "miniz_oxide 0.4.4",
+ "mz-http",
  "nix",
  "once_cell",
  "pin-utils",
@@ -1691,7 +1661,7 @@ dependencies = [
  "countme",
  "derivative",
  "futures",
- "http 0.2.9",
+ "http",
  "hyper",
  "hyper-rustls",
  "log",
@@ -1792,10 +1762,10 @@ dependencies = [
 name = "middleware"
 version = "0.1.0"
 dependencies = [
- "http 0.1.0",
  "lazy_static",
  "log",
  "memoffset 0.6.5",
+ "mz-http",
  "regex",
  "serde_json",
  "thiserror",
@@ -1857,6 +1827,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "mz-http"
+version = "0.1.0"
+dependencies = [
+ "async-compat",
+ "async-compression",
+ "bytes",
+ "crossbeam",
+ "futures",
+ "futures-timer",
+ "hyper",
+ "log",
+ "logdna-client",
+ "metrics",
+ "num_cpus",
+ "prometheus 0.12.0",
+ "proptest",
+ "rand",
+ "rate-limit-macro",
+ "serde",
+ "serde_json",
+ "state",
+ "tempfile",
+ "thiserror",
+ "time 0.3.21",
+ "tokio",
+ "tokio-test",
+ "types",
+ "uuid",
 ]
 
 [[package]]
@@ -2315,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -2413,9 +2414,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -2457,6 +2458,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rate-limit-macro"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f91a006402f2b881c0b34db74da30e885033404dc771676d7a90d30b58c94d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3297,7 +3309,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 0.2.9",
+ "http",
  "http-body",
  "http-range-header",
  "pin-project-lite",
@@ -3375,8 +3387,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "http 0.1.0",
  "logdna-client",
+ "mz-http",
  "proptest",
  "serde_json",
  "state",
@@ -3586,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
 dependencies = [
  "ring",
  "untrusted",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 #local
-http = { package = "http", path = "../common/http" }
+http = { package = "mz-http", path = "../common/http" }
 fs = { package = "fs", path = "../common/fs" }
 config = { package = "config", path = "../common/config" }
 middleware = { package = "middleware", path = "../common/middleware" }

--- a/common/config/Cargo.toml
+++ b/common/config/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 #local
 fs = { package = "fs", path = "../fs" }
 k8s = { package = "k8s", path = "../k8s" }
-http = { package = "http", path = "../http" }
+http = { package = "mz-http", path = "../http" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/common/fs/Cargo.toml
+++ b/common/fs/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 #local
-http = { package = "http", path = "../http" }
+http = { package = "mz-http", path = "../http" }
 metrics = { package = "metrics", path = "../metrics" }
 state = { package = "state", path = "../state" }
 

--- a/common/http/Cargo.toml
+++ b/common/http/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "http"
+name = "mz-http"
 version = "0.1.0"
 authors = ["CJP10 <connor.peticca@logdna.com>"]
 edition = "2018"
@@ -29,6 +29,7 @@ futures = "0.3"
 futures-timer = "3"
 prometheus = { version = "0.12", features = ["process"] }
 async-compression = { version = "0.3.8", features = ["tokio"] }
+rate-limit-macro = { version = "1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/common/http/src/limit.rs
+++ b/common/http/src/limit.rs
@@ -127,8 +127,9 @@ impl Backoff {
 
     pub async fn snooze(&self) {
         let step = self.step.load(Ordering::SeqCst);
-        // TODO make debug
-        info!("hit rate limit, snoozing");
+        rate_limit_macro::rate_limit!(rate = 1, interval = 5, {
+            debug!("hit rate limit, snoozing");
+        });
         tokio::time::sleep(Duration::from_millis(self.base.pow(step) * self.multipler)).await;
         self.step.fetch_add(1, Ordering::SeqCst);
     }

--- a/common/journald/Cargo.toml
+++ b/common/journald/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["jakedipity <jacob.hull@logdna.com>"]
 edition = "2018"
 
 [dependencies]
-http = { package = "http", path = "../http" }
+http = { package = "mz-http", path = "../http" }
 metrics = { package = "metrics", path = "../metrics" }
 
 tokio = { package = "tokio", version = "1", features = ["macros", "process", "rt-multi-thread", "time"] }

--- a/common/k8s/Cargo.toml
+++ b/common/k8s/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 #local
 middleware = { package = "middleware", path = "../middleware" }
-http = { package = "http", path = "../http" }
+http = { package = "mz-http", path = "../http" }
 metrics = { package = "metrics", path = "../metrics" }
 backoff = { version = "0.4.0", features = ["tokio"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/common/middleware/Cargo.toml
+++ b/common/middleware/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 #local
-http = { package = "http", path = "../http" }
+http = { package = "mz-http", path = "../http" }
 memoffset = "0.6"
 regex = "1"
 thiserror = "1.0"

--- a/common/test/types/Cargo.toml
+++ b/common/test/types/Cargo.toml
@@ -13,5 +13,5 @@ futures = "0.3"
 logdna-client = { git = "https://github.com/logdna/logdna-rust.git", branch="0.6.x", version = "0.6" }
 proptest = "1"
 serde_json = "1"
-http = { package = "http", path = "../../http" }
+http = { package = "mz-http", path = "../../http" }
 state = { package = "state", path = "../../state" }


### PR DESCRIPTION
- fix: log flood "hit rate limit snoozing
- chore: webpki v0.22.0 -> v0.22.1

Ref: LOG-11879
