### PR TITLE
fix: respect filesystem offsets when lookback is disabled

### DIFF
--- a/bin/src/_main.rs
+++ b/bin/src/_main.rs
@@ -1,6 +1,7 @@
 use futures::Stream;
 
 use config::{self, Config, DbPath, K8sLeaseConf, K8sTrackingConf};
+use fs::lookback::Lookback;
 use fs::tail;
 use futures::{stream, StreamExt};
 use http::batch::TimedRequestBatcherStreamExt;
@@ -100,15 +101,17 @@ pub async fn _main(
     let mut _agent_state = None;
     let mut offset_state = None;
 
-    if let DbPath::Path(db_path) = &config.log.db_path {
-        match AgentState::new(db_path) {
-            Ok(agent_state) => {
-                let _offset_state = agent_state.get_offset_state();
-                _agent_state = Some(agent_state);
-                offset_state = Some(_offset_state);
-            }
-            Err(e) => {
-                error!("Failed to open agent state db {}", e);
+    if config.log.lookback != Lookback::None {
+        if let DbPath::Path(db_path) = &config.log.db_path {
+            match AgentState::new(db_path) {
+                Ok(agent_state) => {
+                    let _offset_state = agent_state.get_offset_state();
+                    _agent_state = Some(agent_state);
+                    offset_state = Some(_offset_state);
+                }
+                Err(e) => {
+                    error!("Failed to open agent state db {}", e);
+                }
             }
         }
     }

--- a/bin/tests/it/cli.rs
+++ b/bin/tests/it/cli.rs
@@ -2332,6 +2332,7 @@ fn test_offset_stream_state_gc() {
     let mut settings = AgentSettings::new(dir.to_str().unwrap());
     settings.clear_cache_interval = Some(3);
     settings.state_db_dir = Some(db_dir.as_path());
+    settings.lookback = Some("smallfiles");
 
     let mut agent_handle = common::spawn_agent(settings);
 

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -191,7 +191,7 @@ pub fn process(
 
     Ok(events
         .then({
-            let fs = state.fs_cache.clone();
+            let fs = state.fs_cache;
 
             move |event_result| {
                 let fs = fs.clone();


### PR DESCRIPTION
Normally offsets are ignored when lookback is disabled, but filesystem offsets should still be respected. Filesystem offsets track state across internal filesystem offsets and differ from global offsets which track state across application restarts.

Before this change global offsets were always loaded and the filesystem would optionally respect them based on the lookback configuration. Now the filesystem always respect offsets regardless of lookback configuration, and global offsets are only loaded if the current lookback configuration respects global state.

Ref: LOG-17217