### PR TITLE
fix: typo in metrics log output

### DIFF
--- a/common/k8s/src/metrics_stats_stream.rs
+++ b/common/k8s/src/metrics_stats_stream.rs
@@ -42,7 +42,7 @@ impl MetricsStatsStream {
     }
 
     pub async fn start_metrics_call_task(self) -> impl Stream<Item = LineBuilder> {
-        info!("Starting metics reporting task.");
+        info!("Starting metrics reporting task.");
         stream::unfold((self.client, self.leader), |params| async {
             sleep(Duration::from_millis(GENERATE_REPORT_INTERVAL_MS)).await;
             let is_renewed = params.1.renew_feature_leader().await;


### PR DESCRIPTION
Fixes a minor typo in the log output for the metrics stats stream.