### PR TITLE
ci(macos): pin minimum version to 10.14

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -373,7 +373,7 @@ pipeline {
                                 echo "[default]" > ${WORKSPACE}/.aws_creds_mac_static_x86_64
                                 echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${WORKSPACE}/.aws_creds_mac_static_x86_64
                                 echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${WORKSPACE}/.aws_creds_mac_static_x86_64
-                                cargo build --release --target=x86_64-apple-darwin --target-dir x86-target
+                                MACOSX_DEPLOYMENT_TARGET=10.14 cargo build --release --target=x86_64-apple-darwin --target-dir x86-target
                             '''
                         }
                     }
@@ -404,7 +404,7 @@ pipeline {
                                 echo "[default]" > ${WORKSPACE}/.aws_creds_mac_static_arm64
                                 echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${WORKSPACE}/.aws_creds_mac_static_arm64
                                 echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${WORKSPACE}/.aws_creds_mac_static_arm64
-                                cargo build --release --target-dir arm-target
+                                MACOSX_DEPLOYMENT_TARGET=10.14 cargo build --release --target-dir arm-target
                             '''
                         }
                     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,14 +12,11 @@ environment:
   RUST_LOG: info
   RUST_BACKTRACE: 1
 
-cache:
-  - C:\Users\appveyor\.cargo
-
 install:
   - echo Installing with SSL on %OPENSSL_DIR%
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init.exe -y --default-host=x86_64-pc-windows-msvc
-  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin;C:\Users\appveyor\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin
   - del rustup-init.exe
   - rustc -vV
   - cargo -vV

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -745,6 +745,7 @@ mod tests {
 
         let file = OpenOptions::new()
             .create(true)
+            .truncate(true)
             .write(true)
             .read(true)
             .open(&path)

--- a/common/config/src/raw.rs
+++ b/common/config/src/raw.rs
@@ -117,7 +117,7 @@ pub trait Merge {
 impl Merge for PathBuf {
     fn merge(&mut self, other: &Self, default: &Self) {
         if *self != *other && *other != *default {
-            *self = other.clone();
+            self.clone_from(other);
         }
     }
 }
@@ -125,21 +125,22 @@ impl Merge for PathBuf {
 impl Merge for String {
     fn merge(&mut self, other: &Self, default: &Self) {
         if *self != *other && *other != *default {
-            *self = other.clone();
+            self.clone_from(other);
         }
     }
 }
 
 impl Merge for bool {
     fn merge(&mut self, other: &Self, _default: &Self) {
-        *self = *self || *other;
+        let target = *self || *other;
+        self.clone_from(&target);
     }
 }
 
 impl Merge for u16 {
     fn merge(&mut self, other: &Self, default: &Self) {
         if *other != *default {
-            *self = *other;
+            self.clone_from(other);
         }
     }
 }
@@ -147,7 +148,7 @@ impl Merge for u16 {
 impl Merge for u32 {
     fn merge(&mut self, other: &Self, default: &Self) {
         if *other != *default {
-            *self = *other;
+            self.clone_from(other);
         }
     }
 }
@@ -155,7 +156,7 @@ impl Merge for u32 {
 impl Merge for u64 {
     fn merge(&mut self, other: &Self, default: &Self) {
         if *other != *default {
-            *self = *other;
+            self.clone_from(other);
         }
     }
 }
@@ -163,7 +164,7 @@ impl Merge for u64 {
 impl Merge for usize {
     fn merge(&mut self, other: &Self, default: &Self) {
         if *other != *default {
-            *self = *other;
+            self.clone_from(other);
         }
     }
 }
@@ -171,7 +172,7 @@ impl Merge for usize {
 impl Merge for i32 {
     fn merge(&mut self, other: &Self, default: &Self) {
         if *other != *default {
-            *self = *other;
+            self.clone_from(other);
         }
     }
 }
@@ -192,7 +193,7 @@ impl<T: PartialEq + Merge + Clone + Default> Merge for Option<T> {
 impl Merge for Option<ParamsBuilder> {
     fn merge(&mut self, other: &Self, default: &Self) {
         if *other != *default && other.is_some() {
-            *self = other.clone();
+            self.clone_from(other);
         }
     }
 }
@@ -200,7 +201,7 @@ impl Merge for Option<ParamsBuilder> {
 impl<T: PartialEq + Clone> Merge for Vec<T> {
     fn merge(&mut self, other: &Self, default: &Self) {
         if *other != *default {
-            *self = other.clone();
+            self.clone_from(other);
         }
     }
 }

--- a/common/fs/src/cache/mod.rs
+++ b/common/fs/src/cache/mod.rs
@@ -1004,7 +1004,7 @@ impl FileSystem {
 
         if !self.passes(path, _entries) {
             // Do not continuously log ignored files
-            if let false = self.ignored_dirs.contains(path) {
+            if !self.ignored_dirs.contains(path) {
                 self.ignored_dirs.insert(path.to_path_buf());
                 info!("ignoring {:?}", path);
             }
@@ -1012,7 +1012,7 @@ impl FileSystem {
         }
 
         // If we already know about it warn and return
-        if self.watch_descriptors.get(path).is_some() {
+        if self.watch_descriptors.contains_key(path) {
             #[cfg(any(target_os = "windows", target_os = "linux"))] // bug in notify-rs where there is always a create event before most other events, just ignore.
             warn!("watch descriptor for {} already exists...", path.display());
             return Ok(None);
@@ -1103,7 +1103,7 @@ impl FileSystem {
                 // Ensure the symlink's parent directory is being tracked
                 if let Some(parent) = path.parent() {
                     // Manually insert the parent directory for symlink target so that we receive deletes if it's not here
-                    if self.watch_descriptors.get(parent).is_none() {
+                    if !self.watch_descriptors.contains_key(parent) {
                         let new_entry = Entry::Dir {
                             children: Children::default(),
                             path: parent.into(),
@@ -1127,7 +1127,7 @@ impl FileSystem {
                             // Add the parent directory of the target
                             if let Some(parent) = target.parent() {
                                 // Manually insert the parent directory for symlink target so that we receive deletes if it's not here
-                                if self.watch_descriptors.get(parent).is_none() {
+                                if !self.watch_descriptors.contains_key(parent) {
                                     let new_entry = Entry::Dir {
                                         children: Children::default(),
                                         path: parent.into(),

--- a/common/fs/src/cache/tailed_file.rs
+++ b/common/fs/src/cache/tailed_file.rs
@@ -807,26 +807,26 @@ mod tests {
         l.reader.try_lock().unwrap().deref_mut().buf = buf;
 
         {
-            let exclusion = &vec!["DEBUG".to_owned(), "(?i:TRACE)".to_owned()];
-            let p = LineRules::new(exclusion, &[], &[]).unwrap();
+            let exclusion = ["DEBUG".to_owned(), "(?i:TRACE)".to_owned()];
+            let p = LineRules::new(&exclusion, &[], &[]).unwrap();
             assert!(matches!(p.process(&mut l), Status::Skip));
         }
         {
-            let inclusion = &vec!["DEBUG".to_owned(), "(?i:TRACE)".to_owned()];
-            let p = LineRules::new(&[], inclusion, &[]).unwrap();
+            let inclusion = ["DEBUG".to_owned(), "(?i:TRACE)".to_owned()];
+            let p = LineRules::new(&[], &inclusion, &[]).unwrap();
             assert!(matches!(p.process(&mut l), Status::Ok(_)));
         }
     }
 
     #[test]
     fn lazy_lines_should_support_redaction() {
-        let redact = &vec!["NAME".to_owned(), r"\d+".to_owned()];
+        let redact = ["NAME".to_owned(), r"\d+".to_owned()];
         let mut l = get_line();
 
         {
             let buf = b"my name is NAME and I was born in the year 1914".to_vec();
             l.reader.try_lock().unwrap().deref_mut().buf = buf;
-            let p = LineRules::new(&[], &[], redact).unwrap();
+            let p = LineRules::new(&[], &[], &redact).unwrap();
             match p.process(&mut l) {
                 Status::Ok(_) => assert_eq!(
                     std::str::from_utf8(l.get_line_buffer().unwrap()).unwrap(),
@@ -845,6 +845,7 @@ mod tests {
                     .read(true)
                     .write(true)
                     .create(true)
+                    .truncate(true)
                     .open(&file_path)
                     .unwrap(),
             ))

--- a/common/http/src/retry.rs
+++ b/common/http/src/retry.rs
@@ -285,6 +285,7 @@ impl RetrySender {
             let mut file = BufWriter::new(
                 OpenOptions::new()
                     .create(true)
+                    .truncate(true)
                     .write(true)
                     .open(&file_name)
                     .await?,
@@ -517,6 +518,7 @@ mod tests {
         let mut existing_file = BufWriter::new(
             OpenOptions::new()
                 .create(true)
+                .truncate(true)
                 .write(true)
                 .open(&existing_file_path)
                 .await?,

--- a/common/k8s/src/kube_stats/node_stats.rs
+++ b/common/k8s/src/kube_stats/node_stats.rs
@@ -180,16 +180,12 @@ impl NodeStatsBuilder<'_> {
         match status {
             Some(status) => {
                 if status.node_info.is_some() {
-                    container_runtime_version = status
-                        .node_info
-                        .as_ref()
-                        .unwrap()
-                        .container_runtime_version
-                        .clone();
+                    container_runtime_version
+                        .clone_from(&status.node_info.as_ref().unwrap().container_runtime_version);
 
-                    kernel_version = status.node_info.as_ref().unwrap().kernel_version.clone();
-                    kubelet_version = status.node_info.as_ref().unwrap().kubelet_version.clone();
-                    os_image = status.node_info.as_ref().unwrap().os_image.clone();
+                    kernel_version.clone_from(&status.node_info.as_ref().unwrap().kernel_version);
+                    kubelet_version.clone_from(&status.node_info.as_ref().unwrap().kubelet_version);
+                    os_image.clone_from(&status.node_info.as_ref().unwrap().os_image);
                 }
 
                 if status.allocatable.is_some() {
@@ -233,9 +229,9 @@ impl NodeStatsBuilder<'_> {
 
                     for address in addresses {
                         if address.type_.to_lowercase() == "internalip" {
-                            ip = address.address.clone();
+                            ip.clone_from(&address.address);
                         } else if address.type_.to_lowercase() == "externalip" {
-                            ip_external = address.address.clone();
+                            ip_external.clone_from(&address.address);
                         }
                     }
                 }
@@ -254,12 +250,10 @@ impl NodeStatsBuilder<'_> {
 
                                 ready_heartbeat_time = heartbeat.0.timestamp_millis();
 
-                                ready_message = condition
-                                    .message
-                                    .as_ref()
-                                    .unwrap_or(&"".to_string())
-                                    .clone();
-                                ready_status = condition.status.clone();
+                                ready_message.clone_from(
+                                    condition.message.as_ref().unwrap_or(&"".to_string()),
+                                );
+                                ready_status.clone_from(&condition.status);
                             }
 
                             if condition.last_transition_time.is_some() {
@@ -290,7 +284,7 @@ impl NodeStatsBuilder<'_> {
         }
 
         if self.n.metadata.name.is_some() {
-            node = self.n.metadata.name.as_ref().unwrap().clone();
+            node.clone_from(self.n.metadata.name.as_ref().unwrap());
         }
 
         NodeStats {

--- a/common/middleware/src/line_rules.rs
+++ b/common/middleware/src/line_rules.rs
@@ -197,8 +197,8 @@ mod tests {
 
     #[test]
     fn should_exclude_lines() {
-        let exclusion = &vec![s!("DEBUG"), s!("(?i:TRACE)")];
-        let p = LineRules::new(exclusion, &[], &[]).unwrap();
+        let exclusion = [s!("DEBUG"), s!("(?i:TRACE)")];
+        let p = LineRules::new(&exclusion, &[], &[]).unwrap();
         // Not containing any excluded value
         is_match!(p, "Hello INFO something", Status::Ok(_));
 
@@ -215,8 +215,8 @@ mod tests {
     #[test]
     fn should_filter_by_inclusion() {
         // Only include lines with "WARN" (case sensitive) and "error" (case insensitive)
-        let inclusion = &vec![s!("WARN"), s!("(?i:error)")];
-        let p = LineRules::new(&[], inclusion, &[]).unwrap();
+        let inclusion = [s!("WARN"), s!("(?i:error)")];
+        let p = LineRules::new(&[], &inclusion, &[]).unwrap();
 
         // Should match
         is_match!(p, "WARN something", Status::Ok(_));
@@ -237,9 +237,9 @@ mod tests {
     fn should_use_exclusion_last() {
         // Only include lines with "WARN" and "error"
         // And exclude messages with the text "VERBOSE"
-        let inclusion = &vec![s!("WARN"), s!("(?i:error)")];
-        let exclusion = &vec![s!("VERBOSE")];
-        let p = LineRules::new(exclusion, inclusion, &[]).unwrap();
+        let inclusion = [s!("WARN"), s!("(?i:error)")];
+        let exclusion = [s!("VERBOSE")];
+        let p = LineRules::new(&exclusion, &inclusion, &[]).unwrap();
 
         // Should match
         is_match!(p, "WARN something", Status::Ok(_));
@@ -254,12 +254,12 @@ mod tests {
 
     #[test]
     fn should_redact_lines() {
-        let redact = &vec![
+        let redact = [
             s!(r"\S+@\S+\.\S+"),
             s!("(?i:SENSITIVE)"),
             s!(r"\d{1,2}-\d{1,2}-\d{4}"),
         ];
-        let p = LineRules::new(&[], &[], redact).unwrap();
+        let p = LineRules::new(&[], &[], &redact).unwrap();
         redact_match!(p, "Hello INFO not redacted", "Hello INFO not redacted");
         redact_match!(p, "my sensitive information", "my [REDACTED] information");
         redact_match!(p, "Sensitive sentence", "[REDACTED] sentence");
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn should_support_overlapping_redactions() {
-        let redact = &vec![
+        let redact = [
             s!(r"(?i:SI)"),
             s!(r"(?i:SUPERSENSITIVE)"),
             s!(r"(?i:SENSITIVE)"),
@@ -285,7 +285,7 @@ mod tests {
             s!(r"(?i:S\w+E)"),
             s!(r"(?i:SENSITIVE information)"),
         ];
-        let p = LineRules::new(&[], &[], redact).unwrap();
+        let p = LineRules::new(&[], &[], &redact).unwrap();
         redact_match!(p, "Hello INFO not redacted", "Hello INFO not redacted");
         redact_match!(
             p,
@@ -301,8 +301,8 @@ mod tests {
 
     #[test]
     fn should_support_redactions_changing_length() {
-        let redact = &vec![s!(r"(?:123)"), s!(r"(?:def)")];
-        let p = LineRules::new(&[], &[], redact).unwrap();
+        let redact = [s!(r"(?:123)"), s!(r"(?:def)")];
+        let p = LineRules::new(&[], &[], &redact).unwrap();
         redact_match!(p, "Hello INFO not redacted", "Hello INFO not redacted");
         redact_match!(
             p,
@@ -313,8 +313,8 @@ mod tests {
 
     #[test]
     fn should_support_unordered_redactions() {
-        let redact = &vec![s!(r"(?i:AB)"), s!(r"(?i:CD)")];
-        let p = LineRules::new(&[], &[], redact).unwrap();
+        let redact = [s!(r"(?i:AB)"), s!(r"(?i:CD)")];
+        let p = LineRules::new(&[], &[], &redact).unwrap();
         redact_match!(p, "AB CD", "[REDACTED] [REDACTED]");
         redact_match!(
             p,
@@ -330,8 +330,8 @@ mod tests {
 
     #[test]
     fn should_support_unordered_overlapping_redactions() {
-        let redact = &vec![s!(r"(?i:AB)"), s!(r"(?i:CD)"), s!(r"\w{2}"), s!(r"\w{3}")];
-        let p = LineRules::new(&[], &[], redact).unwrap();
+        let redact = [s!(r"(?i:AB)"), s!(r"(?i:CD)"), s!(r"\w{2}"), s!(r"\w{3}")];
+        let p = LineRules::new(&[], &[], &redact).unwrap();
         redact_match!(
             p,
             "CD 1 CDA 2 AB 3 CD",
@@ -341,8 +341,8 @@ mod tests {
 
     #[test]
     fn should_apply_rules_and_redact_lines() {
-        let redact = &vec![s!("(?i:SENSITIVE)")];
-        let p = LineRules::new(&[s!("DEBUG")], &[s!("WARN"), s!("ERROR")], redact).unwrap();
+        let redact = [s!("(?i:SENSITIVE)")];
+        let p = LineRules::new(&[s!("DEBUG")], &[s!("WARN"), s!("ERROR")], &redact).unwrap();
         redact_match!(p, "Hello WARN not redacted", "Hello WARN not redacted");
         redact_match!(
             p,

--- a/common/test/mock-ingester/src/lib.rs
+++ b/common/test/mock-ingester/src/lib.rs
@@ -185,8 +185,8 @@ impl Service<Request<Body>> for Svc {
                         }
                     });
 
-                    file_info.annotation = line.annotation.clone();
-                    file_info.label = line.label.clone();
+                    file_info.annotation.clone_from(&line.annotation);
+                    file_info.label.clone_from(&line.label);
                     file_info.lines += 1;
                     file_info.values.push(raw_line);
                     file_info.meta = line.meta;


### PR DESCRIPTION
Set the minimum target version for macos builds to 10.14. Rocksdb fails to build for earlier versions.

Additionally includes a number of fixes for linter issues.

Finally fixes issue where the std dll was not found in appveyor builds because the toolchain was not in the path.