### PR TITLE
chore: update to ubi9

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -40,7 +40,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     sccache --show-stats
 
 # Use Debian as agent base image
-FROM debian:bullseye
+FROM debian:bookworm
 
 ARG REPO
 ARG BUILD_TIMESTAMP

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -39,7 +39,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     sccache --show-stats
 
 # Use Debian as agent base image
-FROM debian:bullseye
+FROM debian:bookworm
 
 ARG REPO
 ARG BUILD_TIMESTAMP

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,8 +32,8 @@ pipeline {
     }
     environment {
         RUST_IMAGE_REPO = 'us.gcr.io/logdna-k8s/rust'
-        RUST_IMAGE_TAG = 'bullseye-1-stable'
-        TOOLS_IMAGE_TAG = 'bullseye-1-stable'
+        RUST_IMAGE_TAG = 'bookworm-1-stable'
+        TOOLS_IMAGE_TAG = 'bookworm-1-stable'
         SCCACHE_BUCKET = 'logdna-sccache-us-west-2'
         SCCACHE_REGION = 'us-west-2'
         CARGO_INCREMENTAL = 'false'

--- a/docker/kind/Dockerfile
+++ b/docker/kind/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE docker.io/logdna/build-images:rust-bullseye-1-stable-x86_64
+ARG BUILD_IMAGE docker.io/logdna/build-images:rust-bookworm-1-stable-x86_64
 FROM ${BUILD_IMAGE}
 STOPSIGNAL SIGRTMIN+3
 

--- a/docker/socat/Dockerfile
+++ b/docker/socat/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bullseye-curl
+FROM buildpack-deps:bookworm-curl
 
 RUN apt update
 RUN apt install -y socat

--- a/scripts/ubi9-sysroot.sh
+++ b/scripts/ubi9-sysroot.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eux
+
 TARGET_ARCH="$1"
 
 UBI_MAJOR_VERSION="$2"
@@ -11,7 +13,7 @@ SYSROOT_PATH="/sysroot/ubi-$UBI_VERSION"
 
 ubi_packages="systemd-libs systemd-devel glibc glibc-devel gcc libstdc++-devel libstdc++-static kernel-headers"
 
-apt-get update 1>&2 && apt-get install --no-install-recommends -y dnf 1>&2
+apt-get update 1>&2 && apt-get install --no-install-recommends -y dnf rpm 1>&2
 dnf install --releasever="${UBI_MAJOR_VERSION}" --forcearch="${TARGET_ARCH}" \
             --installroot="$SYSROOT_PATH/" --repo="ubi-${UBI_MAJOR_VERSION}-baseos-rpms" \
             --repo="ubi-${UBI_MAJOR_VERSION}-appstream-rpms" --repo="ubi-${UBI_MAJOR_VERSION}-codeready-builder-rpms" -y \


### PR DESCRIPTION
Updates the base image from from ubi8 -> ubi9. Additionally tracks down remaining references to bullseye and replace with bookworm.

Ref: LOG-22220