### PR TITLE
ci: allow multidigit versions in weekly run check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ VCS_URL := https://github.com/logdna/$(REPO)
 BUILD_DATE := $(shell date -u +'%Y%m%d')
 BUILD_TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 BUILD_VERSION := $(shell sed -nE "s/^version = \"(.+)\"\$$/\1/p" bin/Cargo.toml)
-BUILD_TAG ?= $(VCS_REF)
-IMAGE_TAG := $(BUILD_TAG)-$(ARCH)
+BUILD_SLUG ?= $(VCS_REF)
+IMAGE_TAG := $(BUILD_SLUG)-$(ARCH)
 BUILD_NUMBER ?= 0
 
 MAJOR_VERSION := $(shell echo $(BUILD_VERSION) | cut -s -d. -f1)


### PR DESCRIPTION
The regex we use to trigger Jenkins cronjobs for weekly runs only handles versions with single digits e.g. "3.9.0". This changes updates it to recognize any multidigit version e.g. "3.10.2".

Also adds a new Jenkins envvar "BUILD_SLUG" which is a docker tag friendly version of "BUILD_TAG".