### PR TITLE
chore(docker): don't pull in unnecessary deps during update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,9 @@ ENV JEMALLOC_SYS_WITH_MALLOC_CONF="narenas:1,tcache:false,dirty_decay_ms:0,muzzy
 COPY --from=build /opt/logdna-agent-v2/target/release/logdna-agent /work/
 WORKDIR /work/
 
-RUN microdnf update -y \
-    && microdnf install ca-certificates libcap shadow-utils.x86_64 -y \
+RUN microdnf update --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 -y \
+    && microdnf install ca-certificates libcap shadow-utils.x86_64 systemd --best --nodocs --noplugins --setopt=install_weak_deps=0 -y \
+    && microdnf clean all \
     && rm -rf /var/cache/yum \
     && chmod -R 777 . \
     && groupadd -g 5000 logdna \


### PR DESCRIPTION
Add additional microdnf update options to prevent unnecessary dependencies from being pulled in while building the final layer of the docker image.

Install systemd explicitly which was installed implicitly before.

Stops the docker image from being built with a version of python and pip vulnerable to CVE-2019-20916.