### PR TITLE
fix: silently replace existing fs entries

### DIFF
--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -1458,8 +1458,10 @@ impl FileSystem {
                     .entry(component)
                 {
                     HashMapEntry::Vacant(v) => Ok(*v.insert(new_key)),
-                    // TODO: Maybe consider to silently replace
-                    _ => Err(Error::Existing),
+                    HashMapEntry::Occupied(mut o) => {
+                        o.insert(new_key);
+                        Ok(*o.into_mut())
+                    }
                 };
             } else {
                 trace!("parent with path {:?} not found", parent_path);


### PR DESCRIPTION
Not silently replacing fs entries, and instead returning an error, short circuits the logic that normally handles processing new files.

In cases where log rotation re-uses the same inodes, log rotation is seen as log truncation. Truncation is only detected during write events. If this event surpasses the internal 8196 byte limit, tailing will be picked up at the end of the file. This causes the first set of lines to be dropped.

By fixing this short circuiting issue, log truncation should now be correctly handled once the file is created. This should appropriately reset the offsets of the tailed file so the next write event begins properly at the beginning.