### PR TITLE
chore: ignore RUSTSEC-2024-0421

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,11 +264,7 @@ lint-clippy: ## Checks for code errors
 .PHONY:lint-audit
 lint-audit: ## Audits packages for issues
 	$(RUST_COMMAND) "--env RUST_BACKTRACE=full" "cargo audit  \
-	    --ignore RUSTSEC-2020-0071 \
-	    --ignore RUSTSEC-2023-0052 \
-	    --ignore RUSTSEC-2024-0003 \
-	    --ignore RUSTSEC-2024-0006 \
-	    --ignore RUSTSEC-2024-0019"
+	    --ignore RUSTSEC-2024-0421"
 
 .PHONY:lint-docker
 lint-docker: ## Lint the Dockerfile for issues


### PR DESCRIPTION
Ignore a vulnerability for one of our dependencies, `trust-dns-resolver` until a patch fix is available.

Also removes some outdated rustsec ignore rules which are no longer an issue.