### PR TITLE
chore: fix clippy error

### DIFF
--- a/common/k8s/src/event_source.rs
+++ b/common/k8s/src/event_source.rs
@@ -402,7 +402,7 @@ impl K8sEventStream {
                 }
             })
             .map(move |event| {
-                match event.map(|e| {
+                let event_time = event.map(|e| {
                     let latest_event_time = latest_event_time_w.clone();
                     let this_event_time = e
                         .creation_timestamp()
@@ -418,7 +418,8 @@ impl K8sEventStream {
                         latest_event_time.store(this_event_time);
                     };
                     ret
-                }) {
+                });
+                match event_time {
                     Ok(Ok(l)) => Ok(StreamElem::Event(l)),
                     Ok(Err(e)) => {
                         latest_event_time_w.store(NonZeroI64::new(Utc::now().timestamp()));


### PR DESCRIPTION
Clippy does not like complex blocks in the scrutinee of match statements.

Ref: LOG-19431