### PR TITLE
Remove no-longer-necessary Arc<Mutex<T>>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3001,16 +3001,15 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
 dependencies = [
  "bit-set",
  "bitflags",
  "byteorder",
  "lazy_static",
  "num-traits",
- "quick-error 2.0.1",
  "rand",
  "rand_chacha",
  "rand_xorshift",
@@ -3031,12 +3030,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -3219,7 +3212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
- "quick-error 1.2.3",
+ "quick-error",
 ]
 
 [[package]]
@@ -3351,7 +3344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]

--- a/bin/tests/it/cmd_line_env.rs
+++ b/bin/tests/it/cmd_line_env.rs
@@ -106,7 +106,7 @@ fn test_list_config_from_conf() -> io::Result<()> {
     assert!(output.status.success());
     let stdout = from_utf8(&output.stdout).unwrap();
 
-    vec![
+    [
         "Listing current settings from config",
         ", environment variables and command line options in yaml format",
         "ingestion_key: REDACTED",

--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -1698,7 +1698,7 @@ async fn test_k8s_startup_leases_always_start() {
         )
         .await;
 
-        let messages = vec![
+        let messages = [
             "Agent data! 0\n",
             "Agent data! 1\n",
             "Agent data! 2\n",
@@ -1820,7 +1820,7 @@ async fn test_k8s_startup_leases_never_start() {
         )
         .await;
 
-        let messages = vec![
+        let messages = [
             "Agent data! 0\n",
             "Agent data! 1\n",
             "Agent data! 2\n",

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -689,8 +689,7 @@ mod tests {
     fn test_default_rules() {
         let config = get_default_config();
 
-        let should_pass = vec![
-            "/var/log/a.log",
+        let should_pass = ["/var/log/a.log",
             "/var/log/containers/a.log",
             "/var/log/custom/a.log",
 
@@ -698,8 +697,7 @@ mod tests {
             // so if a symlink points to it, it should pass
             "/var/data/a.log",
             "/tmp/app/a.log",
-            "/var/data/kubeletlogs/some-named-service-aabb67c8fc-9ncjd_52c36bc5-4a53-4827-9dc8-082926ac1bc9/some-named-service/1.log",
-        ];
+            "/var/data/kubeletlogs/some-named-service-aabb67c8fc-9ncjd_52c36bc5-4a53-4827-9dc8-082926ac1bc9/some-named-service/1.log"];
 
         for p in should_pass.iter().map(PathBuf::from) {
             assert!(

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -1022,10 +1022,7 @@ ingest_buffer_size = 3145728
         // Case 5: With two None values, the existing value should remain.
         target = None;
         target.merge(&None, &default_val);
-        assert!(
-            matches!(target, None),
-            "None expected when merging with None"
-        );
+        assert!(target.is_none(), "None expected when merging with None");
     }
 
     #[test]
@@ -1322,8 +1319,8 @@ startup: {}",
         let result: Vec<Result<Config, ConfigError>> = try_load_confs(&conf_paths).collect();
 
         assert_eq!(result.len(), 2);
-        assert!(matches!(&result[0], Ok(_)));
-        assert!(matches!(&result[1], Ok(_)));
+        assert!(result[0].is_ok());
+        assert!(result[1].is_ok());
 
         Ok(())
     }
@@ -1393,9 +1390,9 @@ startup: {}",
         let result: Vec<Result<Config, ConfigError>> = try_load_confs(&conf_paths).collect();
 
         assert_eq!(result.len(), 3);
-        assert!(matches!(result[0], Ok(_)));
+        assert!(result[0].is_ok());
         assert!(matches!(result[1], Err(ConfigError::Io(_))));
-        assert!(matches!(result[2], Ok(_)));
+        assert!(result[2].is_ok());
 
         Ok(())
     }

--- a/common/fs/src/cache/dir_path.rs
+++ b/common/fs/src/cache/dir_path.rs
@@ -86,7 +86,7 @@ fn find_valid_path(
 ) -> Result<DirPathBuf, DirPathBufError> {
     match path {
         Some(some_path) => {
-            if matches!(std::fs::canonicalize(&some_path), Ok(_)) {
+            if std::fs::canonicalize(&some_path).is_ok() {
                 Ok(DirPathBuf {
                     inner: some_path,
                     postfix,

--- a/common/k8s/src/middleware/mod.rs
+++ b/common/k8s/src/middleware/mod.rs
@@ -8,7 +8,7 @@ pub use runner::*;
 
 lazy_static! {
     static ref K8S_REG: Regex = Regex::new(
-        r#"^/var/log/containers/([a-z0-9A-Z\-.]+)_([a-z0-9A-Z\-.]+)_([a-z0-9A-Z\-.]+)-([a-z0-9]{64}).log$"#
+        r"^/var/log/containers/([a-z0-9A-Z\-.]+)_([a-z0-9A-Z\-.]+)_([a-z0-9A-Z\-.]+)-([a-z0-9]{64}).log$"
     ).unwrap_or_else(|e| panic!("K8S_REG Regex::new() failed: {}", e));
 }
 

--- a/common/middleware/src/meta_rules.rs
+++ b/common/middleware/src/meta_rules.rs
@@ -226,7 +226,7 @@ impl MetaRules {
         }
         if let (Some(over_k8s_file), true) = (&self.over_k8s_file, is_k8s_line) {
             let file = config::substitute(over_k8s_file.deref(), &meta_map);
-            if line.set_file(file).is_err() {}
+            let _ = line.set_file(file).is_err();
             // overriding "file" will disable server side CRIO log line parsing,
             // so we remove CRIO log prefix from line here to make regular line parser happy
             if let Some(line_text) = line.get_line_buffer() {

--- a/common/test/types/src/strategies.rs
+++ b/common/test/types/src/strategies.rs
@@ -165,6 +165,7 @@ fn key_value_map_st(max_entries: usize) -> impl Strategy<Value = KeyValueMap> {
 }
 
 //recursive JSON type
+#[allow(clippy::arc_with_non_send_sync)]
 fn json_st(depth: u32) -> impl Strategy<Value = serde_json::Value> {
     let leaf = prop_oneof![
         Just(serde_json::Value::Null),


### PR DESCRIPTION
With rust 1.72 the old, no longer necessary, `Arc<Mutex<T>>` in fs is now causing a lint error. This PR replaces it with `RC<RefCell<T>>` where relevant. There are no functional changes.

This also fixes a couple of other lints, like using [T] instead of vec![] where possible and using try_fold where applicable