### PR TITLE
chore: pin jenkins agent to rust nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,12 @@ def PROJECT_NAME = 'logdna-agent-v2'
 def TRIGGER_PATTERN = '.*@logdnabot.*'
 
 pipeline {
-    agent any
+    agent {
+        node {
+            label "rust-x86_64"
+            customWorkspace("/tmp/workspace/${env.BUILD_TAG}")
+        }
+    }
     options {
         timestamps()
         ansiColor 'xterm'


### PR DESCRIPTION
 Pins the Jenkins agent to "rust-x86_64" so that builds always run on an appropriate node.