### PR TITLE
fix: static builds failing due to rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,22 +328,22 @@ checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
- "itertools",
  "lazy_static",
  "lazycell",
+ "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.32",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1991,9 +1991,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.8.3+7.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2001,7 +2001,6 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
- "lz4-sys",
  "zstd-sys",
 ]
 
@@ -2205,16 +2204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2678,6 +2667,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
@@ -3263,9 +3258,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/common/state/Cargo.toml
+++ b/common/state/Cargo.toml
@@ -14,7 +14,7 @@ state = ["rocksdb"]
 [dependencies]
 derivative = "2.2"
 futures = "0.3"
-rocksdb = { version = "0.22", optional = true }
+rocksdb = { version = "0.19", optional = true }
 async-channel = "1.6"
 thiserror = "1.0"
 tracing = "0.1"

--- a/common/state/src/state.rs
+++ b/common/state/src/state.rs
@@ -57,7 +57,7 @@ fn _construct_agent_state(path: &Path) -> Result<AgentState, StateError> {
 
     let cache = Cache::new_lru_cache(ROCKSDB_CACHE_SIZE);
     let mut block_options = BlockBasedOptions::default();
-    block_options.set_block_cache(&cache);
+    block_options.set_block_cache(&cache?);
 
     let mut db_opts = Options::default();
     db_opts.create_missing_column_families(true);


### PR DESCRIPTION
Reverts rocksdb wrapper to 0.19.

This version of the agent is built on rocksdb 7.4.4 which is not compatible with version 0.22 of the rocksdb wrapper. Since this version of the agent is only receiving security updates and the previous versions of rocksdb and the wrapper don't have any security issues, let's just keep using the same version.