### PR TITLE
ci: simplify windows certificate signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -574,9 +574,8 @@ msi-$(1): ## create signed exe and msi files in $(BUILD_DIR)/signed
 	trap \"rm -rf '$(BUILD_DIR)/cert'\" EXIT; \
 	mkdir -p '$(BUILD_DIR)/cert'; \
 	if [ "$(1)" == "release" ]; then \
-	  aws s3 cp s3://ecosys-vault/mezmo_cert_release.p12 '$(BUILD_DIR)/cert'; \
 	  aws s3 cp s3://ecosys-vault/mezmo_cert_release.pem '$(BUILD_DIR)/cert'; \
-	  aws s3 cp s3://ecosys-vault/mezmo_cert_release.env '$(BUILD_DIR)/cert'; \
+	  aws s3 cp s3://ecosys-vault/mezmo_cert_release_alias.txt '$(BUILD_DIR)/cert'; \
 	  aws s3 cp s3://ecosys-vault/x86_64-linux-gnu/smpkcs11.so '$(BUILD_DIR)/cert'; \
 	else \
 	  aws s3 cp s3://ecosys-vault/mezmo_cert_debug.pfx '$(BUILD_DIR)/cert'; \

--- a/packaging/windows/msi/mk_msi.release
+++ b/packaging/windows/msi/mk_msi.release
@@ -2,7 +2,7 @@
 set -eu
 mkdir -p "$SRC_ROOT/$BUILD_DIR/signed"
 pushd "$SRC_ROOT/$BUILD_DIR/cert"
-source "./mezmo_cert_release.env"
+SM_CERT_ALIAS=$(cat ./mezmo_cert_release_alias.txt)
 echo signing agent exe files ...
 #
 # Sign Agent service exe


### PR DESCRIPTION
We include extraneous secrets when handling windows signing. This change simplifies the script to just what is needed.

Ref: LOG-20886