### PR TITLE
fix: retry requests on appropriate response codes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,12 @@ def PROJECT_NAME = 'logdna-agent-v2'
 def TRIGGER_PATTERN = '.*@logdnabot.*'
 
 pipeline {
-    agent any
+    agent {
+        node {
+            label "rust-x86_64"
+            customWorkspace("/tmp/workspace/${env.BUILD_TAG}")
+        }
+    }
     options {
         timestamps()
         ansiColor 'xterm'


### PR DESCRIPTION
If response is one of either 500, 501, 502, 503, 504, 507, or 429; we should retry that request instead of just dumping it.