### PR TITLE
ci: remove auditing from image vulnerability updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,8 @@ pipeline {
     triggers {
         issueCommentTrigger(TRIGGER_PATTERN)
         parameterizedCron(
-            env.BRANCH_NAME ==~ /\d\.\d/ ? 'H 8 * * 1 % PUBLISH_GCR_IMAGE=true;PUBLISH_ICR_IMAGE=true' : ''
+            env.BRANCH_NAME ==~ /\d\.\d/ ? 'H 8 * * 1 % PUBLISH_GCR_IMAGE=true;PUBLISH_ICR_IMAGE=true;AUDIT=false;TASK_NAME=image-vulnerability-update' : '' +
+            env.BRANCH_NAME ==~ /\d\.\d/ ? 'H 12 * * 1 % AUDIT=true;TASK_NAME=audit' : ''
         )
     }
     environment {
@@ -37,7 +38,9 @@ pipeline {
         booleanParam(name: 'PUBLISH_ICR_IMAGE', description: 'Publish docker image to IBM Container Registry (ICR) and Dockerhub', defaultValue: false)
         booleanParam(name: 'PUBLISH_BINARIES', description: 'Publish executable binaries to S3 bucket s3://logdna-agent-build-bin', defaultValue: false)
         booleanParam(name: 'PUBLISH_INSTALLERS', description: 'Publish Choco installer', defaultValue: false)
+        booleanParam(name: 'AUDIT', description: 'Check for application vulnerabilities with cargo audit', defaultValue: true)
         string(name: 'RUST_IMAGE_SUFFIX', description: 'Build image tag suffix', defaultValue: "")
+        choice(name: 'TASK_NAME', choices: ['n/a', 'audit', 'image-vulnerability-update'], description: 'The name of the task being handled in this build, if applicable')
     }
     stages {
         stage('Validate PR Source') {
@@ -64,12 +67,22 @@ pipeline {
                 """
             }
         }
-        stage('Lint and Unit Test') {
+        stage('Lint, Audit, and Unit Test') {
             parallel {
                 stage('Lint') {
                     steps {
                         sh '''
-                            make lint
+                            make lint -o lint-audit
+                        '''
+                    }
+                }
+                stage('Audit') {
+                    when {
+                        environment name: 'AUDIT', value: 'true'
+                    }
+                    steps {
+                        sh '''
+                            make lint-audit
                         '''
                     }
                 }
@@ -549,6 +562,31 @@ pipeline {
                             notFailBuild: true,
                             patterns: [[pattern: '.gitignore', type: 'INCLUDE'],
                                        [pattern: '.propsfile', type: 'EXCLUDE']])
+                }
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.TASK_NAME == 'image-vulnerability-update') {
+                    //TODO: change channel to #ibm-mezmo-agent after testing
+                    notifySlack(
+                        currentBuild.currentResult,
+                        [channel: '#proj-agent'],
+                        "`${PROJECT_NAME}` ${params.TASK_NAME} build took ${currentBuild.durationString.replaceFirst(' and counting', '')}."
+                    )
+                }
+            }
+        }
+        unsuccessful {
+            script {
+                if (params.TASK_NAME == 'audit' || params.TASK_NAME == 'image-vulnerability-update') {
+                    notifySlack(
+                        currentBuild.currentResult,
+                        [channel: '#proj-agent'],
+                        "`${PROJECT_NAME}` ${params.TASK_NAME} build took ${currentBuild.durationString.replaceFirst(' and counting', '')}."
+                    )
                 }
             }
         }

--- a/bin/tests/it/http.rs
+++ b/bin/tests/it/http.rs
@@ -1,5 +1,4 @@
 use crate::common::{self, AgentSettings};
-pub use common::*;
 use std::fs::File;
 use std::io::Write;
 use std::sync::{Arc, Mutex};

--- a/bin/tests/it/k8s.rs
+++ b/bin/tests/it/k8s.rs
@@ -500,7 +500,7 @@ fn ingester_public_addr(ingester_addr: impl ToSocketAddrs) -> SocketAddr {
         .find(|e| e.is_up() && !e.is_loopback() && !e.ips.is_empty())
         .expect("container should have an interface")
         .ips
-        .get(0)
+        .first()
         .expect("container should have an IP")
         .ip();
     let ingester_addr = ingester_addr

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -1465,7 +1465,7 @@ impl FileSystem {
         // Try to find parent
         if let Some(parent_path) = parent_path {
             if let Some(parent_key) = self.watch_descriptors.get(&parent_path) {
-                let parent_key = parent_key.get(0).copied().ok_or(Error::ParentLookup)?;
+                let parent_key = parent_key.first().copied().ok_or(Error::ParentLookup)?;
                 return match entries
                     .get_mut(parent_key)
                     .ok_or(Error::ParentLookup)?

--- a/common/fs/src/tail.rs
+++ b/common/fs/src/tail.rs
@@ -176,6 +176,8 @@ async fn handle_event(
 }
 
 /// Runs the main logic of the tailer, this can only be run once so Tailer is consumed
+//TODO: evaluate how to best handle this clippy error
+#[allow(clippy::await_holding_refcell_ref)]
 pub fn process(
     state: Tailer,
 ) -> Result<impl Stream<Item = Result<LazyLineSerializer, CacheError>>, std::io::Error> {

--- a/common/http/src/retry.rs
+++ b/common/http/src/retry.rs
@@ -127,7 +127,7 @@ impl Retry {
                             .split('_')
                             .map(|s| s.to_string())
                             .collect::<Vec<String>>()
-                            .get(0)
+                            .first()
                             .and_then(|s| FromStr::from_str(s).ok())
                             .ok_or_else(|| Error::InvalidFileName(file_name.clone()))?;
 

--- a/utils/metrics-recorder/src/lib.rs
+++ b/utils/metrics-recorder/src/lib.rs
@@ -31,9 +31,9 @@ fn stream_agent_metrics(
     scrape_delay: Option<Duration>,
 ) -> impl Stream<Item = Sample> {
     stream::unfold(Vec::new(), move |state| async move {
-        let mut state = loop {
+        let mut state = 'ret: {
             if !state.is_empty() {
-                break state;
+                break 'ret state;
             }
 
             // Hitting the metrics endpoint too quick may result in subsequent queries without
@@ -46,7 +46,7 @@ fn stream_agent_metrics(
             match fetch_agent_metrics(metrics_port).await {
                 Ok((StatusCode::OK, Some(body))) => {
                     let body = body.lines().map(|l| Ok(l.to_string()));
-                    break Scrape::parse(body)
+                    break 'ret Scrape::parse(body)
                         .expect("failed to parse the metrics response")
                         .samples;
                 }


### PR DESCRIPTION
This change detangles applicaton auditing from image vulnerability updates. Auditing is now handled in a separate process. This change also adds slack alerting for both auditing and image vulnerability updates.

Ref: LOG-19259