### PR TITLE
fix: handle truncation while assigning initial offsets

### DIFF
--- a/bin/tests/it/common.rs
+++ b/bin/tests/it/common.rs
@@ -62,10 +62,9 @@ pub async fn force_client_to_flush(dir_path: &Path) {
 #[cfg(not(target_os = "macos"))]
 pub fn truncate_file(file_path: &Path) -> Result<(), std::io::Error> {
     OpenOptions::new()
-        .read(true)
         .write(true)
-        .open(file_path)?
-        .set_len(0)?;
+        .truncate(true)
+        .open(file_path)?;
     Ok(())
 }
 


### PR DESCRIPTION
Initial offsets never considered the current state of the file, instead just preferring to use the state saved offsets or defaulting to the value configured by the `MZ_LOOKBACK` option. This means truncation is handled downstream where the agent doesn't have enough contextual information to appropriately handle the case and potentially dropping logs.

This change causes initial offsets to be ignored if they exceed the current length of the file, and instead use the default values.

Ref: LOG-17217